### PR TITLE
Models in parity with shapes.

### DIFF
--- a/plugins/filament_view/CMakeLists.txt
+++ b/plugins/filament_view/CMakeLists.txt
@@ -76,7 +76,8 @@ add_library(plugin_filament_view STATIC
 
         filament_scene.cc
         core/scene/scene_controller.cc
-
+        core/components/basetransform.cc
+        core/components/commonrenderable.cc
         core/model/animation/animation.cc
         core/model/animation/animation_manager.cc
         core/model/loader/model_loader.cc

--- a/plugins/filament_view/core/components/basetransform.cc
+++ b/plugins/filament_view/core/components/basetransform.cc
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020-2024 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "basetransform.h"
+#include "core/include/literals.h"
+#include "core/utils/deserialize.h"
+#include "plugins/common/common.h"
+
+namespace plugin_filament_view {
+
+BaseTransform::BaseTransform(const flutter::EncodableMap& params)
+    : m_f3CenterPosition(0, 0, 0),
+      m_f3ExtentsSize(0, 0, 0),
+      m_f3Scale(1, 1, 1),
+      m_quatRotation(0, 0, 0, 1) {
+  Deserialize::DecodeParameterWithDefault(kSize, &m_f3ExtentsSize, params,
+                                          filament::math::float3(0, 0, 0));
+  Deserialize::DecodeParameterWithDefault(kCenterPosition, &m_f3CenterPosition,
+                                          params,
+                                          filament::math::float3(0, 0, 0));
+  Deserialize::DecodeParameterWithDefault(kScale, &m_f3Scale, params,
+                                          filament::math::float3(1, 1, 1));
+  Deserialize::DecodeParameterWithDefault(kRotation, &m_quatRotation, params,
+                                          filament::math::quatf(0, 0, 0, 1));
+}
+
+void BaseTransform::DebugPrint() const {
+  spdlog::debug("Center Position: x={}, y={}, z={}", m_f3CenterPosition.x,
+                m_f3CenterPosition.y, m_f3CenterPosition.z);
+  spdlog::debug("Scale: x={}, y={}, z={}", m_f3Scale.x, m_f3Scale.y,
+                m_f3Scale.z);
+  spdlog::debug("Rotation: x={}, y={}, z={} w={}", m_quatRotation.x,
+                m_quatRotation.y, m_quatRotation.z);
+  spdlog::debug("Extents Size: x={}, y={}, z={}", m_f3ExtentsSize.x,
+                m_f3ExtentsSize.y, m_f3ExtentsSize.z);
+}
+
+}  // namespace plugin_filament_view

--- a/plugins/filament_view/core/components/basetransform.h
+++ b/plugins/filament_view/core/components/basetransform.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020-2024 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <filament/math/quat.h>
+#include "shell/platform/common/client_wrapper/include/flutter/encodable_value.h"
+
+namespace plugin_filament_view {
+
+class BaseTransform {
+ public:
+  // Constructor
+  BaseTransform()
+      : m_f3CenterPosition(0, 0, 0),
+        m_f3ExtentsSize(0, 0, 0),
+        m_f3Scale(1, 1, 1),
+        m_quatRotation(0, 0, 0, 1) {}
+  explicit BaseTransform(const flutter::EncodableMap& params);
+
+  // Getters
+  [[nodiscard]] const filament::math::float3& GetCenterPosition() const {
+    return m_f3CenterPosition;
+  }
+
+  [[nodiscard]] const filament::math::float3& GetExtentsSize() const {
+    return m_f3ExtentsSize;
+  }
+
+  [[nodiscard]] const filament::math::float3& GetScale() const {
+    return m_f3Scale;
+  }
+
+  [[nodiscard]] const filament::math::quatf& GetRotation() const {
+    return m_quatRotation;
+  }
+
+  // Setters
+  void SetCenterPosition(const filament::math::float3& centerPosition) {
+    m_f3CenterPosition = centerPosition;
+  }
+
+  void SetExtentsSize(const filament::math::float3& extentsSize) {
+    m_f3ExtentsSize = extentsSize;
+  }
+
+  void SetScale(const filament::math::float3& scale) { m_f3Scale = scale; }
+
+  void SetRotation(const filament::math::quatf& rotation) {
+    m_quatRotation = rotation;
+  }
+
+  void DebugPrint() const;
+
+ private:
+  filament::math::float3 m_f3CenterPosition;
+  filament::math::float3 m_f3ExtentsSize;
+  filament::math::float3 m_f3Scale;
+  filament::math::quatf m_quatRotation;
+};
+
+}  // namespace plugin_filament_view

--- a/plugins/filament_view/core/components/commonrenderable.cc
+++ b/plugins/filament_view/core/components/commonrenderable.cc
@@ -1,0 +1,26 @@
+#include "commonrenderable.h"
+#include "core/include/literals.h"
+#include "core/utils/deserialize.h"
+#include "plugins/common/common.h"
+
+namespace plugin_filament_view {
+
+CommonRenderable::CommonRenderable(const flutter::EncodableMap& params)
+    : m_bCullingOfObjectEnabled(true),
+      m_bCastShadows(false),
+      m_bReceiveShadows(false) {
+  Deserialize::DecodeParameterWithDefault(
+      kCullingEnabled, &m_bCullingOfObjectEnabled, params, true);
+  Deserialize::DecodeParameterWithDefault(kReceiveShadows, &m_bReceiveShadows,
+                                          params, false);
+  Deserialize::DecodeParameterWithDefault(kCastShadows, &m_bCastShadows, params,
+                                          false);
+}
+
+void CommonRenderable::DebugPrint() const {
+  spdlog::debug("Culling Enabled: {}", m_bCullingOfObjectEnabled);
+  spdlog::debug("Receive Shadows: {}", m_bReceiveShadows);
+  spdlog::debug("Cast Shadows: {}", m_bCastShadows);
+}
+
+}  // namespace plugin_filament_view

--- a/plugins/filament_view/core/components/commonrenderable.h
+++ b/plugins/filament_view/core/components/commonrenderable.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020-2024 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <filament/math/quat.h>
+#include "shell/platform/common/client_wrapper/include/flutter/encodable_value.h"
+
+namespace plugin_filament_view {
+
+class CommonRenderable {
+ public:
+  // Constructor
+  CommonRenderable()
+      : m_bCullingOfObjectEnabled(true),
+        m_bCastShadows(false),
+        m_bReceiveShadows(false) {}
+  explicit CommonRenderable(const flutter::EncodableMap& params);
+
+  // Getters
+  [[nodiscard]] bool IsCullingOfObjectEnabled() const {
+    return m_bCullingOfObjectEnabled;
+  }
+
+  [[nodiscard]] bool IsReceiveShadowsEnabled() const {
+    return m_bReceiveShadows;
+  }
+
+  [[nodiscard]] bool IsCastShadowsEnabled() const { return m_bCastShadows; }
+
+  // Setters
+  void SetCullingOfObjectEnabled(bool enabled) {
+    m_bCullingOfObjectEnabled = enabled;
+  }
+
+  void SetReceiveShadows(bool enabled) { m_bReceiveShadows = enabled; }
+
+  void SetCastShadows(bool enabled) { m_bCastShadows = enabled; }
+
+  void DebugPrint() const;
+
+ private:
+  bool m_bCullingOfObjectEnabled;
+  bool m_bReceiveShadows;
+  bool m_bCastShadows;
+};
+
+}  // namespace plugin_filament_view

--- a/plugins/filament_view/core/include/literals.h
+++ b/plugins/filament_view/core/include/literals.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020-2024 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace plugin_filament_view {
+
+static constexpr char kId[] = "id";
+static constexpr char kShapeType[] = "shapeType";
+static constexpr char kSize[] = "size";
+static constexpr char kCenterPosition[] = "centerPosition";
+static constexpr char kNormal[] = "normal";
+static constexpr char kScale[] = "scale";
+static constexpr char kRotation[] = "rotation";
+static constexpr char kMaterial[] = "material";
+static constexpr char kDoubleSided[] = "doubleSided";
+static constexpr char kCullingEnabled[] = "cullingEnabled";
+static constexpr char kReceiveShadows[] = "receiveShadows";
+static constexpr char kCastShadows[] = "castShadows";
+
+}  // namespace plugin_filament_view

--- a/plugins/filament_view/core/model/loader/model_loader.cc
+++ b/plugins/filament_view/core/model/loader/model_loader.cc
@@ -25,8 +25,8 @@
 #include <gltfio/ResourceLoader.h>
 #include <gltfio/TextureProvider.h>
 #include <math/mat4.h>
-#include <asio/post.hpp>
 #include <utils/Slice.h>
+#include <asio/post.hpp>
 
 #include "gltfio/materials/uberarchive.h"
 
@@ -131,13 +131,16 @@ void ModelLoader::loadModelGlb(Model* poOurModel,
   auto& rcm = engine->getRenderableManager();
 
   utils::Slice<Entity> const listOfRenderables{
-    asset->getRenderableEntities(), asset->getRenderableEntityCount() };
+      asset->getRenderableEntities(), asset->getRenderableEntityCount()};
 
-  for (auto entity: listOfRenderables) {
+  for (auto entity : listOfRenderables) {
     auto ri = rcm.getInstance(entity);
-    rcm.setCastShadows(ri, poOurModel->GetCommonRenderable().IsCastShadowsEnabled());
-    rcm.setReceiveShadows(ri, poOurModel->GetCommonRenderable().IsReceiveShadowsEnabled());
-    // Investigate this more before making it a property on common renderable component.
+    rcm.setCastShadows(
+        ri, poOurModel->GetCommonRenderable().IsCastShadowsEnabled());
+    rcm.setReceiveShadows(
+        ri, poOurModel->GetCommonRenderable().IsReceiveShadowsEnabled());
+    // Investigate this more before making it a property on common renderable
+    // component.
     rcm.setScreenSpaceContactShadows(ri, false);
   }
 
@@ -181,13 +184,16 @@ void ModelLoader::loadModelGltf(
   auto& rcm = engine->getRenderableManager();
 
   utils::Slice<Entity> const listOfRenderables{
-    asset->getRenderableEntities(), asset->getRenderableEntityCount() };
+      asset->getRenderableEntities(), asset->getRenderableEntityCount()};
 
-  for (auto entity: listOfRenderables) {
+  for (auto entity : listOfRenderables) {
     auto ri = rcm.getInstance(entity);
-    rcm.setCastShadows(ri, poOurModel->GetCommonRenderable().IsCastShadowsEnabled());
-    rcm.setReceiveShadows(ri, poOurModel->GetCommonRenderable().IsReceiveShadowsEnabled());
-    // Investigate this more before making it a property on common renderable component.
+    rcm.setCastShadows(
+        ri, poOurModel->GetCommonRenderable().IsCastShadowsEnabled());
+    rcm.setReceiveShadows(
+        ri, poOurModel->GetCommonRenderable().IsReceiveShadowsEnabled());
+    // Investigate this more before making it a property on common renderable
+    // component.
     rcm.setScreenSpaceContactShadows(ri, false);
   }
 

--- a/plugins/filament_view/core/model/loader/model_loader.cc
+++ b/plugins/filament_view/core/model/loader/model_loader.cc
@@ -18,14 +18,15 @@
 #include <algorithm>  // for max
 #include <sstream>
 
+#include <core/utils/entitytransforms.h>
 #include <filament/DebugRegistry.h>
 #include <filament/RenderableManager.h>
 #include <filament/TransformManager.h>
 #include <gltfio/ResourceLoader.h>
 #include <gltfio/TextureProvider.h>
 #include <math/mat4.h>
-#include <math/vec3.h>
 #include <asio/post.hpp>
+#include <utils/Slice.h>
 
 #include "gltfio/materials/uberarchive.h"
 
@@ -102,11 +103,9 @@ filament::gltfio::FilamentAsset* ModelLoader::poFindAssetByName(
   return assets_[0];
 }
 
-void ModelLoader::loadModelGlb(const std::vector<uint8_t>& buffer,
-                               const ::filament::float3* centerPosition,
-                               float scale,
-                               const std::string& /*assetName*/,
-                               bool /*autoScaleEnabled*/) {
+void ModelLoader::loadModelGlb(Model* poOurModel,
+                               const std::vector<uint8_t>& buffer,
+                               const std::string& /*assetName*/) {
   CustomModelViewer* modelViewer = CustomModelViewer::Instance(__FUNCTION__);
 
   auto* asset = assetLoader_->createAsset(buffer.data(),
@@ -118,6 +117,8 @@ void ModelLoader::loadModelGlb(const std::vector<uint8_t>& buffer,
 
   assets_.push_back(asset);
   resourceLoader_->asyncBeginLoad(asset);
+
+  // This will move to be on the model itself.
   modelViewer->setAnimator(asset->getInstance()->getAnimator());
 
   // TODO Append names or types / change list, something
@@ -126,33 +127,28 @@ void ModelLoader::loadModelGlb(const std::vector<uint8_t>& buffer,
 
   asset->releaseSourceData();
 
-  // TODO is this needed?
-  // if (autoScaleEnabled) {
-  //   transformToUnitCube(asset, centerPosition, scale);
-  // } else {
-  //   clearRootTransform(asset);
-  // }
-
-  clearRootTransform(asset);
-  SPDLOG_DEBUG("glb {}", scale);
-
   ::filament::Engine* engine = modelViewer->getFilamentEngine();
+  auto& rcm = engine->getRenderableManager();
 
-  auto& tm = engine->getTransformManager();
-  auto ei = tm.getInstance(asset->getRoot());
+  utils::Slice<Entity> const listOfRenderables{
+    asset->getRenderableEntities(), asset->getRenderableEntityCount() };
 
-  tm.setTransform(ei, ::filament::math::mat4f{::filament::math::mat3f(scale),
-                                              *centerPosition} *
-                          tm.getWorldTransform(ei));
+  for (auto entity: listOfRenderables) {
+    auto ri = rcm.getInstance(entity);
+    rcm.setCastShadows(ri, poOurModel->GetCommonRenderable().IsCastShadowsEnabled());
+    rcm.setReceiveShadows(ri, poOurModel->GetCommonRenderable().IsReceiveShadowsEnabled());
+    // Investigate this more before making it a property on common renderable component.
+    rcm.setScreenSpaceContactShadows(ri, false);
+  }
+
+  poOurModel->setAsset(asset);
 }
 
 void ModelLoader::loadModelGltf(
+    Model* poOurModel,
     const std::vector<uint8_t>& buffer,
-    const ::filament::float3* centerPosition,
-    float scale,
     std::function<const ::filament::backend::BufferDescriptor&(
-        std::string uri)>& /* callback */,
-    bool transform) {
+        std::string uri)>& /* callback */) {
   CustomModelViewer* modelViewer = CustomModelViewer::Instance(__FUNCTION__);
 
   auto* asset = assetLoader_->createAsset(buffer.data(),
@@ -180,49 +176,30 @@ void ModelLoader::loadModelGltf(
   resourceLoader_->asyncBeginLoad(asset);
   modelViewer->setAnimator(asset->getInstance()->getAnimator());
   asset->releaseSourceData();
-  if (transform) {
-    transformToUnitCube(asset, centerPosition, scale);
-  }
-}
 
-void ModelLoader::transformToUnitCube(
-    filament::gltfio::FilamentAsset* asset,
-    const ::filament::float3* /* centerPoint */,
-    float /* modelScale */) {
-  if (!asset) {
-    return;
-  }
-  auto aabb = asset->getBoundingBox();
-  auto center = aabb.center();
-  auto halfExtent = aabb.extent();
-  auto maxExtent = max(halfExtent) * 2;
-  auto scaleFactor = 2.0f / maxExtent;
-  auto transform = ::filament::math::mat4f::scaling(scaleFactor) *
-                   ::filament::math::mat4f::translation(-center);
-
-  CustomModelViewer* modelViewer = CustomModelViewer::Instance(__FUNCTION__);
   ::filament::Engine* engine = modelViewer->getFilamentEngine();
+  auto& rcm = engine->getRenderableManager();
 
-  auto& tm = engine->getTransformManager();
-  tm.setTransform(tm.getInstance(asset->getRoot()), transform);
+  utils::Slice<Entity> const listOfRenderables{
+    asset->getRenderableEntities(), asset->getRenderableEntityCount() };
+
+  for (auto entity: listOfRenderables) {
+    auto ri = rcm.getInstance(entity);
+    rcm.setCastShadows(ri, poOurModel->GetCommonRenderable().IsCastShadowsEnabled());
+    rcm.setReceiveShadows(ri, poOurModel->GetCommonRenderable().IsReceiveShadowsEnabled());
+    // Investigate this more before making it a property on common renderable component.
+    rcm.setScreenSpaceContactShadows(ri, false);
+  }
+
+  poOurModel->setAsset(asset);
 }
 
 void ModelLoader::populateScene(::filament::gltfio::FilamentAsset* asset) {
   CustomModelViewer* modelViewer = CustomModelViewer::Instance(__FUNCTION__);
-  ::filament::Engine* engine = modelViewer->getFilamentEngine();
-
-  auto& rcm = engine->getRenderableManager();
 
   size_t count = asset->popRenderables(nullptr, 0);
   while (count) {
     asset->popRenderables(readyRenderables_, count);
-    for (int i = 0; i < count; i++) {
-      auto ri = rcm.getInstance(readyRenderables_[i]);
-      // TODO move to settings & per model
-      // rcm.setCastShadows(ri, true);
-      // rcm.setReceiveShadows(ri, true);
-      rcm.setScreenSpaceContactShadows(ri, false);
-    }
     modelViewer->getFilamentScene()->addEntities(readyRenderables_, count);
     count = asset->popRenderables(nullptr, 0);
   }
@@ -274,9 +251,8 @@ void ModelLoader::clearRootTransform(filament::gltfio::FilamentAsset* asset) {
 }
 
 std::future<Resource<std::string_view>> ModelLoader::loadGlbFromAsset(
+    Model* poOurModel,
     const std::string& path,
-    float scale,
-    const ::filament::math::float3* centerPosition,
     bool isFallback) {
   const auto promise(
       std::make_shared<std::promise<Resource<std::string_view>>>());
@@ -288,11 +264,10 @@ std::future<Resource<std::string_view>> ModelLoader::loadGlbFromAsset(
     const asio::io_context::strand& strand_(modelViewer->getStrandContext());
     const std::string assetPath = modelViewer->getAssetPath();
 
-    asio::post(strand_, [&, promise, path, scale, centerPosition, isFallback,
-                         assetPath] {
+    asio::post(strand_, [&, poOurModel, promise, path, isFallback, assetPath] {
       try {
         auto buffer = readBinaryFile(path, assetPath);
-        handleFile(buffer, path, scale, centerPosition, isFallback, promise);
+        handleFile(poOurModel, buffer, path, isFallback, promise);
       } catch (const std::exception& e) {
         std::cerr << "Lambda Exception " << e.what() << '\n';
         promise->set_exception(std::make_exception_ptr(e));
@@ -308,39 +283,36 @@ std::future<Resource<std::string_view>> ModelLoader::loadGlbFromAsset(
 }
 
 std::future<Resource<std::string_view>> ModelLoader::loadGlbFromUrl(
+    Model* poOurModel,
     std::string url,
-    float scale,
-    const ::filament::math::float3* centerPosition,
     bool isFallback) {
   const auto promise(
       std::make_shared<std::promise<Resource<std::string_view>>>());
   auto promise_future(promise->get_future());
   CustomModelViewer* modelViewer = CustomModelViewer::Instance(__FUNCTION__);
   modelViewer->setModelState(ModelState::LOADING);
-  asio::post(
-      modelViewer->getStrandContext(),
-      [&, promise, url = std::move(url), scale, centerPosition, isFallback] {
-        plugin_common_curl::CurlClient client;
-        auto buffer = client.RetrieveContentAsVector();
-        if (client.GetCode() != CURLE_OK) {
-          modelViewer->setModelState(ModelState::ERROR);
-          promise->set_value(Resource<std::string_view>::Error(
-              "Couldn't load Glb from " + url));
-        }
-        handleFile(buffer, url, scale, centerPosition, isFallback, promise);
-      });
+  asio::post(modelViewer->getStrandContext(),
+             [&, poOurModel, promise, url = std::move(url), isFallback] {
+               plugin_common_curl::CurlClient client;
+               auto buffer = client.RetrieveContentAsVector();
+               if (client.GetCode() != CURLE_OK) {
+                 modelViewer->setModelState(ModelState::ERROR);
+                 promise->set_value(Resource<std::string_view>::Error(
+                     "Couldn't load Glb from " + url));
+               }
+               handleFile(poOurModel, buffer, url, isFallback, promise);
+             });
   return promise_future;
 }
 
-void ModelLoader::handleFile(const std::vector<uint8_t>& buffer,
+void ModelLoader::handleFile(Model* poOurModel,
+                             const std::vector<uint8_t>& buffer,
                              const std::string& fileSource,
-                             float scale,
-                             const ::filament::math::float3* centerPosition,
                              bool isFallback,
                              const PromisePtr& promise) {
   CustomModelViewer* modelViewer = CustomModelViewer::Instance(__FUNCTION__);
   if (!buffer.empty()) {
-    loadModelGlb(buffer, centerPosition, scale, fileSource, true);
+    loadModelGlb(poOurModel, buffer, fileSource);
     modelViewer->setModelState(isFallback ? ModelState::FALLBACK_LOADED
                                           : ModelState::LOADED);
     promise->set_value(Resource<std::string_view>::Success(
@@ -353,11 +325,10 @@ void ModelLoader::handleFile(const std::vector<uint8_t>& buffer,
 }
 
 std::future<Resource<std::string_view>> ModelLoader::loadGltfFromAsset(
+    Model* /*poOurModel*/,
     const std::string& /* path */,
     const std::string& /* pre_path */,
     const std::string& /* post_path */,
-    float /* scale */,
-    const ::filament::math::float3* /* centerPosition */,
     bool /* isFallback */) {
   const auto promise(
       std::make_shared<std::promise<Resource<std::string_view>>>());
@@ -367,9 +338,8 @@ std::future<Resource<std::string_view>> ModelLoader::loadGltfFromAsset(
 }
 
 std::future<Resource<std::string_view>> ModelLoader::loadGltfFromUrl(
+    Model* /*poOurModel*/,
     const std::string& /* url */,
-    float /* scale */,
-    const ::filament::math::float3* /* centerPosition */,
     bool /* isFallback */) {
   const auto promise(
       std::make_shared<std::promise<Resource<std::string_view>>>());

--- a/plugins/filament_view/core/model/loader/model_loader.h
+++ b/plugins/filament_view/core/model/loader/model_loader.h
@@ -44,18 +44,14 @@ class ModelLoader {
 
   void destroyModel(filament::gltfio::FilamentAsset* asset);
 
-  void loadModelGlb(const std::vector<uint8_t>& buffer,
-                    const ::filament::float3* centerPosition,
-                    float scale,
-                    const std::string& assetName,
-                    bool transformToUnitCube = false);
+  void loadModelGlb(Model* poOurModel,
+                    const std::vector<uint8_t>& buffer,
+                    const std::string& assetName);
 
-  void loadModelGltf(const std::vector<uint8_t>& buffer,
-                     const ::filament::float3* centerPosition,
-                     float scale,
+  void loadModelGltf(Model* poOurModel,
+                     const std::vector<uint8_t>& buffer,
                      std::function<const ::filament::backend::BufferDescriptor&(
-                         std::string uri)>& callback,
-                     bool transform = false);
+                         std::string uri)>& callback);
 
   [[nodiscard]] std::vector<filament::gltfio::FilamentAsset*> getAssets()
       const {
@@ -69,36 +65,26 @@ class ModelLoader {
 
   static void clearRootTransform(filament::gltfio::FilamentAsset* asset);
 
-  static void transformToUnitCube(filament::gltfio::FilamentAsset* asset,
-                                  const ::filament::float3* centerPoint,
-                                  float scale);
-
   void updateScene();
 
   std::future<Resource<std::string_view>> loadGlbFromAsset(
+      Model* poOurModel,
       const std::string& path,
-      float scale,
-      const ::filament::float3* centerPosition,
       bool isFallback = false);
 
-  std::future<Resource<std::string_view>> loadGlbFromUrl(
-      std::string url,
-      float scale,
-      const ::filament::float3* centerPosition,
-      bool isFallback = false);
+  std::future<Resource<std::string_view>>
+  loadGlbFromUrl(Model* poOurModel, std::string url, bool isFallback = false);
 
   static std::future<Resource<std::string_view>> loadGltfFromAsset(
+      Model* poOurModel,
       const std::string& path,
       const std::string& pre_path,
       const std::string& post_path,
-      float scale,
-      const ::filament::float3* centerPosition,
       bool isFallback = false);
 
   static std::future<Resource<std::string_view>> loadGltfFromUrl(
+      Model* poOurModel,
       const std::string& url,
-      float scale,
-      const ::filament::float3* centerPosition,
       bool isFallback = false);
 
   friend class CustomModelViewer;
@@ -111,6 +97,7 @@ class ModelLoader {
   ::filament::gltfio::MaterialProvider* materialProvider_;
   ::filament::gltfio::ResourceLoader* resourceLoader_;
 
+  // TODO This *might* should go away, its stored on model now.
   std::vector<filament::gltfio::FilamentAsset*> assets_;
 
   ::filament::IndirectLight* indirectLight_ = nullptr;
@@ -146,10 +133,9 @@ class ModelLoader {
 
   using PromisePtr = std::shared_ptr<std::promise<Resource<std::string_view>>>;
   void handleFile(
+      Model* poOurModel,
       const std::vector<uint8_t>& buffer,
       const std::string& fileSource,
-      float scale,
-      const ::filament::float3* centerPosition,
       bool isFallback,
       const PromisePtr&
           promise);  // NOLINT(readability-avoid-const-params-in-decls)

--- a/plugins/filament_view/core/model/model.h
+++ b/plugins/filament_view/core/model/model.h
@@ -58,7 +58,9 @@ class Model {
   filament::gltfio::FilamentAsset* getAsset() const { return m_poAsset; }
 
   const BaseTransform& GetBaseTransform() const { return m_oBaseTransform; }
-  const CommonRenderable& GetCommonRenderable() const { return m_oCommonRenderable; }
+  const CommonRenderable& GetCommonRenderable() const {
+    return m_oCommonRenderable;
+  }
 
  protected:
   std::string assetPath_;

--- a/plugins/filament_view/core/model/model.h
+++ b/plugins/filament_view/core/model/model.h
@@ -16,9 +16,12 @@
 
 #pragma once
 
+#include <core/components/commonrenderable.h>
 #include <string>
 
+#include "core/components/basetransform.h"
 #include "core/model/animation/animation.h"
+#include "core/scene/geometry/direction.h"
 #include "core/scene/geometry/position.h"
 
 namespace plugin_filament_view {
@@ -30,21 +33,15 @@ class Model {
   Model(std::string assetPath,
         std::string url,
         Model* fallback,
-        const float scale,
-        ::filament::math::float3* centerPosition,
-        Animation* animation);
+        Animation* animation,
+        BaseTransform& oTransform,
+        CommonRenderable& oCommonRenderable);
 
   virtual ~Model() = default;
 
   static std::unique_ptr<Model> Deserialize(
       const std::string& flutterAssetsPath,
-      const flutter::EncodableValue& params);
-
-  [[nodiscard]] float GetScale() const { return scale_; }
-
-  [[nodiscard]] ::filament::math::float3* GetCenterPosition() const {
-    return center_position_;
-  }
+      const flutter::EncodableMap& params);
 
   [[nodiscard]] Model* GetFallback() const { return fallback_; }
 
@@ -52,16 +49,28 @@ class Model {
 
   // Disallow copy and assign.
   Model(const Model&) = delete;
-
   Model& operator=(const Model&) = delete;
+
+  void setAsset(filament::gltfio::FilamentAsset* poAsset) {
+    m_poAsset = poAsset;
+  }
+
+  filament::gltfio::FilamentAsset* getAsset() const { return m_poAsset; }
+
+  const BaseTransform& GetBaseTransform() const { return m_oBaseTransform; }
+  const CommonRenderable& GetCommonRenderable() const { return m_oCommonRenderable; }
 
  protected:
   std::string assetPath_;
   std::string url_;
   Model* fallback_;
-  float scale_;
-  ::filament::math::float3* center_position_;
   Animation* animation_;
+
+  filament::gltfio::FilamentAsset* m_poAsset;
+
+  // Components
+  BaseTransform m_oBaseTransform;
+  CommonRenderable m_oCommonRenderable;
 };
 
 class GlbModel final : public Model {
@@ -69,9 +78,9 @@ class GlbModel final : public Model {
   GlbModel(std::string assetPath,
            std::string url,
            Model* fallback,
-           float scale,
-           ::filament::math::float3* centerPosition,
-           Animation* animation);
+           Animation* animation,
+           BaseTransform& oTransform,
+           CommonRenderable& oCommonRenderable);
 
   ~GlbModel() override = default;
 
@@ -87,9 +96,9 @@ class GltfModel final : public Model {
             std::string pathPrefix,
             std::string pathPostfix,
             Model* fallback,
-            float scale,
-            ::filament::math::float3* centerPosition,
-            Animation* animation);
+            Animation* animation,
+            BaseTransform& oTransform,
+            CommonRenderable& oCommonRenderable);
 
   ~GltfModel() override = default;
 

--- a/plugins/filament_view/core/shapes/baseshape.h
+++ b/plugins/filament_view/core/shapes/baseshape.h
@@ -24,6 +24,9 @@
 #include "core/scene/geometry/position.h"
 #include "core/scene/material/material_definitions.h"
 
+#include "core/components/basetransform.h"
+#include "core/components/commonrenderable.h"
+
 namespace plugin_filament_view {
 
 class MaterialManager;
@@ -50,8 +53,6 @@ class BaseShape {
                                    std::shared_ptr<Entity> entityObject,
                                    MaterialManager* material_manager) = 0;
 
-  [[nodiscard]] filament::math::float3 f3GetCenterPosition() const;
-
   void vRemoveEntityFromScene();
   void vAddEntityToScene();
 
@@ -69,11 +70,10 @@ class BaseShape {
 
   int id{};
   ShapeType type_{};
-  /// center position of the shape in the world space.
-  filament::math::float3 m_f3CenterPosition;
-  filament::math::float3 m_f3ExtentsSize;
-  filament::math::float3 m_f3Scale;
-  filament::math::quatf m_quatRotation;
+
+  // Components
+  BaseTransform m_oBaseTransform;
+  CommonRenderable m_oCommonRenderable;
 
   /// direction of the shape rotation in the world space
   filament::math::float3 m_f3Normal;
@@ -83,11 +83,9 @@ class BaseShape {
 
   std::shared_ptr<utils::Entity> m_poEntity;
 
-  // tasking for future implementation
+  // Whether we have winding indexes in both directions.
   bool m_bDoubleSided = false;
-  bool m_bCullingOfObjectEnabled = false;
-  bool m_bReceiveShadows = false;
-  bool m_bCastShadows = false;
+
   // TODO - Note this is backlogged for using value.
   //        For now this is unimplemented, but would be a <small> savings
   //        when building as code currently allocates buffers for UVs

--- a/plugins/filament_view/core/utils/entitytransforms.cc
+++ b/plugins/filament_view/core/utils/entitytransforms.cc
@@ -341,4 +341,34 @@ void EntityTransforms::vApplyLookAt(
   transformManager.setTransform(instance, lookAtMatrix);
 }
 
+void EntityTransforms::vApplyTransform(filament::gltfio::FilamentAsset* poAsset,
+                                       const BaseTransform& transform,
+                                       ::filament::Engine* engine) {
+  auto& transformManager = engine->getTransformManager();
+  auto ei = transformManager.getInstance(poAsset->getRoot());
+
+  // Create the rotation, scaling, and translation matrices
+  auto rotationMatrix = QuaternionToMat4f(transform.GetRotation());
+  auto scalingMatrix = filament::math::mat4f::scaling(transform.GetScale());
+  auto translationMatrix =
+      filament::math::mat4f::translation(transform.GetCenterPosition());
+
+  // Combine the transformations: translate * rotate * scale
+  auto combinedTransform = translationMatrix * rotationMatrix * scalingMatrix;
+
+  // Set the combined transform back to the entity
+  transformManager.setTransform(ei, combinedTransform);
+}
+
+void EntityTransforms::vApplyTransform(filament::gltfio::FilamentAsset* poAsset,
+                                       const BaseTransform& transform) {
+  if (!poAsset)
+    return;
+
+  const auto engine =
+      CustomModelViewer::Instance(__FUNCTION__)->getFilamentEngine();
+
+  vApplyTransform(poAsset, transform, engine);
+}
+
 }  // namespace plugin_filament_view

--- a/plugins/filament_view/core/utils/entitytransforms.h
+++ b/plugins/filament_view/core/utils/entitytransforms.h
@@ -99,6 +99,11 @@ class EntityTransforms {
                            filament::math::float3 target,
                            filament::math::float3 up,
                            ::filament::Engine* engine);
+  static void vApplyTransform(filament::gltfio::FilamentAsset* poAsset,
+                              const BaseTransform& transform);
+  static void vApplyTransform(filament::gltfio::FilamentAsset* poAsset,
+                              const BaseTransform& transform,
+                              ::filament::Engine* engine);
 };
 
 }  // namespace plugin_filament_view

--- a/plugins/filament_view/filament_scene.cc
+++ b/plugins/filament_view/filament_scene.cc
@@ -51,14 +51,16 @@ FilamentScene::FilamentScene(PlatformView* platformView,
       SPDLOG_WARN("Loading Single Model - Deprecated Functionality {}", key);
       models_ = std::make_unique<std::vector<std::unique_ptr<Model>>>();
 
-      auto deserializedModel = Model::Deserialize(flutterAssetsPath, it.second);
+      auto deserializedModel = Model::Deserialize(
+          flutterAssetsPath, std::get<flutter::EncodableMap>(it.second));
       if (deserializedModel == nullptr) {
         // load fallback
         static constexpr char kFallback[] = "fallback";
         auto fallbackToDeserialize =
             Deserialize::DeserializeParameter(kFallback, it.second);
-        deserializedModel =
-            Model::Deserialize(flutterAssetsPath, fallbackToDeserialize);
+        deserializedModel = Model::Deserialize(
+            flutterAssetsPath,
+            std::get<flutter::EncodableMap>(fallbackToDeserialize));
       }
       if (deserializedModel == nullptr) {
         spdlog::error("Unable to load model and fallback model");
@@ -79,14 +81,16 @@ FilamentScene::FilamentScene(PlatformView* platformView,
           continue;
         }
 
-        auto deserializedModel = Model::Deserialize(flutterAssetsPath, iter);
+        auto deserializedModel = Model::Deserialize(
+            flutterAssetsPath, std::get<flutter::EncodableMap>(iter));
         if (deserializedModel == nullptr) {
           // load fallback
           static constexpr char kFallback[] = "fallback";
           auto fallbackToDeserialize =
               Deserialize::DeserializeParameter(kFallback, iter);
-          deserializedModel =
-              Model::Deserialize(flutterAssetsPath, fallbackToDeserialize);
+          deserializedModel = Model::Deserialize(
+              flutterAssetsPath,
+              std::get<flutter::EncodableMap>(fallbackToDeserialize));
         }
         if (deserializedModel == nullptr) {
           spdlog::error("Unable to load model and fallback model");


### PR DESCRIPTION
Models can now have individual properties for shadow casting and receiving. 
Models now have their own scale in each axis.
Models now know the asset they're referencing. (Future work for model_loader to become model_manager).
Started with the concept of components. Having a basetransform and commonrenderable components. This will turn into a list of components with a base class components in the future. For now both shape and models use the same code.
Started a common literals file for deserialization parameter help.

![image](https://github.com/user-attachments/assets/a665da28-5747-47f7-96ff-4d6ab0af6408)
