### PR TITLE
Enforce #version directive to first line of GLSL shader definition.

### DIFF
--- a/plugins/video_player_linux/nv12.h
+++ b/plugins/video_player_linux/nv12.h
@@ -25,8 +25,7 @@
 
 namespace video_player_linux::nv12 {
 
-static const GLchar* kVertexSource = R"glsl(
-  #version 300 es
+static const GLchar* kVertexSource = R"glsl(#version 300 es
   precision highp float;
 
   layout(location = 0) in vec3 vertexPosition_modelspace;
@@ -40,8 +39,7 @@ static const GLchar* kVertexSource = R"glsl(
   }
 )glsl";
 
-static const GLchar* kFragmentSource = R"glsl(
-  #version 300 es
+static const GLchar* kFragmentSource = R"glsl(#version 300 es
   precision highp float;
   in vec2 Texcoord;
   uniform sampler2D textureY;


### PR DESCRIPTION
Note: The #version has to be in the first line. Otherwise glCompileShader() fails with error "Failed to compile 0:2: P0005: #version must be on the first line in a program and only whitespace are allowed in the declaration".

Run into this problem when I tried to use the video_player_linux plugin on an i.MX95.