### PR TITLE
feat(common): Enhance CurlClient for generic HTTP requests

### DIFF
--- a/plugins/common/curl_client/curl_client.cc
+++ b/plugins/common/curl_client/curl_client.cc
@@ -31,11 +31,20 @@ namespace plugin_common_curl {
 
 CurlClient::CurlClient() : mCode(CURLE_OK) {
   curl_global_init(CURL_GLOBAL_DEFAULT);
+  mConn = curl_easy_init();
   std::make_unique<char>(CURL_ERROR_SIZE);
 }
 
 CurlClient::~CurlClient() {
-  curl_easy_cleanup(mConn);
+  if(mConn){
+    curl_easy_cleanup(mConn);
+  }
+
+  if(mHeadersList){
+    curl_slist_free_all(mHeadersList);
+  }
+
+  curl_global_cleanup();
   mErrorBuffer.reset();
 }
 
@@ -56,6 +65,14 @@ int CurlClient::VectorWriter(char* data,
   return static_cast<int>(size * num_mem_block);
 }
 
+void CurlClient::SetBearerToken(const std::string& token){
+  if(token.empty()){
+    mAuthHeader.clear();
+  } else {
+    mAuthHeader = "Authorization: Bearer " + token;
+  }
+}
+
 bool CurlClient::Init(
     const std::string& url,
     const std::vector<std::string>& headers,
@@ -63,19 +80,28 @@ bool CurlClient::Init(
     const bool follow_location) {
   mCode = CURLE_OK;
 
-  mConn = curl_easy_init();
   if (mConn == nullptr) {
     spdlog::error("[CurlClient] Failed to create CURL connection");
     return false;
   }
 
+  curl_easy_reset(mConn);
+  mStringBuffer.clear();
+  mVectorBuffer.clear();
+  mPostFields.clear();
+
+  if(mHeadersList){
+    curl_slist_free_all(mHeadersList);
+    mHeadersList = nullptr;
+  }
+/*
   mCode = curl_easy_setopt(mConn, CURLOPT_ERRORBUFFER, mErrorBuffer.get());
   if (mCode != CURLE_OK) {
     spdlog::error("[CurlClient] Failed to set error buffer [{}]",
                   static_cast<int>(mCode));
     return false;
   }
-
+*/
   mUrl = url;
   spdlog::trace("[CurlClient] URL: {}", mUrl);
 
@@ -86,37 +112,41 @@ bool CurlClient::Init(
   }
 
   if (!url_form.empty()) {
-    mPostFields.clear();
-    int count = 0;
     for (const auto& [fst, snd] : url_form) {
-      if (count) {
+      if (!mPostFields.empty()) {
         mPostFields += "&";
       }
-      mPostFields.append(fst);
-      mPostFields.append("=");
-      mPostFields.append(snd);
-      count++;
+      char* encoded_Key = curl_easy_escape(mConn,fst.c_str(), fst.length());
+      char* encoded_value = curl_easy_escape(mConn,snd.c_str(), snd.length());
+      if(encoded_Key && encoded_value){
+        mPostFields.append(encoded_Key);
+        mPostFields.append("=");
+        mPostFields.append(encoded_value);
+      }
+      curl_free(encoded_Key);
+      curl_free(encoded_value);
     }
     spdlog::trace("[CurlClient] PostFields: {}", mPostFields);
-    curl_easy_setopt(mConn, CURLOPT_POSTFIELDSIZE, mPostFields.length());
     // libcurl does not copy
     curl_easy_setopt(mConn, CURLOPT_POSTFIELDS, mPostFields.c_str());
   }
 
-  if (!headers.empty()) {
-    curl_slist* curl_headers{};
-    for (const auto& header : headers) {
-      spdlog::trace("[CurlClient] Header: {}", header);
-      curl_headers = curl_slist_append(curl_headers, header.c_str());
-    }
-    mCode = curl_easy_setopt(mConn, CURLOPT_HTTPHEADER, curl_headers);
-    if (mCode != CURLE_OK) {
-      spdlog::error("[CurlClient] Failed to set headers option [{}]",
-                    mErrorBuffer.get());
-      return false;
-    }
+  if (!mAuthHeader.empty()) {
+    mHeadersList = curl_slist_append(mHeadersList, mAuthHeader.c_str());  
   }
-
+  for (const auto& header : headers) {
+    spdlog::trace("[CurlClient] Header: {}", header);
+    mHeadersList = curl_slist_append(mHeadersList, header.c_str());
+  }
+  if(mHeadersList){
+    mCode = curl_easy_setopt(mConn, CURLOPT_HTTPHEADER, mHeadersList);
+  }  
+  if (mCode != CURLE_OK) {
+    spdlog::error("[CurlClient] Failed to set headers option [{}]",
+                  mErrorBuffer.get());
+    return false;
+  }
+  
   mCode = curl_easy_setopt(mConn, CURLOPT_FOLLOWLOCATION,
                            follow_location ? 1L : 0L);
   if (mCode != CURLE_OK) {
@@ -128,7 +158,29 @@ bool CurlClient::Init(
   return true;
 }
 
+std::string CurlClient::Get(const std::string& url,
+  const std::vector<std::string>& additional_headers){
+  if(Init(url, additional_headers , {})) {
+    return RetrieveContentAsString();
+  }
+  return "";
+}
+
+std::string CurlClient::Post(
+    const std::string& url,
+    const std::vector<std::pair<std::string ,std::string>>& form_data,
+    const std::vector<std::string>& additional_headers){
+  if (Init(url, additional_headers, form_data)) {
+    return RetrieveContentAsString();
+  }
+  return "";
+}
+
 std::string CurlClient::RetrieveContentAsString(const bool verbose) {
+  if(mConn == nullptr){
+    return "";
+  }
+  
   curl_easy_setopt(mConn, CURLOPT_VERBOSE, verbose ? 1L : 0L);
   if (mCode != CURLE_OK) {
     spdlog::error("[CurlClient] Failed to set 'CURLOPT_VERBOSE' [{}]\n",
@@ -149,19 +201,22 @@ std::string CurlClient::RetrieveContentAsString(const bool verbose) {
     return {};
   }
 
-  mStringBuffer.clear();
-
   mCode = curl_easy_perform(mConn);
   if (mCode != CURLE_OK) {
-    spdlog::error("[CurlClient] Failed to get '{}' [{}]\n", mUrl,
-                  mErrorBuffer.get());
-    return {};
+    spdlog::error("[CurlClient] Failed to perform request : {}", 
+                  curl_easy_strerror(mCode));
+    return "";
   }
   return mStringBuffer;
 }
 
 const std::vector<uint8_t>& CurlClient::RetrieveContentAsVector(
     const bool verbose) {
+  if(mConn == nullptr){
+    mVectorBuffer.clear();
+    return mVectorBuffer;
+  }
+  
   curl_easy_setopt(mConn, CURLOPT_VERBOSE, verbose ? 1L : 0L);
   if (mCode != CURLE_OK) {
     spdlog::error("[CurlClient] Failed to set 'CURLOPT_VERBOSE' [{}]\n",

--- a/plugins/common/curl_client/curl_client.cc
+++ b/plugins/common/curl_client/curl_client.cc
@@ -116,8 +116,10 @@ bool CurlClient::Init(
       if (!mPostFields.empty()) {
         mPostFields += "&";
       }
-      char* encoded_Key = curl_easy_escape(mConn, key.c_str(), static_cast<int>(key.length()));
-      char* encoded_value = curl_easy_escape(mConn, value.c_str(), static_cast<int>(value.length()));
+      char* encoded_Key =
+          curl_easy_escape(mConn, key.c_str(), static_cast<int>(key.length()));
+      char* encoded_value = curl_easy_escape(mConn, value.c_str(),
+                                             static_cast<int>(value.length()));
       if (encoded_Key && encoded_value) {
         mPostFields += encoded_Key;
         mPostFields += "=";

--- a/plugins/common/curl_client/curl_client.cc
+++ b/plugins/common/curl_client/curl_client.cc
@@ -116,9 +116,8 @@ bool CurlClient::Init(
       if (!mPostFields.empty()) {
         mPostFields += "&";
       }
-      char* encoded_Key = curl_easy_escape(mConn, key.c_str(), key.length());
-      char* encoded_value =
-          curl_easy_escape(mConn, value.c_str(), value.length());
+      char* encoded_Key = curl_easy_escape(mConn, key.c_str(), static_cast<int>(key.length()));
+      char* encoded_value = curl_easy_escape(mConn, value.c_str(), static_cast<int>(value.length()));
       if (encoded_Key && encoded_value) {
         mPostFields += encoded_Key;
         mPostFields += "=";

--- a/plugins/common/curl_client/curl_client.cc
+++ b/plugins/common/curl_client/curl_client.cc
@@ -36,11 +36,11 @@ CurlClient::CurlClient() : mCode(CURLE_OK) {
 }
 
 CurlClient::~CurlClient() {
-  if(mConn){
+  if (mConn) {
     curl_easy_cleanup(mConn);
   }
 
-  if(mHeadersList){
+  if (mHeadersList) {
     curl_slist_free_all(mHeadersList);
   }
 
@@ -65,8 +65,8 @@ int CurlClient::VectorWriter(char* data,
   return static_cast<int>(size * num_mem_block);
 }
 
-void CurlClient::SetBearerToken(const std::string& token){
-  if(token.empty()){
+void CurlClient::SetBearerToken(const std::string& token) {
+  if (token.empty()) {
     mAuthHeader.clear();
   } else {
     mAuthHeader = "Authorization: Bearer " + token;
@@ -90,7 +90,7 @@ bool CurlClient::Init(
   mVectorBuffer.clear();
   mPostFields.clear();
 
-  if(mHeadersList){
+  if (mHeadersList) {
     curl_slist_free_all(mHeadersList);
     mHeadersList = nullptr;
   }
@@ -116,9 +116,10 @@ bool CurlClient::Init(
       if (!mPostFields.empty()) {
         mPostFields += "&";
       }
-      char* encoded_Key = curl_easy_escape(mConn,key.c_str(), key.length());
-      char* encoded_value = curl_easy_escape(mConn,value.c_str(), value.length());
-      if(encoded_Key && encoded_value){
+      char* encoded_Key = curl_easy_escape(mConn, key.c_str(), key.length());
+      char* encoded_value =
+          curl_easy_escape(mConn, value.c_str(), value.length());
+      if (encoded_Key && encoded_value) {
         mPostFields += encoded_Key;
         mPostFields += "=";
         mPostFields += encoded_value;
@@ -133,21 +134,21 @@ bool CurlClient::Init(
   }
 
   if (!mAuthHeader.empty()) {
-    mHeadersList = curl_slist_append(mHeadersList, mAuthHeader.c_str());  
+    mHeadersList = curl_slist_append(mHeadersList, mAuthHeader.c_str());
   }
   for (const auto& header : headers) {
     spdlog::trace("[CurlClient] Header: {}", header);
     mHeadersList = curl_slist_append(mHeadersList, header.c_str());
   }
-  if(mHeadersList){
+  if (mHeadersList) {
     mCode = curl_easy_setopt(mConn, CURLOPT_HTTPHEADER, mHeadersList);
-  }  
+  }
   if (mCode != CURLE_OK) {
     spdlog::error("[CurlClient] Failed to set headers option [{}]",
                   mErrorBuffer.get());
     return false;
   }
-  
+
   mCode = curl_easy_setopt(mConn, CURLOPT_FOLLOWLOCATION,
                            follow_location ? 1L : 0L);
   if (mCode != CURLE_OK) {
@@ -159,9 +160,10 @@ bool CurlClient::Init(
   return true;
 }
 
-std::string CurlClient::Get(const std::string& url,
-  const std::vector<std::string>& additional_headers){
-  if(Init(url, additional_headers , {})) {
+std::string CurlClient::Get(
+    const std::string& url,
+    const std::vector<std::string>& additional_headers) {
+  if (Init(url, additional_headers, {})) {
     return RetrieveContentAsString();
   }
   return "";
@@ -169,8 +171,8 @@ std::string CurlClient::Get(const std::string& url,
 
 std::string CurlClient::Post(
     const std::string& url,
-    const std::vector<std::pair<std::string ,std::string>>& form_data,
-    const std::vector<std::string>& additional_headers){
+    const std::vector<std::pair<std::string, std::string>>& form_data,
+    const std::vector<std::string>& additional_headers) {
   if (Init(url, additional_headers, form_data)) {
     return RetrieveContentAsString();
   }
@@ -178,10 +180,10 @@ std::string CurlClient::Post(
 }
 
 std::string CurlClient::RetrieveContentAsString(const bool verbose) {
-  if(mConn == nullptr){
+  if (mConn == nullptr) {
     return "";
   }
-  
+
   curl_easy_setopt(mConn, CURLOPT_VERBOSE, verbose ? 1L : 0L);
   if (mCode != CURLE_OK) {
     spdlog::error("[CurlClient] Failed to set 'CURLOPT_VERBOSE' [{}]\n",
@@ -204,7 +206,7 @@ std::string CurlClient::RetrieveContentAsString(const bool verbose) {
 
   mCode = curl_easy_perform(mConn);
   if (mCode != CURLE_OK) {
-    spdlog::error("[CurlClient] Failed to perform request : {}", 
+    spdlog::error("[CurlClient] Failed to perform request : {}",
                   curl_easy_strerror(mCode));
     return "";
   }
@@ -213,11 +215,11 @@ std::string CurlClient::RetrieveContentAsString(const bool verbose) {
 
 const std::vector<uint8_t>& CurlClient::RetrieveContentAsVector(
     const bool verbose) {
-  if(mConn == nullptr){
+  if (mConn == nullptr) {
     mVectorBuffer.clear();
     return mVectorBuffer;
   }
-  
+
   curl_easy_setopt(mConn, CURLOPT_VERBOSE, verbose ? 1L : 0L);
   if (mCode != CURLE_OK) {
     spdlog::error("[CurlClient] Failed to set 'CURLOPT_VERBOSE' [{}]\n",

--- a/plugins/common/curl_client/curl_client.h
+++ b/plugins/common/curl_client/curl_client.h
@@ -77,7 +77,7 @@ class CurlClient {
    * google_sign_in
    */
   [[nodiscard]] CURLcode GetCode() const { return mCode; }
-   
+
   /**
    * @brief Function sets the bearer token for the OAuth 2.0 authentication.
    * @param token The authentication token.
@@ -85,26 +85,27 @@ class CurlClient {
    * google_sign_in
    */
   void SetBearerToken(const std::string& token);
-  
+
   /**
    * @brief Performs an HTTP POST request with URL-encoded from data.
    * @param url The URL to post to.
    * @param additional_headers A vector of additional headers to send.
-   * @return std::string The response body. 
+   * @return std::string The response body.
    */
-  std::string Get(const std::string& url, const std::vector<std::string>& additional_headers = {});
+  std::string Get(const std::string& url,
+                  const std::vector<std::string>& additional_headers = {});
 
   /**
    * @brief Performs an HTTP POST request with URL-encoded from data.
    * @param url The URL to post to.
    * @param form_data A vector of key-valued pair for the form data.
    * @param additional_headers A vector of additional headers to send.
-   * @return std::string The response body.    
+   * @return std::string The response body.
    */
   std::string Post(
-    const std::string& url,
-    const std::vector<std::pair<std::string ,std::string>>& form_data,
-    const std::vector<std::string>& additional_headers = {});
+      const std::string& url,
+      const std::vector<std::pair<std::string, std::string>>& form_data,
+      const std::vector<std::string>& additional_headers = {});
 
   // Prevent copying.
   CurlClient(CurlClient const&) = delete;

--- a/plugins/common/curl_client/curl_client.h
+++ b/plugins/common/curl_client/curl_client.h
@@ -117,7 +117,7 @@ class CurlClient {
   std::string mUrl;
   std::string mAuthHeader;
   std::string mPostFields;
-  std::unique_ptr<char> mErrorBuffer;
+  std::unique_ptr<char[]> mErrorBuffer;
   std::string mStringBuffer;
   std::vector<uint8_t> mVectorBuffer;
 

--- a/plugins/common/curl_client/curl_client.h
+++ b/plugins/common/curl_client/curl_client.h
@@ -77,6 +77,34 @@ class CurlClient {
    * google_sign_in
    */
   [[nodiscard]] CURLcode GetCode() const { return mCode; }
+   
+  /**
+   * @brief Function sets the bearer token for the OAuth 2.0 authentication.
+   * @param token The authentication token.
+   * @relation
+   * google_sign_in
+   */
+  void SetBearerToken(const std::string& token);
+  
+  /**
+   * @brief Performs an HTTP POST request with URL-encoded from data.
+   * @param url The URL to post to.
+   * @param additional_headers A vector of additional headers to send.
+   * @return std::string The response body. 
+   */
+  std::string Get(const std::string& url, const std::vector<std::string>& additional_headers = {});
+
+  /**
+   * @brief Performs an HTTP POST request with URL-encoded from data.
+   * @param url The URL to post to.
+   * @param form_data A vector of key-valued pair for the form data.
+   * @param additional_headers A vector of additional headers to send.
+   * @return std::string The response body.    
+   */
+  std::string Post(
+    const std::string& url,
+    const std::vector<std::pair<std::string ,std::string>>& form_data,
+    const std::vector<std::string>& additional_headers = {});
 
   // Prevent copying.
   CurlClient(CurlClient const&) = delete;
@@ -84,8 +112,10 @@ class CurlClient {
 
  private:
   CURL* mConn{};
+  struct curl_slist* mHeadersList{};
   CURLcode mCode;
   std::string mUrl;
+  std::string mAuthHeader;
   std::string mPostFields;
   std::unique_ptr<char> mErrorBuffer;
   std::string mStringBuffer;


### PR DESCRIPTION
This pull request is the first step in implementing the #123 feature. It enhances the common `CurlClient` to provide a robust and generic interface for making the HTTP requests required to communicate with a remote repository.

**Key Changes:**

*   **New `Get()` and `Post()` Methods:** Introduced simple, self-contained `Get()` and `Post()` methods to the public API. This provides a modern, stateless interface for making RESTful API calls.
*   **Authentication Support:** Added a `SetBearerToken()` method to easily include an `Authorization: Bearer` header for authenticated requests.
*   **Memory Leak Fixed:** Corrected a critical memory leak where the `curl_slist` for headers was not being freed after a request. The header list is now properly managed across the lifecycle of each request.
*   **POST Data Integrity:** Implemented proper URL-encoding for all form data using `curl_easy_escape`, ensuring that requests with special characters are handled correctly.
*   **Internal Refactoring:** The existing `Init()` method has been refactored for safety and is now used internally by `Get()` and `Post()` to ensure consistent setup and resource management.

This enhanced `CurlClient` provides the necessary foundation for the `SyncManager` (PR #130) to fetch and store data from the Flat-manager remote.
