### PR TITLE
Bugfix/debug message fixes

### DIFF
--- a/plugins/video_player_linux/nv12.h
+++ b/plugins/video_player_linux/nv12.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <array>
+
 #include <GLES3/gl3.h>
 #include <glib.h>
 
@@ -221,15 +223,15 @@ class Shader {
                       const GLchar* fsource = kFragmentSource) {
     GLint result;
     GLsizei length;
-    GLchar* info{};
+    std::array<GLchar, 1000> info{};
 
     vertex_shader_ = glCreateShader(GL_VERTEX_SHADER);
     glShaderSource(vertex_shader_, 1, &vsource, nullptr);
     glCompileShader(vertex_shader_);
     glGetShaderiv(vertex_shader_, GL_COMPILE_STATUS, &result);
     if (result == GL_FALSE) {
-      glGetShaderInfoLog(vertex_shader_, 1000, &length, info);
-      SPDLOG_ERROR("Failed to compile {}", info);
+      glGetShaderInfoLog(vertex_shader_, info.size(), &length, info.data());
+      SPDLOG_ERROR("Failed to compile {}", std::string(info.data(), length));
       return 0;
     }
 
@@ -238,8 +240,8 @@ class Shader {
     glCompileShader(fragment_shader_);
     glGetShaderiv(fragment_shader_, GL_COMPILE_STATUS, &result);
     if (result == GL_FALSE) {
-      glGetShaderInfoLog(fragment_shader_, 1000, &length, info);
-      SPDLOG_ERROR("Fail to compile {}", info);
+      glGetShaderInfoLog(vertex_shader_, info.size(), &length, info.data());
+      SPDLOG_ERROR("Failed to compile {}", std::string(info.data(), length));
       return 0;
     }
 
@@ -250,8 +252,8 @@ class Shader {
 
     glGetProgramiv(shaderProgram, GL_LINK_STATUS, &result);
     if (result == GL_FALSE) {
-      glGetProgramInfoLog(shaderProgram, 1000, &length, info);
-      SPDLOG_ERROR("Fail to link {}", info);
+      glGetProgramInfoLog(shaderProgram, info.size(), &length, info.data());
+      SPDLOG_ERROR("Fail to link {}", std::string(info.data(), length));
       return 0;
     }
 

--- a/plugins/video_player_linux/video_player.cc
+++ b/plugins/video_player_linux/video_player.cc
@@ -316,7 +316,7 @@ gboolean VideoPlayer::OnBusMessage(GstBus* bus,
 
       val = gst_message_get_stream_status_object(msg);
 
-      SPDLOG_DEBUG("\ttype:   {}", type);
+      SPDLOG_DEBUG("\ttype:   {}", static_cast<guint>(type));
       path = gst_object_get_path_string(GST_MESSAGE_SRC(msg));
       SPDLOG_DEBUG("\tsource: {}", path);
       g_free(path);


### PR DESCRIPTION
This PR fixes two issues regarding debug output.

1. Add proper memory allocation to correctly log the info / error message of  glGetShaderInfoLog() & glGetProgramInfoLog(). Maybe it's not the best idea to allocate 1000 bytes on the stack. I can also reduce the amount of bytes.
2. Fix a compilation error when compiling with GSTREAMER_DEBUG = 1
