### PR TITLE
[filament_view] Added Filament version define and print

### DIFF
--- a/.github/workflows/ivi-homescreen.yaml
+++ b/.github/workflows/ivi-homescreen.yaml
@@ -10,6 +10,9 @@ on:
     # daily
     - cron: '0 0 * * *'
 
+env:
+  FILAMENT_VERSION: '1.56.7'
+
 jobs:
   homescreen:
     permissions:
@@ -113,7 +116,7 @@ jobs:
         run: |
           git clone -b release https://github.com/google/filament.git
           cd filament
-          git checkout v1.56.7
+          git checkout v${{ env.FILAMENT_VERSION }}
           PATCHES=${{github.workspace}}/.github/workflows/patches
           git apply $PATCHES/filament/0001-disable-backend-tests.patch
           git apply $PATCHES/filament/0002-install-required-files.patch
@@ -127,6 +130,7 @@ jobs:
           cd $FILAMENT_BUILD_DIR
           CC=/usr/bin/clang CXX=/usr/bin/clang++ \
           cmake .. -GNinja \
+            -DFILAMENT_VERSION="${{ env.FILAMENT_VERSION }}" \
             -DFILAMENT_SUPPORTS_VULKAN=ON \
             -DFILAMENT_ENABLE_LTO=ON \
             -DFILAMENT_SUPPORTS_OPENGL=OFF \

--- a/plugins/filament_view/CMakeLists.txt
+++ b/plugins/filament_view/CMakeLists.txt
@@ -142,6 +142,9 @@ target_link_libraries(plugin_filament_view PUBLIC
         toolchain::toolchain
 )
 
+# Sets the Filament version
+target_compile_definitions(plugin_filament_view PUBLIC FILAMENT_VERSION="${FILAMENT_VERSION}")
+
 #
 # Filament MVP Example
 #

--- a/plugins/filament_view/core/systems/derived/filament_system.cc
+++ b/plugins/filament_view/core/systems/derived/filament_system.cc
@@ -23,7 +23,7 @@ namespace plugin_filament_view {
 
 ////////////////////////////////////////////////////////////////////////////////////
 void FilamentSystem::vOnInitSystem() {
-  spdlog::debug("Engine creation Filament API thread: 0x{:x}", pthread_self());
+  DebugPrint();
 
   /* Note; this is checked in for future reference, on some systems this might
   be needed. TBD
@@ -64,6 +64,9 @@ void FilamentSystem::vShutdownSystem() {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////
-void FilamentSystem::DebugPrint() { spdlog::debug("{}", __FUNCTION__); }
+void FilamentSystem::DebugPrint() {
+  spdlog::debug("google/filament v{}", getFilamentVersionString());
+  spdlog::debug("Engine creation Filament API thread: 0x{:x}", pthread_self());
+}
 
 }  // namespace plugin_filament_view

--- a/plugins/filament_view/core/systems/derived/filament_system.h
+++ b/plugins/filament_view/core/systems/derived/filament_system.h
@@ -20,6 +20,10 @@
 #include <core/utils/ibl_profiler.h>
 #include <memory>
 
+#ifndef FILAMENT_VERSION
+#error "Filament version not defined. Please add the appropriate define in your build system."
+#endif
+
 namespace plugin_filament_view {
 
 class FilamentSystem : public ECSystem {
@@ -34,6 +38,12 @@ class FilamentSystem : public ECSystem {
     void vUpdate(float fElapsedTime) override;
     void vShutdownSystem() override;
     void DebugPrint() override;
+
+    [[nodiscard]] const char* getFilamentVersionString() const {
+      // Get the Filament version string from define FILAMENT_VERSION as a constexpr (define doesn't include quotes)
+      constexpr char* version = FILAMENT_VERSION;
+      return version;
+    }
 
     [[nodiscard]] ::filament::Engine* getFilamentEngine() const { return fengine_; }
 


### PR DESCRIPTION
NOTE: requires a define in `workspace-automation` (see meta-flutter/workspace-automation#113)

Adds the ability to print the Filament version in the `filament_scene` engine. It will do so automatically during `FilamentSystem` init.

Fixes https://github.com/toyota-connected/tcna-packages/issues/29