### PR TITLE
[filament_scene] Updated transform Dart API

### DIFF
--- a/plugins/filament_view/core/components/derived/basetransform.h
+++ b/plugins/filament_view/core/components/derived/basetransform.h
@@ -140,12 +140,12 @@ class BaseTransform : public Component {
     [[nodiscard]] inline const filament::math::quatf& GetRotation() const { return local.rotation; }
 
     // Setters
-    inline void SetPosition(const filament::math::float3& position) {
+    inline void setPosition(const filament::math::float3& position) {
       local.position = position;
       _isDirty = true;
     }
 
-    inline void SetScale(const filament::math::float3& scale) {
+    inline void setScale(const filament::math::float3& scale) {
       // assert positive scale
       /// TODO: if interested in supporting e.g. negative scalings and shear
       ///       should look at Graphics Gems II §VII.1.
@@ -155,7 +155,7 @@ class BaseTransform : public Component {
       _isDirty = true;
     }
 
-    inline void SetRotation(const filament::math::quatf& rotation) {
+    inline void setRotation(const filament::math::quatf& rotation) {
       local.rotation = rotation;
       _isDirty = true;
     }

--- a/plugins/filament_view/core/components/derived/light.h
+++ b/plugins/filament_view/core/components/derived/light.h
@@ -68,7 +68,7 @@ class Light : public Component {
     inline void SetColor(const std::string& color) { m_szColor = color; }
     inline void SetColorTemperature(float temperature) { m_fColorTemperature = temperature; }
     inline void SetIntensity(float intensity) { m_fIntensity = intensity; }
-    inline void SetPosition(const filament::math::float3& position) { m_f3Position = position; }
+    inline void setPosition(const filament::math::float3& position) { m_f3Position = position; }
     inline void SetDirection(const filament::math::float3& direction) { m_f3Direction = direction; }
     inline void SetCastLight(bool castLight) { m_bCastLight = castLight; }
     inline void SetCastShadows(bool castShadows) { m_bCastShadows = castShadows; }

--- a/plugins/filament_view/core/systems/derived/light_system.cc
+++ b/plugins/filament_view/core/systems/derived/light_system.cc
@@ -45,7 +45,7 @@ void LightSystem::vCreateDefaultLight() {
 
   oLightComp->SetIntensity(200);
   oLightComp->SetDirection({0, -1, 0});
-  oLightComp->SetPosition({0, 5, 0});
+  oLightComp->setPosition({0, 5, 0});
   oLightComp->SetCastLight(true);
   // if you're in an closed space (IE Garage), it will self shadow cast
   oLightComp->SetCastShadows(false);
@@ -167,7 +167,7 @@ void LightSystem::vOnInitSystem() {
     // find the entity in our list:
     const auto theLight = ecs->getComponent<Light>(guid);
     runtime_assert(theLight != nullptr, fmt::format("Entity({}): Light not found", guid));
-    theLight->SetPosition(position);
+    theLight->setPosition(position);
     theLight->SetDirection(rotation);
 
     vRemoveLightFromScene(*theLight);

--- a/plugins/filament_view/core/systems/derived/model_system.cc
+++ b/plugins/filament_view/core/systems/derived/model_system.cc
@@ -656,68 +656,6 @@ void ModelSystem::vOnInitSystem() {
   resourceLoader_->addTextureProvider("image/jpeg", decoder);
   // TODO: add support for other texture formats here
 
-  // ChangeTranslationByGUID
-  // TODO: move to TransformSystem
-  vRegisterMessageHandler(ECSMessageType::ChangeTranslationByGUID, [this](const ECSMessage& msg) {
-    SPDLOG_TRACE("ChangeTranslationByGUID");
-
-    const auto guid = msg.getData<EntityGUID>(ECSMessageType::ChangeTranslationByGUID);
-
-    const auto position = msg.getData<filament::math::float3>(ECSMessageType::floatVec3);
-
-    // find the model in our list:
-    if (const auto ourEntity = _models.find(guid); ourEntity != _models.end()) {
-      const auto model = ourEntity->second;
-      const auto transform = model->getComponent<BaseTransform>();
-
-      // change stuff.
-      transform->SetPosition(position);
-    }
-
-    spdlog::trace("ChangeTranslationByGUID Complete");
-  });
-
-  // ChangeRotationByGUID
-  // TODO: move to TransformSystem
-  vRegisterMessageHandler(ECSMessageType::ChangeRotationByGUID, [this](const ECSMessage& msg) {
-    SPDLOG_TRACE("ChangeRotationByGUID");
-
-    const auto guid = msg.getData<EntityGUID>(ECSMessageType::ChangeRotationByGUID);
-
-    const auto values = msg.getData<filament::math::float4>(ECSMessageType::floatVec4);
-    filament::math::quatf rotation(values);
-
-    // find the model in our list:
-    if (const auto ourEntity = _models.find(guid); ourEntity != _models.end()) {
-      const auto model = ourEntity->second;
-      const auto transform = model->getComponent<BaseTransform>();
-
-      transform->SetRotation(rotation);
-    }
-
-    spdlog::trace("ChangeRotationByGUID Complete");
-  });
-
-  // ChangeScaleByGUID
-  // TODO: move to TransformSystem
-  vRegisterMessageHandler(ECSMessageType::ChangeScaleByGUID, [this](const ECSMessage& msg) {
-    SPDLOG_TRACE("ChangeScaleByGUID");
-
-    const auto guid = msg.getData<EntityGUID>(ECSMessageType::ChangeScaleByGUID);
-
-    const auto values = msg.getData<filament::math::float3>(ECSMessageType::floatVec3);
-
-    // find the model in our list:
-    if (const auto ourEntity = _models.find(guid); ourEntity != _models.end()) {
-      const auto model = ourEntity->second;
-      const auto transform = model->getComponent<BaseTransform>();
-
-      transform->SetScale(values);
-    }
-
-    spdlog::trace("ChangeScaleByGUID Complete");
-  });
-
   vRegisterMessageHandler(ECSMessageType::ToggleVisualForEntity, [this](const ECSMessage& msg) {
     spdlog::debug("ToggleVisualForEntity");
 

--- a/plugins/filament_view/core/systems/derived/shape_system.cc
+++ b/plugins/filament_view/core/systems/derived/shape_system.cc
@@ -232,66 +232,6 @@ void ShapeSystem::vOnInitSystem() {
 
     spdlog::trace("ToggleVisualForEntity Complete");
   });
-
-  // ChangeTranslationByGUID
-  vRegisterMessageHandler(ECSMessageType::ChangeTranslationByGUID, [this](const ECSMessage& msg) {
-    SPDLOG_TRACE("ChangeTranslationByGUID");
-
-    const auto guid = msg.getData<EntityGUID>(ECSMessageType::ChangeTranslationByGUID);
-
-    const auto position = msg.getData<filament::math::float3>(ECSMessageType::floatVec3);
-
-    // find the entity in our list:
-    if (hasShape(guid)) {
-      const auto entity = getShape(guid);
-      const auto baseTransform = entity->getComponent<BaseTransform>();
-      const auto collidable = entity->getComponent<Collidable>();
-
-      baseTransform->SetPosition(position);
-    }
-
-    SPDLOG_TRACE("ChangeTranslationByGUID Complete");
-  });
-
-  // ChangeRotationByGUID
-  vRegisterMessageHandler(ECSMessageType::ChangeRotationByGUID, [this](const ECSMessage& msg) {
-    SPDLOG_TRACE("ChangeRotationByGUID");
-
-    const auto guid = msg.getData<EntityGUID>(ECSMessageType::ChangeRotationByGUID);
-
-    const auto values = msg.getData<filament::math::float4>(ECSMessageType::floatVec4);
-    filament::math::quatf rotation(values);
-
-    // find the entity in our list:
-    if (hasShape(guid)) {
-      const auto entity = getShape(guid);
-      const auto baseTransform = entity->getComponent<BaseTransform>();
-
-      baseTransform->SetRotation(rotation);
-    }
-
-    SPDLOG_TRACE("ChangeRotationByGUID Complete");
-  });
-
-  // ChangeScaleByGUID
-  vRegisterMessageHandler(ECSMessageType::ChangeScaleByGUID, [this](const ECSMessage& msg) {
-    SPDLOG_TRACE("ChangeScaleByGUID");
-
-    const auto guid = msg.getData<EntityGUID>(ECSMessageType::ChangeScaleByGUID);
-
-    const auto values = msg.getData<filament::math::float3>(ECSMessageType::floatVec3);
-
-    // find the entity in our list:
-    if (hasShape(guid)) {
-      const auto entity = getShape(guid);
-      const auto baseTransform = entity->getComponent<BaseTransform>();
-      const auto collidable = entity->getComponent<Collidable>();
-
-      baseTransform->SetScale(values);
-    }
-
-    SPDLOG_TRACE("ChangeScaleByGUID Complete");
-  });
 }
 
 ////////////////////////////////////////////////////////////////////////////////////

--- a/plugins/filament_view/core/systems/messages/ecs_message_types.h
+++ b/plugins/filament_view/core/systems/messages/ecs_message_types.h
@@ -74,9 +74,6 @@ enum class ECSMessageType {
   AnimationResume,
   AnimationSetLooping,
 
-  ChangeTranslationByGUID,
-  ChangeRotationByGUID,
-  ChangeScaleByGUID,
   floatVec3,
   floatVec4,
 

--- a/plugins/filament_view/filament_view_plugin.cc
+++ b/plugins/filament_view/filament_view_plugin.cc
@@ -17,6 +17,7 @@
 #include "filament_view_plugin.h"
 
 #include <asio/post.hpp>
+#include <core/components/derived/basetransform.h>
 #include <core/scene/serialization/scene_text_deserializer.h>
 #include <core/systems/derived/animation_system.h>
 #include <core/systems/derived/collision_system.h>
@@ -334,42 +335,6 @@ std::optional<FlutterError> FilamentViewPlugin::ToggleShapesInScene(const bool v
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-std::optional<FlutterError> FilamentViewPlugin::SetShapeTransform(
-  const int64_t guid,
-  const double posx,
-  const double posy,
-  const double posz,
-  const double rotx,
-  const double roty,
-  const double rotz,
-  const double rotw,
-  const double sclx,
-  const double scly,
-  const double sclz
-) {
-  filament::math::float3 position(
-    static_cast<float>(posx), static_cast<float>(posy), static_cast<float>(posz)
-  );
-  // quaternion
-  filament::math::quatf rotation(
-    static_cast<float>(rotx), static_cast<float>(roty), static_cast<float>(rotz),
-    static_cast<float>(rotw)
-  );
-  filament::math::float3 scale(
-    static_cast<float>(sclx), static_cast<float>(scly), static_cast<float>(sclz)
-  );
-
-  ECSMessage shapeData;
-  shapeData.addData(ECSMessageType::SetShapeTransform, guid);
-  shapeData.addData(ECSMessageType::Position, position);
-  shapeData.addData(ECSMessageType::Rotation, rotation);
-  shapeData.addData(ECSMessageType::Scale, scale);
-  ECSManager::GetInstance()->vRouteMessage(shapeData);
-
-  return std::nullopt;
-}
-
-//////////////////////////////////////////////////////////////////////////////////////////
 std::optional<FlutterError> FilamentViewPlugin::ToggleDebugCollidableViewsInScene(const bool value
 ) {
   ECSMessage toggleMessage;
@@ -622,59 +587,28 @@ std::optional<FlutterError> FilamentViewPlugin::RequestCollisionCheckFromRay(
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-std::optional<FlutterError> FilamentViewPlugin::ChangeScaleByGUID(
-  const int64_t guid,
-  const double x,
-  const double y,
-  const double z
-) {
-  const filament::math::float3 values(
-    static_cast<float>(x), static_cast<float>(y), static_cast<float>(z)
-  );
-
-  ECSMessage changeRequest;
-  changeRequest.addData(ECSMessageType::ChangeScaleByGUID, guid);
-  changeRequest.addData(ECSMessageType::floatVec3, values);
-  ECSManager::GetInstance()->vRouteMessage(changeRequest);
+std::optional<FlutterError>
+FilamentViewPlugin::SetEntityTransformScale(const int64_t guid, const std::vector<double>& scl) {
+  ECSManager::GetInstance()->getComponent<BaseTransform>(guid)->setScale({scl[0], scl[1], scl[2]});
 
   return std::nullopt;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-std::optional<FlutterError> FilamentViewPlugin::ChangeTranslationByGUID(
-  const int64_t guid,
-  const double x,
-  const double y,
-  const double z
-) {
-  const filament::math::float3 values(
-    static_cast<float>(x), static_cast<float>(y), static_cast<float>(z)
+std::optional<FlutterError>
+FilamentViewPlugin::SetEntityTransformPosition(const int64_t guid, const std::vector<double>& pos) {
+  ECSManager::GetInstance()->getComponent<BaseTransform>(guid)->setPosition({pos[0], pos[1], pos[2]}
   );
-
-  ECSMessage changeRequest;
-  changeRequest.addData(ECSMessageType::ChangeTranslationByGUID, guid);
-  changeRequest.addData(ECSMessageType::floatVec3, values);
-  ECSManager::GetInstance()->vRouteMessage(changeRequest);
 
   return std::nullopt;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-std::optional<FlutterError> FilamentViewPlugin::ChangeRotationByGUID(
-  const int64_t guid,
-  const double x,
-  const double y,
-  const double z,
-  const double w
-) {
-  const filament::math::float4 values(
-    static_cast<float>(x), static_cast<float>(y), static_cast<float>(z), static_cast<float>(w)
+std::optional<FlutterError>
+FilamentViewPlugin::SetEntityTransformRotation(const int64_t guid, const std::vector<double>& rot) {
+  ECSManager::GetInstance()->getComponent<BaseTransform>(guid)->setRotation(
+    {rot[0], rot[1], rot[2], rot[3]}
   );
-
-  ECSMessage changeRequest;
-  changeRequest.addData(ECSMessageType::ChangeRotationByGUID, guid);
-  changeRequest.addData(ECSMessageType::floatVec4, values);
-  ECSManager::GetInstance()->vRouteMessage(changeRequest);
 
   return std::nullopt;
 }

--- a/plugins/filament_view/filament_view_plugin.h
+++ b/plugins/filament_view/filament_view_plugin.h
@@ -75,20 +75,6 @@ class FilamentViewPlugin : public flutter::Plugin, public FilamentViewApi, publi
     ChangeMaterialDefinition(const flutter::EncodableMap& params, const int64_t guid) override;
     // Toggle shapes visibility in the scene.
     std::optional<FlutterError> ToggleShapesInScene(bool value) override;
-    // Set shape transform
-    std::optional<FlutterError> SetShapeTransform(
-      const int64_t guid,
-      double posx,
-      double posy,
-      double posz,
-      double rotx,
-      double roty,
-      double rotz,
-      double rotw,
-      double sclx,
-      double scly,
-      double sclz
-    ) override;
     // Toggle debug collidable visuals in the scene.
     std::optional<FlutterError> ToggleDebugCollidableViewsInScene(bool value) override;
     // Change the camera mode by name.
@@ -139,12 +125,12 @@ class FilamentViewPlugin : public flutter::Plugin, public FilamentViewApi, publi
       double length
     ) override;
 
-    std::optional<FlutterError> ChangeScaleByGUID(const int64_t guid, double x, double y, double z)
-      override;
     std::optional<FlutterError>
-    ChangeTranslationByGUID(const int64_t guid, double x, double y, double z) override;
+    SetEntityTransformScale(const int64_t guid, const std::vector<double>& scl) override;
     std::optional<FlutterError>
-    ChangeRotationByGUID(const int64_t guid, double x, double y, double z, double w) override;
+    SetEntityTransformPosition(const int64_t guid, const std::vector<double>& pos) override;
+    std::optional<FlutterError>
+    SetEntityTransformRotation(const int64_t guid, const std::vector<double>& rot) override;
 
     std::optional<FlutterError> TurnOffVisualForEntity(const int64_t guid) override;
     std::optional<FlutterError> TurnOnVisualForEntity(const int64_t guid) override;

--- a/plugins/filament_view/messages.g.cc
+++ b/plugins/filament_view/messages.g.cc
@@ -64,8 +64,7 @@ const flutter::StandardMessageCodec& FilamentViewApi::GetCodec() {
   return flutter::StandardMessageCodec::GetInstance(&PigeonInternalCodecSerializer::GetInstance());
 }
 
-// Sets up an instance of `FilamentViewApi` to handle messages through the
-// `binary_messenger`.
+// Sets up an instance of `FilamentViewApi` to handle messages through the `binary_messenger`.
 void FilamentViewApi::SetUp(flutter::BinaryMessenger* binary_messenger, FilamentViewApi* api) {
   FilamentViewApi::SetUp(binary_messenger, api, "");
 }
@@ -80,8 +79,7 @@ void FilamentViewApi::SetUp(
   {
     BasicMessageChannel<> channel(
       binary_messenger,
-      "dev.flutter.pigeon.filament_scene."
-      "FilamentViewApi.changeMaterialParameter"
+      "dev.flutter.pigeon.filament_scene.FilamentViewApi.changeMaterialParameter"
         + prepended_suffix,
       &GetCodec()
     );
@@ -122,8 +120,7 @@ void FilamentViewApi::SetUp(
   {
     BasicMessageChannel<> channel(
       binary_messenger,
-      "dev.flutter.pigeon.filament_scene."
-      "FilamentViewApi.changeMaterialDefinition"
+      "dev.flutter.pigeon.filament_scene.FilamentViewApi.changeMaterialDefinition"
         + prepended_suffix,
       &GetCodec()
     );
@@ -164,9 +161,7 @@ void FilamentViewApi::SetUp(
   {
     BasicMessageChannel<> channel(
       binary_messenger,
-      "dev.flutter.pigeon.filament_scene."
-      "FilamentViewApi.toggleShapesInScene"
-        + prepended_suffix,
+      "dev.flutter.pigeon.filament_scene.FilamentViewApi.toggleShapesInScene" + prepended_suffix,
       &GetCodec()
     );
     if (api != nullptr) {
@@ -200,105 +195,7 @@ void FilamentViewApi::SetUp(
   {
     BasicMessageChannel<> channel(
       binary_messenger,
-      "dev.flutter.pigeon.filament_scene.FilamentViewApi.setShapeTransform" + prepended_suffix,
-      &GetCodec()
-    );
-    if (api != nullptr) {
-      channel.SetMessageHandler(
-        [api](const EncodableValue& message, const flutter::MessageReply<EncodableValue>& reply) {
-          try {
-            const auto& args = std::get<EncodableList>(message);
-            const auto& encodable_id_arg = args.at(0);
-            if (encodable_id_arg.IsNull()) {
-              reply(WrapError("id_arg unexpectedly null."));
-              return;
-            }
-            const int64_t id_arg = encodable_id_arg.LongValue();
-            const auto& encodable_posx_arg = args.at(1);
-            if (encodable_posx_arg.IsNull()) {
-              reply(WrapError("posx_arg unexpectedly null."));
-              return;
-            }
-            const auto& posx_arg = std::get<double>(encodable_posx_arg);
-            const auto& encodable_posy_arg = args.at(2);
-            if (encodable_posy_arg.IsNull()) {
-              reply(WrapError("posy_arg unexpectedly null."));
-              return;
-            }
-            const auto& posy_arg = std::get<double>(encodable_posy_arg);
-            const auto& encodable_posz_arg = args.at(3);
-            if (encodable_posz_arg.IsNull()) {
-              reply(WrapError("posz_arg unexpectedly null."));
-              return;
-            }
-            const auto& posz_arg = std::get<double>(encodable_posz_arg);
-            const auto& encodable_rotx_arg = args.at(4);
-            if (encodable_rotx_arg.IsNull()) {
-              reply(WrapError("rotx_arg unexpectedly null."));
-              return;
-            }
-            const auto& rotx_arg = std::get<double>(encodable_rotx_arg);
-            const auto& encodable_roty_arg = args.at(5);
-            if (encodable_roty_arg.IsNull()) {
-              reply(WrapError("roty_arg unexpectedly null."));
-              return;
-            }
-            const auto& roty_arg = std::get<double>(encodable_roty_arg);
-            const auto& encodable_rotz_arg = args.at(6);
-            if (encodable_rotz_arg.IsNull()) {
-              reply(WrapError("rotz_arg unexpectedly null."));
-              return;
-            }
-            const auto& rotz_arg = std::get<double>(encodable_rotz_arg);
-            const auto& encodable_rotw_arg = args.at(7);
-            if (encodable_rotw_arg.IsNull()) {
-              reply(WrapError("rotw_arg unexpectedly null."));
-              return;
-            }
-            const auto& rotw_arg = std::get<double>(encodable_rotw_arg);
-            const auto& encodable_sclx_arg = args.at(8);
-            if (encodable_sclx_arg.IsNull()) {
-              reply(WrapError("sclx_arg unexpectedly null."));
-              return;
-            }
-            const auto& sclx_arg = std::get<double>(encodable_sclx_arg);
-            const auto& encodable_scly_arg = args.at(9);
-            if (encodable_scly_arg.IsNull()) {
-              reply(WrapError("scly_arg unexpectedly null."));
-              return;
-            }
-            const auto& scly_arg = std::get<double>(encodable_scly_arg);
-            const auto& encodable_sclz_arg = args.at(10);
-            if (encodable_sclz_arg.IsNull()) {
-              reply(WrapError("sclz_arg unexpectedly null."));
-              return;
-            }
-            const auto& sclz_arg = std::get<double>(encodable_sclz_arg);
-            std::optional<FlutterError> output = api->SetShapeTransform(
-              id_arg, posx_arg, posy_arg, posz_arg, rotx_arg, roty_arg, rotz_arg, rotw_arg,
-              sclx_arg, scly_arg, sclz_arg
-            );
-            if (output.has_value()) {
-              reply(WrapError(output.value()));
-              return;
-            }
-            EncodableList wrapped;
-            wrapped.emplace_back();
-            reply(EncodableValue(std::move(wrapped)));
-          } catch (const std::exception& exception) {
-            reply(WrapError(exception.what()));
-          }
-        }
-      );
-    } else {
-      channel.SetMessageHandler(nullptr);
-    }
-  }
-  {
-    BasicMessageChannel<> channel(
-      binary_messenger,
-      "dev.flutter.pigeon.filament_scene."
-      "FilamentViewApi.changeViewQualitySettings"
+      "dev.flutter.pigeon.filament_scene.FilamentViewApi.changeViewQualitySettings"
         + prepended_suffix,
       &GetCodec()
     );
@@ -394,8 +291,7 @@ void FilamentViewApi::SetUp(
   {
     BasicMessageChannel<> channel(
       binary_messenger,
-      "dev.flutter.pigeon.filament_scene.FilamentViewApi."
-      "changeCameraOrbitHomePosition"
+      "dev.flutter.pigeon.filament_scene.FilamentViewApi.changeCameraOrbitHomePosition"
         + prepended_suffix,
       &GetCodec()
     );
@@ -443,8 +339,7 @@ void FilamentViewApi::SetUp(
   {
     BasicMessageChannel<> channel(
       binary_messenger,
-      "dev.flutter.pigeon.filament_scene."
-      "FilamentViewApi.changeCameraTargetPosition"
+      "dev.flutter.pigeon.filament_scene.FilamentViewApi.changeCameraTargetPosition"
         + prepended_suffix,
       &GetCodec()
     );
@@ -492,8 +387,7 @@ void FilamentViewApi::SetUp(
   {
     BasicMessageChannel<> channel(
       binary_messenger,
-      "dev.flutter.pigeon.filament_scene.FilamentViewApi."
-      "changeCameraFlightStartPosition"
+      "dev.flutter.pigeon.filament_scene.FilamentViewApi.changeCameraFlightStartPosition"
         + prepended_suffix,
       &GetCodec()
     );
@@ -541,8 +435,7 @@ void FilamentViewApi::SetUp(
   {
     BasicMessageChannel<> channel(
       binary_messenger,
-      "dev.flutter.pigeon.filament_scene.FilamentViewApi."
-      "resetInertiaCameraToDefaultValues"
+      "dev.flutter.pigeon.filament_scene.FilamentViewApi.resetInertiaCameraToDefaultValues"
         + prepended_suffix,
       &GetCodec()
     );
@@ -604,9 +497,7 @@ void FilamentViewApi::SetUp(
   {
     BasicMessageChannel<> channel(
       binary_messenger,
-      "dev.flutter.pigeon.filament_scene."
-      "FilamentViewApi.changeLightColorByGUID"
-        + prepended_suffix,
+      "dev.flutter.pigeon.filament_scene.FilamentViewApi.changeLightColorByGUID" + prepended_suffix,
       &GetCodec()
     );
     if (api != nullptr) {
@@ -653,8 +544,7 @@ void FilamentViewApi::SetUp(
   {
     BasicMessageChannel<> channel(
       binary_messenger,
-      "dev.flutter.pigeon.filament_scene."
-      "FilamentViewApi.changeLightTransformByGUID"
+      "dev.flutter.pigeon.filament_scene.FilamentViewApi.changeLightTransformByGUID"
         + prepended_suffix,
       &GetCodec()
     );
@@ -767,9 +657,7 @@ void FilamentViewApi::SetUp(
   {
     BasicMessageChannel<> channel(
       binary_messenger,
-      "dev.flutter.pigeon.filament_scene."
-      "FilamentViewApi.clearAnimationQueue"
-        + prepended_suffix,
+      "dev.flutter.pigeon.filament_scene.FilamentViewApi.clearAnimationQueue" + prepended_suffix,
       &GetCodec()
     );
     if (api != nullptr) {
@@ -843,9 +731,7 @@ void FilamentViewApi::SetUp(
   {
     BasicMessageChannel<> channel(
       binary_messenger,
-      "dev.flutter.pigeon.filament_scene."
-      "FilamentViewApi.changeAnimationSpeed"
-        + prepended_suffix,
+      "dev.flutter.pigeon.filament_scene.FilamentViewApi.changeAnimationSpeed" + prepended_suffix,
       &GetCodec()
     );
     if (api != nullptr) {
@@ -953,9 +839,7 @@ void FilamentViewApi::SetUp(
   {
     BasicMessageChannel<> channel(
       binary_messenger,
-      "dev.flutter.pigeon.filament_scene."
-      "FilamentViewApi.setAnimationLooping"
-        + prepended_suffix,
+      "dev.flutter.pigeon.filament_scene.FilamentViewApi.setAnimationLooping" + prepended_suffix,
       &GetCodec()
     );
     if (api != nullptr) {
@@ -995,8 +879,7 @@ void FilamentViewApi::SetUp(
   {
     BasicMessageChannel<> channel(
       binary_messenger,
-      "dev.flutter.pigeon.filament_scene.FilamentViewApi."
-      "requestCollisionCheckFromRay"
+      "dev.flutter.pigeon.filament_scene.FilamentViewApi.requestCollisionCheckFromRay"
         + prepended_suffix,
       &GetCodec()
     );
@@ -1076,8 +959,7 @@ void FilamentViewApi::SetUp(
   {
     BasicMessageChannel<> channel(
       binary_messenger,
-      "dev.flutter.pigeon.filament_scene.FilamentViewApi."
-      "turnOffCollisionChecksForEntity"
+      "dev.flutter.pigeon.filament_scene.FilamentViewApi.turnOffCollisionChecksForEntity"
         + prepended_suffix,
       &GetCodec()
     );
@@ -1112,8 +994,7 @@ void FilamentViewApi::SetUp(
   {
     BasicMessageChannel<> channel(
       binary_messenger,
-      "dev.flutter.pigeon.filament_scene.FilamentViewApi."
-      "turnOnCollisionChecksForEntity"
+      "dev.flutter.pigeon.filament_scene.FilamentViewApi.turnOnCollisionChecksForEntity"
         + prepended_suffix,
       &GetCodec()
     );
@@ -1148,8 +1029,7 @@ void FilamentViewApi::SetUp(
   {
     BasicMessageChannel<> channel(
       binary_messenger,
-      "dev.flutter.pigeon.filament_scene.FilamentViewApi."
-      "toggleDebugCollidableViewsInScene"
+      "dev.flutter.pigeon.filament_scene.FilamentViewApi.toggleDebugCollidableViewsInScene"
         + prepended_suffix,
       &GetCodec()
     );
@@ -1184,7 +1064,8 @@ void FilamentViewApi::SetUp(
   {
     BasicMessageChannel<> channel(
       binary_messenger,
-      "dev.flutter.pigeon.filament_scene.FilamentViewApi.changeScaleByGUID" + prepended_suffix,
+      "dev.flutter.pigeon.filament_scene.FilamentViewApi.setEntityTransformScale"
+        + prepended_suffix,
       &GetCodec()
     );
     if (api != nullptr) {
@@ -1198,26 +1079,13 @@ void FilamentViewApi::SetUp(
               return;
             }
             const int64_t id_arg = encodable_id_arg.LongValue();
-            const auto& encodable_x_arg = args.at(1);
-            if (encodable_x_arg.IsNull()) {
-              reply(WrapError("x_arg unexpectedly null."));
+            const auto& encodable_scl_arg = args.at(1);
+            if (encodable_scl_arg.IsNull()) {
+              reply(WrapError("scl_arg unexpectedly null."));
               return;
             }
-            const auto& x_arg = std::get<double>(encodable_x_arg);
-            const auto& encodable_y_arg = args.at(2);
-            if (encodable_y_arg.IsNull()) {
-              reply(WrapError("y_arg unexpectedly null."));
-              return;
-            }
-            const auto& y_arg = std::get<double>(encodable_y_arg);
-            const auto& encodable_z_arg = args.at(3);
-            if (encodable_z_arg.IsNull()) {
-              reply(WrapError("z_arg unexpectedly null."));
-              return;
-            }
-            const auto& z_arg = std::get<double>(encodable_z_arg);
-            std::optional<FlutterError> output =
-              api->ChangeScaleByGUID(id_arg, x_arg, y_arg, z_arg);
+            const auto& scl_arg = std::get<std::vector<double>>(encodable_scl_arg);
+            std::optional<FlutterError> output = api->SetEntityTransformScale(id_arg, scl_arg);
             if (output.has_value()) {
               reply(WrapError(output.value()));
               return;
@@ -1237,8 +1105,7 @@ void FilamentViewApi::SetUp(
   {
     BasicMessageChannel<> channel(
       binary_messenger,
-      "dev.flutter.pigeon.filament_scene."
-      "FilamentViewApi.changeTranslationByGUID"
+      "dev.flutter.pigeon.filament_scene.FilamentViewApi.setEntityTransformPosition"
         + prepended_suffix,
       &GetCodec()
     );
@@ -1253,26 +1120,13 @@ void FilamentViewApi::SetUp(
               return;
             }
             const int64_t id_arg = encodable_id_arg.LongValue();
-            const auto& encodable_x_arg = args.at(1);
-            if (encodable_x_arg.IsNull()) {
-              reply(WrapError("x_arg unexpectedly null."));
+            const auto& encodable_pos_arg = args.at(1);
+            if (encodable_pos_arg.IsNull()) {
+              reply(WrapError("pos_arg unexpectedly null."));
               return;
             }
-            const auto& x_arg = std::get<double>(encodable_x_arg);
-            const auto& encodable_y_arg = args.at(2);
-            if (encodable_y_arg.IsNull()) {
-              reply(WrapError("y_arg unexpectedly null."));
-              return;
-            }
-            const auto& y_arg = std::get<double>(encodable_y_arg);
-            const auto& encodable_z_arg = args.at(3);
-            if (encodable_z_arg.IsNull()) {
-              reply(WrapError("z_arg unexpectedly null."));
-              return;
-            }
-            const auto& z_arg = std::get<double>(encodable_z_arg);
-            std::optional<FlutterError> output =
-              api->ChangeTranslationByGUID(id_arg, x_arg, y_arg, z_arg);
+            const auto& pos_arg = std::get<std::vector<double>>(encodable_pos_arg);
+            std::optional<FlutterError> output = api->SetEntityTransformPosition(id_arg, pos_arg);
             if (output.has_value()) {
               reply(WrapError(output.value()));
               return;
@@ -1292,8 +1146,7 @@ void FilamentViewApi::SetUp(
   {
     BasicMessageChannel<> channel(
       binary_messenger,
-      "dev.flutter.pigeon.filament_scene."
-      "FilamentViewApi.changeRotationByGUID"
+      "dev.flutter.pigeon.filament_scene.FilamentViewApi.setEntityTransformRotation"
         + prepended_suffix,
       &GetCodec()
     );
@@ -1308,32 +1161,13 @@ void FilamentViewApi::SetUp(
               return;
             }
             const int64_t id_arg = encodable_id_arg.LongValue();
-            const auto& encodable_x_arg = args.at(1);
-            if (encodable_x_arg.IsNull()) {
-              reply(WrapError("x_arg unexpectedly null."));
+            const auto& encodable_rot_arg = args.at(1);
+            if (encodable_rot_arg.IsNull()) {
+              reply(WrapError("rot_arg unexpectedly null."));
               return;
             }
-            const auto& x_arg = std::get<double>(encodable_x_arg);
-            const auto& encodable_y_arg = args.at(2);
-            if (encodable_y_arg.IsNull()) {
-              reply(WrapError("y_arg unexpectedly null."));
-              return;
-            }
-            const auto& y_arg = std::get<double>(encodable_y_arg);
-            const auto& encodable_z_arg = args.at(3);
-            if (encodable_z_arg.IsNull()) {
-              reply(WrapError("z_arg unexpectedly null."));
-              return;
-            }
-            const auto& z_arg = std::get<double>(encodable_z_arg);
-            const auto& encodable_w_arg = args.at(4);
-            if (encodable_w_arg.IsNull()) {
-              reply(WrapError("w_arg unexpectedly null."));
-              return;
-            }
-            const auto& w_arg = std::get<double>(encodable_w_arg);
-            std::optional<FlutterError> output =
-              api->ChangeRotationByGUID(id_arg, x_arg, y_arg, z_arg, w_arg);
+            const auto& rot_arg = std::get<std::vector<double>>(encodable_rot_arg);
+            std::optional<FlutterError> output = api->SetEntityTransformRotation(id_arg, rot_arg);
             if (output.has_value()) {
               reply(WrapError(output.value()));
               return;
@@ -1353,9 +1187,7 @@ void FilamentViewApi::SetUp(
   {
     BasicMessageChannel<> channel(
       binary_messenger,
-      "dev.flutter.pigeon.filament_scene."
-      "FilamentViewApi.turnOffVisualForEntity"
-        + prepended_suffix,
+      "dev.flutter.pigeon.filament_scene.FilamentViewApi.turnOffVisualForEntity" + prepended_suffix,
       &GetCodec()
     );
     if (api != nullptr) {
@@ -1389,9 +1221,7 @@ void FilamentViewApi::SetUp(
   {
     BasicMessageChannel<> channel(
       binary_messenger,
-      "dev.flutter.pigeon.filament_scene."
-      "FilamentViewApi.turnOnVisualForEntity"
-        + prepended_suffix,
+      "dev.flutter.pigeon.filament_scene.FilamentViewApi.turnOnVisualForEntity" + prepended_suffix,
       &GetCodec()
     );
     if (api != nullptr) {

--- a/plugins/filament_view/messages.g.h
+++ b/plugins/filament_view/messages.g.h
@@ -96,8 +96,7 @@ class PigeonInternalCodecSerializer : public flutter::StandardCodecSerializer {
       const override;
 };
 
-// Generated interface from Pigeon that represents a handler of messages from
-// Flutter.
+// Generated interface from Pigeon that represents a handler of messages from Flutter.
 class FilamentViewApi {
   public:
     FilamentViewApi(const FilamentViewApi&) = delete;
@@ -111,20 +110,6 @@ class FilamentViewApi {
     ChangeMaterialDefinition(const flutter::EncodableMap& params, int64_t id) = 0;
     // Toggle shapes visibility in the scene.
     virtual std::optional<FlutterError> ToggleShapesInScene(bool value) = 0;
-    // Set shape's transform by GUID.
-    virtual std::optional<FlutterError> SetShapeTransform(
-      int64_t id,
-      double posx,
-      double posy,
-      double posz,
-      double rotx,
-      double roty,
-      double rotz,
-      double rotw,
-      double sclx,
-      double scly,
-      double sclz
-    ) = 0;
     // Cycle between view quality settings presets.
     virtual std::optional<FlutterError> ChangeViewQualitySettings() = 0;
     // Set fog options
@@ -162,8 +147,7 @@ class FilamentViewApi {
     virtual std::optional<FlutterError> ResumeAnimation(int64_t id) = 0;
     virtual std::optional<FlutterError> SetAnimationLooping(int64_t id, bool looping) = 0;
     // Perform a raycast query.
-    // The result will be sent back to the client via the collision_info event
-    // channel.
+    // The result will be sent back to the client via the collision_info event channel.
     virtual std::optional<FlutterError> RequestCollisionCheckFromRay(
       const std::string& query_i_d,
       double origin_x,
@@ -183,18 +167,17 @@ class FilamentViewApi {
     // Enable/disable debug collidable visuals in the scene.
     virtual std::optional<FlutterError> ToggleDebugCollidableViewsInScene(bool value) = 0;
     virtual std::optional<FlutterError>
-    ChangeScaleByGUID(int64_t id, double x, double y, double z) = 0;
+    SetEntityTransformScale(int64_t id, const std::vector<double>& scl) = 0;
     virtual std::optional<FlutterError>
-    ChangeTranslationByGUID(int64_t id, double x, double y, double z) = 0;
+    SetEntityTransformPosition(int64_t id, const std::vector<double>& pos) = 0;
     virtual std::optional<FlutterError>
-    ChangeRotationByGUID(int64_t id, double x, double y, double z, double w) = 0;
+    SetEntityTransformRotation(int64_t id, const std::vector<double>& rot) = 0;
     virtual std::optional<FlutterError> TurnOffVisualForEntity(int64_t id) = 0;
     virtual std::optional<FlutterError> TurnOnVisualForEntity(int64_t id) = 0;
 
     // The codec used by FilamentViewApi.
     static const flutter::StandardMessageCodec& GetCodec();
-    // Sets up an instance of `FilamentViewApi` to handle messages through the
-    // `binary_messenger`.
+    // Sets up an instance of `FilamentViewApi` to handle messages through the `binary_messenger`.
     static void SetUp(flutter::BinaryMessenger* binary_messenger, FilamentViewApi* api);
     static void SetUp(
       flutter::BinaryMessenger* binary_messenger,


### PR DESCRIPTION
Tiny PR!

Simplified the way transform API calls from Dart are handled, now the plugin will set the transform params directly instead of routing messages around - this is more in line with how the engine does things post-refactor.

Sure, it introduces tighter coupling between the plugin code and engine internals, but given the substantial reduction in performance overhead (and given this is a VERY hot endpoint), the gains are well worth it. Most likely other Dart-C++ APis will follow suit in the future

Sister PR to https://github.com/toyota-connected/tcna-packages/pull/12