### PR TITLE
Wayland Protocol Error Fix

### DIFF
--- a/plugins/filament_view/core/systems/base/ecsystem.cc
+++ b/plugins/filament_view/core/systems/base/ecsystem.cc
@@ -152,7 +152,7 @@ void ECSystem::vSetupMessageChannels(
     return;
   }
 
-  SPDLOG_DEBUG("Creating Event Channel {}::{}}", __FUNCTION__, szChannelName);
+  SPDLOG_DEBUG("Creating Event Channel {}::{}", __FUNCTION__, szChannelName);
 
   event_channel_ = std::make_unique<flutter::EventChannel<>>(
       poPluginRegistrar->messenger(), szChannelName,


### PR DESCRIPTION
1. Wayland Protocol Error
    
    -Fix for "Release or Acquire point set but no buffer attach", which
     happens when Wayland transactions complete prior to frame being drawn.

2. Log Error    

    -Resolves
     `[*** LOG ERROR #0001 ***] [2024-12-18 09:24:52] [primary] unmatched '}' in format string [/mnt/raid10/workspace-automation/app/ivi-homescreen-plugins/plugins/filament_view/core/systems/base/ecsystem.cc(155)]`
    
    -Validated on Fedora 41