### PR TITLE
Flatpak CI

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -50,7 +50,9 @@ jobs:
             libunwind-dev \
             \
             libjpeg-turbo8-dev libturbojpeg0-dev libjpeg-dev \
-            libpng-dev libwebp-dev
+            libpng-dev libwebp-dev \
+            \
+            libflatpak-dev libxml2-dev zlib1g-dev
 
           sudo apt-get -y install \
             clang \
@@ -181,6 +183,7 @@ jobs:
             -D BUILD_PLUGIN_URL_LAUNCHER=ON \
             -D BUILD_PLUGIN_VIDEO_PLAYER_LINUX=OFF \
             -D BUILD_PLUGIN_WEBVIEW_FLUTTER_VIEW=ON \
+            -D BUILD_PLUGIN_FLATPAK=ON \
             \
             -D ENABLE_CLANG_STATIC_LINK=OFF \
             -D BUILD_WATCHDOG=OFF \

--- a/.github/workflows/ivi-homescreen.yaml
+++ b/.github/workflows/ivi-homescreen.yaml
@@ -56,7 +56,9 @@ jobs:
             libunwind-dev \
             \
             libjpeg-turbo8-dev libturbojpeg0-dev libjpeg-dev \
-            libpng-dev libwebp-dev
+            libpng-dev libwebp-dev \
+            \
+            libflatpak-dev libxml2-dev zlib1g-dev
 
           sudo apt-get -y install \
             clang \
@@ -182,6 +184,7 @@ jobs:
             -D BUILD_PLUGIN_URL_LAUNCHER=ON \
             -D BUILD_PLUGIN_VIDEO_PLAYER_LINUX=OFF \
             -D BUILD_PLUGIN_WEBVIEW_FLUTTER_VIEW=OFF \
+            -D BUILD_PLUGIN_FLATPAK=ON \
             \
             -D ENABLE_CLANG_STATIC_LINK=OFF \
             -D BUILD_WATCHDOG=OFF \
@@ -257,6 +260,7 @@ jobs:
             -D BUILD_PLUGIN_URL_LAUNCHER=ON \
             -D BUILD_PLUGIN_VIDEO_PLAYER_LINUX=OFF \
             -D BUILD_PLUGIN_WEBVIEW_FLUTTER_VIEW=OFF \
+            -D BUILD_PLUGIN_FLATPAK=ON \
             \
             -D ENABLE_CLANG_STATIC_LINK=OFF \
             -D BUILD_WATCHDOG=OFF \

--- a/plugins/flatpak/CMakeLists.txt
+++ b/plugins/flatpak/CMakeLists.txt
@@ -17,6 +17,7 @@
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(FLATPAK IMPORTED_TARGET REQUIRED flatpak)
 pkg_check_modules(XML2 IMPORTED_TARGET REQUIRED libxml-2.0)
+pkg_check_modules(ZLIB IMPORTED_TARGET REQUIRED zlib)
 
 add_library(plugin_flatpak STATIC
         flatpak_plugin_c_api.cc
@@ -31,4 +32,5 @@ target_link_libraries(plugin_flatpak PUBLIC
         platform_homescreen
         PkgConfig::FLATPAK
         PkgConfig::XML2
+        PkgConfig::ZLIB
 )

--- a/plugins/flatpak/flatpak_plugin.h
+++ b/plugins/flatpak/flatpak_plugin.h
@@ -17,6 +17,8 @@
 #ifndef FLUTTER_PLUGIN_FLATPAK_PLUGIN_H
 #define FLUTTER_PLUGIN_FLATPAK_PLUGIN_H
 
+#undef FLATPAK_EXTERN
+#define FLATPAK_EXTERN extern "C"
 #include <flatpak/flatpak.h>
 
 #include <filesystem>


### PR DESCRIPTION
-redefine FLATPAK_EXTERN as extern "C" to avoid compile error: "templates must have c++ linkage"
-CI updates
 install runtime packages
 enable building flatpak-plugin by default