### PR TITLE
Add Curl Client Tests (Part of Feature #123)

### DIFF
--- a/plugins/common/curl_client/curl_client.h
+++ b/plugins/common/curl_client/curl_client.h
@@ -17,16 +17,28 @@
 #ifndef PLUGINS_COMMON_CURL_CLIENT_CURL_CLIENT_H_
 #define PLUGINS_COMMON_CURL_CLIENT_CURL_CLIENT_H_
 
+#include <curl/curl.h>
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include <curl/curl.h>
-
 namespace plugin_common_curl {
+
+struct ResponseInfo {
+  long http_code = 0;
+  double total_time = 0.0;
+  double download_size = 0.0;
+  double upload_size = 0.0;
+  long redirect_count = 0;
+  std::string effective_url;
+  std::string content_type;
+  std::map<std::string, std::string> headers;
+};
 
 class CurlClient {
  public:
@@ -79,6 +91,83 @@ class CurlClient {
   [[nodiscard]] CURLcode GetCode() const { return mCode; }
 
   /**
+   * @brief Function to return HTTP response code
+   * @return long
+   * @retval the HTTP response code (200, 404, 500, etc.)
+   * @relation
+   * google_sign_in
+   */
+  [[nodiscard]] long GetHttpCode() const { return mResponseInfo.http_code; }
+
+  /**
+   * @brief Function to return complete response information
+   * @return const ResponseInfo&
+   * @retval detailed response information including timing, sizes, etc.
+   * @relation
+   * google_sign_in
+   */
+  [[nodiscard]] const ResponseInfo& GetResponseInfo() const {
+    return mResponseInfo;
+  }
+
+  /**
+   * @brief Function to check if request was successful
+   * @return bool
+   * @retval true if CURL operation succeeded AND HTTP code indicates success
+   * @relation
+   * google_sign_in
+   */
+  [[nodiscard]] bool IsSuccess() const {
+    return mCode == CURLE_OK && mResponseInfo.http_code >= 200 &&
+           mResponseInfo.http_code < 300;
+  }
+  /**
+   * @brief Function to check if request had client error (4xx)
+   * @return bool
+   * @retval true if HTTP code is 4xx
+   * @relation
+   * google_sign_in
+   */
+  [[nodiscard]] bool IsClientError() const {
+    return mResponseInfo.http_code >= 400 && mResponseInfo.http_code < 500;
+  }
+
+  /**
+   * @brief Function to check if request had server error (5xx)
+   * @return bool
+   * @retval true if HTTP code is 5xx
+   * @relation
+   * google_sign_in
+   */
+  [[nodiscard]] bool IsServerError() const {
+    return mResponseInfo.http_code >= 500 && mResponseInfo.http_code < 600;
+  }
+
+  /**
+   * @brief Set request timeout in seconds
+   * @param timeout_seconds Timeout in seconds
+   * @relation
+   * google_sign_in
+   */
+  void SetTimeout(long timeout_seconds);
+
+  /**
+   * @brief Set connection timeout in seconds
+   * @param timeout_seconds Connection timeout in seconds
+   * @relation
+   * google_sign_in
+   */
+  void SetConnectionTimeout(long timeout_seconds);
+
+  /**
+   * @brief Set maximum number of redirects to follow
+   * @param max_redirects Maximum redirects (-1 for unlimited)
+   * @relation
+   * google_sign_in
+   */
+  void SetMaxRedirects(long max_redirects);
+
+  /**
    * @brief Function sets the bearer token for the OAuth 2.0 authentication.
    * @param token The authentication token.
    * @relation
@@ -107,6 +196,26 @@ class CurlClient {
       const std::vector<std::pair<std::string, std::string>>& form_data,
       const std::vector<std::string>& additional_headers = {});
 
+  /**
+   * @brief Performs an HTTP PUT request
+   * @param url The URL to put to
+   * @param data Data to put
+   * @param additional_headers A vector of additional headers to send
+   * @return std::string The response body
+   */
+  std::string Put(const std::string& url,
+                  const std::string& data,
+                  const std::vector<std::string>& additional_headers = {});
+
+  /**
+   * @brief Performs an HTTP DELETE request
+   * @param url The URL to delete
+   * @param additional_headers A vector of additional headers to send
+   * @return std::string The response body
+   */
+  std::string Delete(const std::string& url,
+                     const std::vector<std::string>& additional_headers = {});
+
   // Prevent copying.
   CurlClient(CurlClient const&) = delete;
   CurlClient& operator=(CurlClient const&) = delete;
@@ -121,6 +230,12 @@ class CurlClient {
   std::unique_ptr<char[]> mErrorBuffer;
   std::string mStringBuffer;
   std::vector<uint8_t> mVectorBuffer;
+  ResponseInfo mResponseInfo;
+  std::string mHeaderBuffer;
+
+  long mTimeout{30};
+  long mConnectionTimeout{10};
+  long mMaxRedirects{5};
 
   /**
    * @brief Callback function for curl client
@@ -153,6 +268,39 @@ class CurlClient {
                           size_t size,
                           size_t num_mem_block,
                           std::vector<uint8_t>* writerData);
+
+  /**
+   * @brief Callback function for curl client header content
+   */
+  static size_t HeaderWriter(char* data,
+                             size_t size,
+                             size_t num_mem_block,
+                             std::string* writerData);
+
+  /**
+   * @brief Internal function to setup common curl options
+   */
+  bool SetupCommonOptions(bool verbose);
+
+  /**
+   * @brief Internal function to extract response information after request
+   */
+  void ExtractResponseInfo();
+
+  /**
+   * @brief Internal function to parse response headers
+   */
+  void ParseHeaders();
+
+  /**
+   * @brief Internal function to reset buffers and state
+   */
+  void ResetState();
+
+  /**
+   * @brief Internal function to perform the actual HTTP request
+   */
+  bool PerformRequest(bool verbose);
 };
 }  // namespace plugin_common_curl
 

--- a/plugins/common/curl_client/test/CMakeLists.txt
+++ b/plugins/common/curl_client/test/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.10)
+project(CurlClientTest CXX)
+
+set(TESTCASE_NAME "CurlClientTest")
+set(TESTCASE_CC test_curl_client.cc)
+set(CURL_CLIENT_CC ../curl_client.cc)
+
+add_executable(
+    ${TESTCASE_NAME}
+    ${TESTCASE_CC}
+    ${CURL_CLIENT_CC}
+)
+
+find_package(Threads REQUIRED)
+find_package(CURL REQUIRED)
+find_package(spdlog REQUIRED)
+find_package(fmt REQUIRED)
+find_package(GTest REQUIRED)
+
+target_compile_features(${TESTCASE_NAME} PRIVATE cxx_std_17)
+
+target_include_directories(
+    ${TESTCASE_NAME}
+    PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+)
+
+target_link_libraries(
+    ${TESTCASE_NAME}
+    PRIVATE
+    CURL::libcurl
+    spdlog::spdlog
+    fmt::fmt
+    Threads::Threads
+    GTest::gtest
+    GTest::gtest_main
+)
+
+add_test(
+    NAME ${TESTCASE_NAME}
+    COMMAND ${TESTCASE_NAME}
+)

--- a/plugins/common/curl_client/test/test_curl_client.cc
+++ b/plugins/common/curl_client/test/test_curl_client.cc
@@ -1,0 +1,379 @@
+#include <curl/curl.h>
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <fstream>
+#include <future>
+#include <memory>
+#include <random>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include "gtest/gtest.h"
+
+#include "../curl_client.h"
+
+using namespace plugin_common_curl;
+using namespace testing;
+
+class CurlClientTest : public Test {
+ protected:
+  void SetUp() override {
+    curl_global_init(CURL_GLOBAL_DEFAULT);
+
+    valid_url = "https://httpbin.org/get";
+    post_url = "https://httpbin.org/post";
+    put_url = "https://httpbin.org/put";
+    delete_url = "https://httpbin.org/delete";
+    redirect_url = "https://httpbin.org/redirect/3";
+    timeout_url = "https://httpbin.org/delay/5";
+    invalid_url = "https://nonexistent-domain-12345.com";
+    large_data_url = "https://httpbin.org/bytes/102400";  // 100KB
+    auth_url = "https://httpbin.org/bearer";
+    headers_url = "https://httpbin.org/headers";
+    status_404_url = "https://httpbin.org/status/404";
+    status_500_url = "https://httpbin.org/status/500";
+  }
+
+  void TearDown() override { curl_global_cleanup(); }
+
+  std::string valid_url;
+  std::string post_url;
+  std::string put_url;
+  std::string delete_url;
+  std::string redirect_url;
+  std::string timeout_url;
+  std::string invalid_url;
+  std::string large_data_url;
+  std::string auth_url;
+  std::string headers_url;
+  std::string status_404_url;
+  std::string status_500_url;
+
+  std::string GenerateRandomString(size_t length) {
+    const std::string charset =
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<> dis(0, charset.size() - 1);
+
+    std::string result;
+    result.reserve(length);
+    for (size_t i = 0; i < length; ++i) {
+      result += charset[dis(gen)];
+    }
+    return result;
+  }
+
+  std::vector<std::pair<std::string, std::string>> GenerateFormData(
+      size_t count) {
+    std::vector<std::pair<std::string, std::string>> form_data;
+    for (size_t i = 0; i < count; ++i) {
+      form_data.emplace_back("key" + std::to_string(i),
+                             GenerateRandomString(50));
+    }
+    return form_data;
+  }
+};
+
+TEST_F(CurlClientTest, BasicGETRequest) {
+  CurlClient client;
+
+  ASSERT_TRUE(client.Init(valid_url, {}, {}, true));
+
+  std::string response = client.RetrieveContentAsString();
+
+  EXPECT_EQ(client.GetCode(), CURLE_OK);
+  EXPECT_EQ(client.GetHttpCode(), 200);
+  EXPECT_TRUE(client.IsSuccess());
+  EXPECT_FALSE(client.IsClientError());
+  EXPECT_FALSE(client.IsServerError());
+  EXPECT_FALSE(response.empty());
+}
+
+TEST_F(CurlClientTest, BasicPOSTRequest) {
+  CurlClient client;
+
+  auto form_data = GenerateFormData(5);
+  std::string response = client.Post(post_url, form_data);
+
+  EXPECT_EQ(client.GetCode(), CURLE_OK);
+  EXPECT_EQ(client.GetHttpCode(), 200);
+  EXPECT_TRUE(client.IsSuccess());
+  EXPECT_FALSE(response.empty());
+}
+
+TEST_F(CurlClientTest, BasicPUTRequest) {
+  CurlClient client;
+
+  auto test_data = GenerateRandomString(1000);
+  std::string response = client.Put(put_url, test_data);
+
+  EXPECT_EQ(client.GetCode(), CURLE_OK);
+  EXPECT_EQ(client.GetHttpCode(), 200);
+  EXPECT_TRUE(client.IsSuccess());
+  EXPECT_FALSE(response.empty());
+}
+
+TEST_F(CurlClientTest, BasicDELETERequest) {
+  CurlClient client;
+
+  std::string response = client.Delete(delete_url);
+
+  EXPECT_EQ(client.GetCode(), CURLE_OK);
+  EXPECT_EQ(client.GetHttpCode(), 200);
+  EXPECT_TRUE(client.IsSuccess());
+  EXPECT_FALSE(response.empty());
+}
+
+TEST_F(CurlClientTest, VectorResponse) {
+  CurlClient client;
+
+  ASSERT_TRUE(client.Init(valid_url, {}, {}, true));
+
+  const auto& response = client.RetrieveContentAsVector();
+
+  EXPECT_EQ(client.GetCode(), CURLE_OK);
+  EXPECT_EQ(client.GetHttpCode(), 200);
+  EXPECT_TRUE(client.IsSuccess());
+  EXPECT_FALSE(response.empty());
+}
+
+TEST_F(CurlClientTest, CustomHeaders) {
+  CurlClient client;
+
+  std::vector<std::string> headers = {"X-Custom-Header: test-value",
+                                      "Content-Type: application/json",
+                                      "User-Agent: CurlClient-Test/1.0"};
+  std::string response = client.Get(headers_url, headers);
+
+  EXPECT_EQ(client.GetCode(), CURLE_OK);
+  EXPECT_EQ(client.GetHttpCode(), 200);
+  EXPECT_TRUE(client.IsSuccess());
+  EXPECT_FALSE(response.empty());
+  EXPECT_TRUE(response.find("X-Custom-Header") != std::string::npos);
+}
+
+TEST_F(CurlClientTest, BearerTokenAuth) {
+  CurlClient client;
+
+  client.SetBearerToken("test-token-12345");
+  std::string response = client.Get(auth_url);
+
+  EXPECT_EQ(client.GetCode(), CURLE_OK);
+  EXPECT_EQ(client.GetHttpCode(), 200);
+  EXPECT_TRUE(client.IsSuccess());
+  EXPECT_FALSE(response.empty());
+}
+
+TEST_F(CurlClientTest, FollowRedirects) {
+  CurlClient client;
+
+  ASSERT_TRUE(client.Init(redirect_url, {}, {}, true));
+  std::string response = client.RetrieveContentAsString();
+
+  EXPECT_EQ(client.GetCode(), CURLE_OK);
+  EXPECT_EQ(client.GetHttpCode(), 200);
+  EXPECT_TRUE(client.IsSuccess());
+
+  const auto& response_info = client.GetResponseInfo();
+  EXPECT_GT(response_info.redirect_count, 0);
+}
+
+TEST_F(CurlClientTest, NoFollowRedirects) {
+  CurlClient client;
+
+  ASSERT_TRUE(client.Init(redirect_url, {}, {}, false));
+  std::string response = client.RetrieveContentAsString();
+
+  EXPECT_EQ(client.GetCode(), CURLE_OK);
+  EXPECT_EQ(client.GetHttpCode(), 302);  // redirect
+  EXPECT_FALSE(client.IsSuccess());
+}
+
+TEST_F(CurlClientTest, TimeoutTest) {
+  CurlClient client;
+  client.SetTimeout(2);
+
+  ASSERT_TRUE(client.Init(timeout_url, {}, {}, true));
+  auto start_time = std::chrono::steady_clock::now();
+  std::string response = client.RetrieveContentAsString();
+  auto end_time = std::chrono::steady_clock::now();
+
+  auto duration =
+      std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time);
+  EXPECT_NE(client.GetCode(), CURLE_OK);
+  EXPECT_FALSE(client.IsSuccess());
+  EXPECT_LE(duration.count(), 3);  // timeout within 3 seconds
+}
+
+TEST_F(CurlClientTest, ConnectionTimeoutTest) {
+  CurlClient client;
+  client.SetTimeout(1);
+
+  ASSERT_TRUE(client.Init(invalid_url, {}, {}, true));
+  auto start_time = std::chrono::steady_clock::now();
+  std::string response = client.RetrieveContentAsString();
+  auto end_time = std::chrono::steady_clock::now();
+
+  auto duration =
+      std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time);
+  EXPECT_NE(client.GetCode(), CURLE_OK);
+  EXPECT_FALSE(client.IsSuccess());
+  EXPECT_LE(duration.count(), 5);  // timeout within 5 seconds
+}
+
+TEST_F(CurlClientTest, InvalidURL) {
+  CurlClient client;
+
+  ASSERT_TRUE(client.Init(invalid_url, {}, {}, true));
+
+  std::string response = client.RetrieveContentAsString();
+
+  EXPECT_NE(client.GetCode(), CURLE_OK);
+  EXPECT_FALSE(client.IsSuccess());
+}
+
+TEST_F(CurlClientTest, ClientError404) {
+  CurlClient client;
+
+  std::string response = client.Get(status_404_url);
+
+  EXPECT_EQ(client.GetCode(), CURLE_OK);
+  EXPECT_FALSE(client.IsSuccess());
+  EXPECT_EQ(client.GetHttpCode(), 404);
+  EXPECT_TRUE(client.IsClientError());
+  EXPECT_FALSE(client.IsServerError());
+}
+
+TEST_F(CurlClientTest, ServerError500) {
+  CurlClient client;
+
+  std::string response = client.Get(status_500_url);
+
+  EXPECT_EQ(client.GetCode(), CURLE_OK);
+  EXPECT_FALSE(client.IsSuccess());
+  EXPECT_EQ(client.GetHttpCode(), 500);
+  EXPECT_FALSE(client.IsClientError());
+  EXPECT_TRUE(client.IsServerError());
+}
+
+TEST_F(CurlClientTest, LargeDataDownload) {
+  CurlClient client;
+
+  ASSERT_TRUE(client.Init(large_data_url, {}, {}, true));
+
+  const auto& response = client.RetrieveContentAsVector();
+
+  EXPECT_EQ(client.GetCode(), CURLE_OK);
+  EXPECT_EQ(client.GetHttpCode(), 200);
+  EXPECT_TRUE(client.IsSuccess());
+  EXPECT_GE(response.size(), 100000);  // At least 100KB
+
+  const auto& response_info = client.GetResponseInfo();
+  EXPECT_GT(response_info.download_size, 0);
+  EXPECT_GT(response_info.total_time, 0);
+  EXPECT_FALSE(response_info.effective_url.empty());
+}
+
+TEST_F(CurlClientTest, LargeFormDataPost) {
+  CurlClient client;
+  auto large_form_data = GenerateFormData(100);  // 100 fields
+
+  std::string response = client.Post(post_url, large_form_data);
+
+  EXPECT_EQ(client.GetCode(), CURLE_OK);
+  EXPECT_EQ(client.GetHttpCode(), 200);
+  EXPECT_TRUE(client.IsSuccess());
+  EXPECT_FALSE(response.empty());
+}
+
+TEST_F(CurlClientTest, ResponseInfoTest) {
+  CurlClient client;
+
+  ASSERT_TRUE(client.Init(valid_url, {}, {}, true));
+
+  std::string response = client.RetrieveContentAsString();
+
+  EXPECT_EQ(client.GetCode(), CURLE_OK);
+  EXPECT_EQ(client.GetHttpCode(), 200);
+  EXPECT_FALSE(response.empty());
+
+  const auto& response_info = client.GetResponseInfo();
+  EXPECT_EQ(response_info.http_code, 200);
+  EXPECT_GT(response_info.total_time, 0);
+  EXPECT_GT(response_info.download_size, 0);
+  EXPECT_FALSE(response_info.effective_url.empty());
+}
+
+TEST_F(CurlClientTest, ConcurrentRequests) {
+  const int num_threads = 10;
+  std::vector<std::future<bool>> futures;
+  std::atomic<int> success_count{0};
+
+  for (int i = 0; i < num_threads; ++i) {
+    futures.push_back(std::async(std::launch::async, [&, i]() {
+      CurlClient client;
+
+      std::string url = valid_url + "?thread=" + std::to_string(i);
+      std::string response = client.Get(url);
+
+      if (client.IsSuccess()) {
+        success_count++;
+        return true;
+      }
+      return false;
+    }));
+  }
+
+  for (auto& future : futures) {
+    future.wait();
+  }
+
+  EXPECT_EQ(success_count.load(), num_threads);
+}
+
+TEST_F(CurlClientTest, MemoryLeakTest) {
+  // Create and destroy many clients
+  for (int i = 0; i < 100; ++i) {
+    auto client = std::make_unique<CurlClient>();
+    ASSERT_TRUE(client->Init(valid_url, {}, {}, true));
+    std::string response = client->RetrieveContentAsString();
+    EXPECT_TRUE(client->IsSuccess());
+  }
+
+  SUCCEED();
+}
+
+TEST_F(CurlClientTest, StressTestAllMethods) {
+  const int iterations = 20;
+
+  for (int i = 0; i < iterations; ++i) {
+    CurlClient client;
+
+    // GET
+    std::string get_response = client.Get(valid_url);
+    EXPECT_TRUE(client.IsSuccess());
+
+    // POST
+    auto form_data = GenerateFormData(5);
+    std::string post_response = client.Post(post_url, form_data);
+    EXPECT_TRUE(client.IsSuccess());
+
+    // PUT
+    std::string put_data = GenerateRandomString(100);
+    std::string put_response = client.Put(put_url, put_data);
+    EXPECT_TRUE(client.IsSuccess());
+
+    // DELETE
+    std::string delete_response = client.Delete(delete_url);
+    EXPECT_TRUE(client.IsSuccess());
+  }
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/plugins/flatpak/cache/cache_config.h
+++ b/plugins/flatpak/cache/cache_config.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020-2024 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLUGINS_FLATPAK_CACHE_CACHE_CONFIG_H
+#define PLUGINS_FLATPAK_CACHE_CACHE_CONFIG_H
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <string>
+
+namespace flatpak_plugin {
+
+/**
+ * @enum CachePolicy
+ * @brief Enumerates cache access strategies.
+ * - CACHE_FIRST: Prefer cache, fallback to network if not found.
+ * - NETWORK_FIRST: Prefer network, fallback to cache if network fails.
+ * - CACHE_ONLY: Use cache exclusively.
+ * - NETWORK_ONLY: Use network exclusively.
+ */
+enum class CachePolicy { CACHE_FIRST, NETWORK_FIRST, CACHE_ONLY, NETWORK_ONLY };
+
+/**
+ * @struct CacheConfig
+ * @brief Configuration options for cache management.
+ * @var db_path Path to the cache database (default: in-memory).
+ * @var default_ttl Default time-to-live for cached entries (in seconds).
+ * @var policy Cache access strategy.
+ * @var enable_compression Enable compression for cached data.
+ * @var max_cache_size_mb Maximum cache size in megabytes.
+ * @var network_timeout Network operation timeout (in seconds).
+ * @var max_retries Maximum number of network retries.
+ * @var enable_auto_cleanup Enable automatic cache cleanup.
+ * @var cleanup_interval Interval for automatic cleanup (in minutes).
+ * @var enable_metrics Enable cache metrics collection.
+ */
+struct CacheConfig {
+  std::string db_path = ":memory:";
+  std::chrono::seconds default_ttl{3600};
+  CachePolicy policy = CachePolicy::CACHE_FIRST;
+  bool enable_compression = false;
+  size_t max_cache_size_mb = 100;
+  std::chrono::seconds network_timeout{30};
+  int max_retries = 3;
+  bool enable_auto_cleanup = true;
+  std::chrono::minutes cleanup_interval{60};
+  bool enable_metrics = true;
+};
+
+/**
+ * @struct CacheMetrics
+ * @brief Stores cache performance metrics and statistics.
+ *
+ * This structure tracks various metrics related to cache usage, including
+ * hit/miss counts, network calls, cache size, expired entries, and network
+ * errors. All counters are atomic for thread-safe updates. It also records the
+ * cache start time for uptime calculation.
+ */
+struct CacheMetrics {
+  std::atomic<uint64_t> hits{0};
+  std::atomic<uint64_t> misses{0};
+  std::atomic<uint64_t> network_calls{0};
+  std::atomic<uint64_t> cache_size_bytes{0};
+  std::atomic<uint64_t> expired_entries{0};
+  std::atomic<uint64_t> network_errors{0};
+
+  std::chrono::system_clock::time_point start_time{std::chrono::system_clock::now()};
+
+  // Explicitly delete copy operations - force move/reference usage
+  CacheMetrics(const CacheMetrics&) = delete;
+  CacheMetrics& operator=(const CacheMetrics&) = delete;
+
+  [[nodiscard]] double GetHitRatio() const {
+    auto total = hits.load() + misses.load();
+    return total > 0 ? (static_cast<double>(hits.load()) * 100.0) / total : 0.0;
+  }
+
+  [[nodiscard]] std::chrono::seconds GetUptime() const {
+    return std::chrono::duration_cast<std::chrono::seconds>(
+        std::chrono::system_clock::now() - start_time);
+  }
+};
+
+}
+#endif  // PLUGINS_FLATPAK_CACHE_CACHE_CONFIG_H

--- a/plugins/flatpak/cache/cache_config.h
+++ b/plugins/flatpak/cache/cache_config.h
@@ -78,7 +78,8 @@ struct CacheMetrics {
   std::atomic<uint64_t> expired_entries{0};
   std::atomic<uint64_t> network_errors{0};
 
-  std::chrono::system_clock::time_point start_time{std::chrono::system_clock::now()};
+  std::chrono::system_clock::time_point start_time{
+      std::chrono::system_clock::now()};
 
   // Explicitly delete copy operations - force move/reference usage
   CacheMetrics(const CacheMetrics&) = delete;
@@ -95,5 +96,5 @@ struct CacheMetrics {
   }
 };
 
-}
+}  // namespace flatpak_plugin
 #endif  // PLUGINS_FLATPAK_CACHE_CACHE_CONFIG_H

--- a/plugins/flatpak/cache/cache_manager.cc
+++ b/plugins/flatpak/cache/cache_manager.cc
@@ -1,0 +1,405 @@
+#include "cache_manager.h"
+#include <spdlog/spdlog.h>
+#include <chrono>
+#include <exception>
+#include <fstream>
+#include <ios>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <sstream>
+#include <thread>
+#include "cache_config.h"
+#include "interfaces/cache_observer.h"
+#include "interfaces/cache_storage.h"
+#include "network/curl_network_fetcher.h"
+#include "storage/sqlite_cache_storage.h"
+
+flatpak_plugin::CacheManager::CacheManager(const CacheConfig& config)
+    : config_(std::move(config)), metrics_{} {}
+
+flatpak_plugin::CacheManager::~CacheManager() {
+  stop_cleanup_.store(true);
+  cleanup_cv_.notify_all();
+  if (cleanup_thread_.joinable()) {
+    cleanup_thread_.join();
+  }
+}
+
+bool flatpak_plugin::CacheManager::Initialize() {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+  spdlog::info(
+      "Initializing CacheManager with config: db_path={}, ttl={}, policy={}, "
+      "max_size={}",
+      config_.db_path, config_.default_ttl.count(),
+      static_cast<int>(config_.policy), config_.max_cache_size_mb);
+
+  storage_ = std::make_unique<SQLiteCacheStorage>(config_.db_path,
+                                                  config_.enable_compression);
+  if (!storage_->Initialize()) {
+    spdlog::error("Failed to initialize cache storage");
+    return false;
+  }
+
+  network_fetcher_ = std::make_unique<CurlNetworkFetcher>(
+      config_.network_timeout, config_.max_retries);
+
+  if (config_.enable_metrics) {
+    metrics_.hits = 0;
+    metrics_.misses = 0;
+    metrics_.cache_size_bytes = 0;
+    metrics_.network_calls = 0;
+    metrics_.network_errors = 0;
+    metrics_.start_time = std::chrono::system_clock::now();
+  }
+
+  if (config_.enable_auto_cleanup) {
+    cleanup_thread_ = std::thread(&CacheManager::CleanupWorker, this);
+  }
+
+  spdlog::info("Cache Manager initialized successfully");
+  return true;
+}
+
+void flatpak_plugin::CacheManager::AddObserver(
+    std::unique_ptr<ICacheObserver> observer) {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+  observers_.push_back(std::move(observer));
+}
+
+void flatpak_plugin::CacheManager::SetBearerToken(const std::string& token) {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+  if (network_fetcher_) {
+    network_fetcher_->SetBearerToken(token);
+  }
+}
+
+std::string flatpak_plugin::CacheManager::GenerateKey(
+    const std::string& base_key,
+    const std::vector<std::string>& params) {
+  std::ostringstream oss;
+  oss << base_key;
+  for (const auto& param : params) {
+    oss << ":" << param;
+  }
+  return oss.str();
+}
+
+void flatpak_plugin::CacheManager::NotifyObservers(
+    const std::function<void(ICacheObserver*)>& notification) {
+  for (const auto& observer : observers_) {
+    if (observer) {
+      notification(observer.get());
+    }
+  }
+}
+
+void flatpak_plugin::CacheManager::CleanupWorker() {
+  std::unique_lock<std::mutex> lock(cleanup_mutex_);
+  spdlog::info("Cleanup thread started, interval={} minutes",
+               config_.cleanup_interval.count());
+
+  while (!stop_cleanup_.load()) {
+    cleanup_cv_.wait_for(lock, config_.cleanup_interval,
+                         [this] { return stop_cleanup_.load(); });
+
+    if (stop_cleanup_.load()) {
+      break;
+    }
+
+    try {
+      size_t cleaned = storage_->CleanupExpired();
+      if (cleaned > 0) {
+        spdlog::info("Cleaned up {} expired cache entries", cleaned);
+        NotifyObservers([cleaned](ICacheObserver* observer) {
+          observer->OnCacheCleanup(cleaned);
+        });
+      }
+    } catch (const std::exception& e) {
+      spdlog::error("Error during cache cleanup: {}", e.what());
+    }
+  }
+}
+
+template <typename T>
+std::optional<T> flatpak_plugin::CacheManager::PerformCacheOperation(
+    const std::string& key,
+    std::function<std::optional<T>()> network_operation,
+    CacheOperationTemplate<T>* cache_operation) {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+
+  bool use_cache = (config_.policy == CachePolicy::CACHE_FIRST ||
+                    config_.policy == CachePolicy::CACHE_ONLY);
+
+  bool use_network = (config_.policy == CachePolicy::NETWORK_FIRST ||
+                      config_.policy == CachePolicy::NETWORK_ONLY);
+
+  std::optional<T> result;
+  // try cache first
+  if (use_cache) {
+    auto cached_data = storage_->Retrieve(key);
+    if (cached_data.has_value()) {
+      result = cache_operation->DeserializeData(cached_data.value());
+      if (result.has_value()) {
+        if (config_.enable_metrics) {
+          metrics_.hits++;
+        }
+        NotifyObservers(
+            [key, data_size = cached_data->size()](ICacheObserver* observer) {
+              observer->OnCacheHit(key, data_size);
+            });
+        return result;
+      }
+    }
+    if (config_.enable_metrics) {
+      metrics_.misses++;
+    }
+    NotifyObservers(
+        [&key](ICacheObserver* observer) { observer->OnCacheMiss(key); });
+  }
+
+  // try network
+
+  if (use_network && network_operation) {
+    try {
+      if (config_.enable_metrics) {
+        metrics_.network_calls++;
+      }
+
+      result = network_operation();
+      if (result.has_value()) {
+        if (config_.policy != CachePolicy::NETWORK_ONLY) {
+          auto serialized = cache_operation->SerializeData(result.has_value());
+          auto expiry = std::chrono::system_clock::now() + config_.default_ttl;
+          storage_->Store(key, serialized, expiry);
+        }
+
+        NotifyObservers([&key](ICacheObserver* observer) {
+          observer->OnNetworkFallback("Data fetched from network");
+        });
+      }
+    } catch (const std::exception& e) {
+      if (config_.enable_metrics) {
+        metrics_.network_errors++;
+      }
+
+      spdlog::error("Network operation failed for key{}: {}", key, e.what());
+      NotifyObservers([&key, error_code = -1](ICacheObserver* observer) {
+        observer->OnNetworkError(key, error_code);
+      });
+    }
+  }
+
+  return result;
+}
+
+std::optional<flutter::EncodableList>
+flatpak_plugin::CacheManager::GetApplicationsInstalled(bool force_refresh) {
+  std::string key = GenerateKey("applications_installed");
+
+  if (force_refresh) {
+    InvalidateKey(key);
+  }
+
+  auto network_ops = [this]() -> std::optional<flutter::EncodableList> {
+    // some flatpak API work , TODO on PR#3 in "[Feature] Add Flatpak remote
+    // management and installation support"
+    return std::nullopt;
+  };
+
+  // Create cache operation template for EncodableList
+  // some flatpak API work , TODO on PR#3 in "[Feature] Add Flatpak remote
+  // management and installation support"
+
+  return std::nullopt;
+}
+
+std::optional<flutter::EncodableList>
+flatpak_plugin::CacheManager::GetApplicationsRemote(
+    const std::string& remote_id,
+    bool force_refresh) {
+  std::string key = GenerateKey("applications_installed", {remote_id});
+
+  if (force_refresh) {
+    InvalidateKey(key);
+  }
+
+  auto network_ops = [this,
+                      remote_id]() -> std::optional<flutter::EncodableList> {
+    // Implementation would fetch from remote Flatpak repository , TODO on PR#3
+    // in "[Feature] Add Flatpak remote management and installation support"
+    return std::nullopt;
+  };
+
+  return std::nullopt;
+}
+
+std::optional<Installation> flatpak_plugin::CacheManager::GetUserInstallation(
+    bool force_refresh) {
+  std::string key = GenerateKey("user_installation");
+
+  if (force_refresh) {
+    InvalidateKey(key);
+  }
+
+  auto network_ops = [this]() -> std::optional<Installation> {
+    // Implementation would get user installation info , TODO on PR#3 in
+    // "[Feature] Add Flatpak remote management and installation support"
+    return std::nullopt;
+  };
+
+  return std::nullopt;
+}
+
+std::optional<flutter::EncodableList>
+flatpak_plugin::CacheManager::GetSystemInstallations(bool force_refresh) {
+  std::string key = GenerateKey("system_installations");
+
+  if (force_refresh) {
+    InvalidateKey(key);
+  }
+
+  auto network_ops = [this]() -> std::optional<flutter::EncodableList> {
+    // Implementation would get system installations, TODO on PR#3 in "[Feature]
+    // Add Flatpak remote management and installation support"
+    return std::nullopt;
+  };
+
+  return std::nullopt;
+}
+
+std::optional<flutter::EncodableList> flatpak_plugin::CacheManager::GetRemotes(
+    const std::string& installation_id,
+    bool force_refresh) {
+  std::string key = GenerateKey("remotes", {installation_id});
+
+  if (force_refresh) {
+    InvalidateKey(key);
+  }
+
+  auto network_ops =
+      [this, installation_id]() -> std::optional<flutter::EncodableList> {
+    // Implementation would get system installations, TODO on PR#3 in "[Feature]
+    // Add Flatpak remote management and installation support"
+    return std::nullopt;
+  };
+
+  return std::nullopt;
+}
+
+void flatpak_plugin::CacheManager::InvalidateAll() {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+  if (storage_) {
+    storage_->Invalidate();
+    NotifyObservers([](ICacheObserver* observer) {
+      spdlog::info("All cache entries invalidated");
+    });
+  }
+}
+
+void flatpak_plugin::CacheManager::InvalidateKey(const std::string& key) {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+  storage_->Invalidate(key);
+  std::ostringstream oss;
+  oss << std::this_thread::get_id();
+  spdlog::info("Invalidated cache key: '{}', thread={}", key, oss.str());
+  NotifyObservers(
+      [&key](ICacheObserver* observer) { observer->OnCacheExpired(key); });
+}
+
+bool flatpak_plugin::CacheManager::IsHealthy() const {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+  if (!storage_) {
+    return false;
+  }
+
+  // check network
+  if (network_fetcher_ && !network_fetcher_->IsNetworkAvailable()) {
+    spdlog::warn("Network not available");
+  }
+
+  // check cache size
+  size_t current_size = storage_->GetCacheSize();
+  if (current_size > config_.max_cache_size_mb * 1024 * 1024) {
+    spdlog::warn("Cache size {} exceeds limit {}", current_size,
+                 config_.max_cache_size_mb * 1024 * 1024);
+  }
+
+  return true;
+}
+
+size_t flatpak_plugin::CacheManager::GetCacheSize() const {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+  return storage_ ? storage_->GetCacheSize() : 0;
+}
+
+void flatpak_plugin::CacheManager::SetCachePolicy(CachePolicy policy) {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+  config_.policy = policy;
+  spdlog::info("Cache policy changed to {}", static_cast<int>(policy));
+}
+
+flatpak_plugin::CachePolicy flatpak_plugin::CacheManager::GetCachePolicy()
+    const {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+  return config_.policy;
+}
+
+size_t flatpak_plugin::CacheManager::ForceCleanup() {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+
+  size_t cleaned = storage_->CleanupExpired();
+  NotifyObservers([cleaned](ICacheObserver* observer) {
+    observer->OnCacheCleanup(cleaned);
+  });
+
+  spdlog::info("Manual cleanup removed {} expired entries", cleaned);
+  return cleaned;
+}
+
+const flatpak_plugin::CacheConfig& flatpak_plugin::CacheManager::GetConfig()
+    const {
+  return config_;
+}
+
+bool flatpak_plugin::CacheManager::ExportCache(const std::string& filepath) {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+
+  try {
+    std::ofstream file(filepath, std::ios::binary);
+    if (!file.is_open()) {
+      spdlog::error("Failed to open export file: {}", filepath);
+      return false;
+    }
+    // could enhance this import logic ....
+
+    spdlog::info("Cache exported to {}", filepath);
+    return true;
+  } catch (const std::exception& e) {
+    spdlog::error("Failed to export cache: {}", e.what());
+    return false;
+  }
+}
+
+bool flatpak_plugin::CacheManager::ImportCache(const std::string& filepath) {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+
+  try {
+    std::ifstream file(filepath, std::ios::binary);
+    if (!file.is_open()) {
+      spdlog::error("Failed to open import file: {}", filepath);
+      return false;
+    }
+    // could enhance this import logic ....
+    return true;
+  } catch (const std::exception& e) {
+    spdlog::error("Failed to import cache: {}", e.what());
+    return false;
+  }
+}
+
+std::unique_ptr<flatpak_plugin::CacheManager>
+flatpak_plugin::CacheManager::Builder::Build() {
+  auto manager = std::make_unique<CacheManager>(config_);
+  return manager;
+}

--- a/plugins/flatpak/cache/cache_manager.h
+++ b/plugins/flatpak/cache/cache_manager.h
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2020-2024 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLUGINS_FLATPAK_CACHE_CACHE_MANAGER_H
+#define PLUGINS_FLATPAK_CACHE_CACHE_MANAGER_H
+
+#include <spdlog/spdlog.h>
+#include <sqlite3.h>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+#include "cache_config.h"
+#include "interfaces/cache_observer.h"
+#include "interfaces/cache_storage.h"
+#include "interfaces/network_fetcher.h"
+#include "operations/cache_operation_template.h"
+#include "../../common/curl_client/curl_client.h"
+
+namespace flutter {
+    using EncodableList = std::vector<int>; // Dummy type for testing
+}
+struct Installation {}; // Dummy struct for testing
+
+namespace flatpak_plugin {
+
+/**
+ * @class CacheManager
+ * @brief Manages caching operations for Flatpak-related data, including
+ * storage, fetching, and cleanup.
+ */
+class CacheManager {
+ private:
+  std::unique_ptr<ICacheStorage> storage_;
+  std::unique_ptr<INetworkFetcher> network_fetcher_;
+  std::vector<std::unique_ptr<ICacheObserver>> observers_;
+  CacheConfig config_;
+  mutable std::mutex cache_mutex_;
+
+  std::thread cleanup_thread_;
+  std::atomic<bool> stop_cleanup_{false};
+  std::condition_variable cleanup_cv_;
+  std::mutex cleanup_mutex_;
+  
+  mutable CacheMetrics metrics_;
+
+  std::string GenerateKey(const std::string& base_key,
+                          const std::vector<std::string>& params = {});
+
+  void NotifyObservers(
+      const std::function<void(ICacheObserver*)>& notification);
+
+  void CleanupWorker();
+
+  template <typename T>
+  std::optional<T> PerformCacheOperation(
+      const std::string& key,
+      std::function<std::optional<T>()> network_operation,
+      CacheOperationTemplate<T>* cache_operation);
+
+
+
+ public:
+  class Builder {
+   private:
+    CacheConfig config_;
+
+   public:
+    Builder& WithDatabasePath(const std::string& path) {
+      config_.db_path = path;
+      return *this;
+    }
+
+    Builder& WithDefaultTTL(std::chrono::seconds ttl) {
+      config_.default_ttl = ttl;
+      return *this;
+    }
+
+    Builder& WithCachePolicy(CachePolicy policy) {
+      config_.policy = policy;
+      return *this;
+    }
+
+    Builder& WithCompression(bool enable = true) {
+      config_.enable_compression = enable;
+      return *this;
+    }
+
+    Builder& WithMaxCacheSize(size_t size_mb) {
+      config_.max_cache_size_mb = size_mb;
+      return *this;
+    }
+
+    Builder& WithNetworkTimeout(std::chrono::seconds timeout) {
+      config_.network_timeout = timeout;
+      return *this;
+    }
+
+    Builder& WithMaxRetries(int retries) {
+      config_.max_retries = retries;
+      return *this;
+    }
+
+    Builder& WithAutoCleanup(
+        bool enable,
+        std::chrono::minutes interval = std::chrono::minutes(60)) {
+      config_.enable_auto_cleanup = enable;
+      config_.cleanup_interval = interval;
+      return *this;
+    }
+
+    Builder& WithMetrics(bool enable = true) {
+      config_.enable_metrics = enable;
+      return *this;
+    }
+
+    std::unique_ptr<CacheManager> Build();
+  };
+
+  explicit CacheManager(const CacheConfig& config);
+
+  ~CacheManager();
+
+  bool Initialize();
+
+  void AddObserver(std::unique_ptr<ICacheObserver> observer);
+
+  void SetBearerToken(const std::string& token);
+
+  // Flatpak-specific cache operations
+
+  /**
+   * @brief Retrieves the list of installed applications.
+   * @param force_refresh If true, forces a refresh of the installed
+   * applications cache. Defaults to false.
+   * @return std::optional<flutter::EncodableList> Optional list of installed
+   * applications.
+   */
+  std::optional<flutter::EncodableList> GetApplicationsInstalled(
+      bool force_refresh = false);
+
+  /**
+   * @brief Retrieves the list of applications from a specified remote source.
+   * @param remote_id The identifier of the remote source to query for
+   * applications.
+   * @param force_refresh If true, forces a refresh from the remote source
+   * instead of using cached data. Defaults to false.
+   * @return An optional EncodableList containing the applications retrieved
+   * from the remote. Returns std::nullopt if no applications are found or an
+   * error occurs.
+   */
+  std::optional<flutter::EncodableList> GetApplicationsRemote(
+      const std::string& remote_id,
+      bool force_refresh = false);
+
+  /**
+   * @brief Retrieves the user installation information.
+   * @param force_refresh If true, forces a refresh of the installation
+   * information. Defaults to false.
+   * @return std::optional<Installation> The user's installation information, or
+   * std::nullopt if not available.
+   */
+  std::optional<Installation> GetUserInstallation(bool force_refresh = false);
+
+  /**
+   * @brief Retrieves the list of system installations.
+   * @param force_refresh If true, forces a refresh of the cached installations.
+   * @return std::optional<flutter::EncodableList> An optional list of system
+   * installations. If no installations are found or an error occurs, the
+   * optional will be empty.
+   */
+  std::optional<flutter::EncodableList> GetSystemInstallations(
+      bool force_refresh = false);
+
+  /**
+   * @brief Retrieves the list of remotes for a given installation.
+   * @param installation_id The identifier of the installation to query remotes
+   * for.
+   * @param force_refresh If true, forces a refresh of the remotes from the
+   * source. Defaults to false.
+   * @return std::optional<flutter::EncodableList> An optional list of remotes.
+   * If no remotes are found or an error occurs, std::nullopt is returned.
+   */
+  std::optional<flutter::EncodableList> GetRemotes(
+      const std::string& installation_id,
+      bool force_refresh = false);
+
+  // Cache management operations
+
+  /**
+   * @brief Invalidate all cache entries
+   */
+  void InvalidateAll();
+
+  /**
+   * @brief Invalidate specific cache key
+   * @param key Cache key to invalidate
+   */
+  void InvalidateKey(const std::string& key);
+
+  /**
+   * @brief Check if cache is healthy
+   * @return true if cache is functioning properly
+   */
+  bool IsHealthy() const;
+
+  /**
+   * @brief Get current cache size
+   * @return Cache size in bytes
+   */
+  size_t GetCacheSize() const;
+
+  /**
+   * @brief Set cache policy
+   * @param policy New cache policy
+   */
+  void SetCachePolicy(CachePolicy policy);
+
+  /**
+   * @brief Get current cache policy
+   * @return Current cache policy
+   */
+  CachePolicy GetCachePolicy() const;
+
+  /**
+   * @brief Force cleanup of expired entries
+   * @return Number of entries cleaned
+   */
+  size_t ForceCleanup();
+
+  /**
+   * @brief Get cache metrics
+   * @return Current cache metrics
+   */
+  const CacheMetrics& GetMetrics() const { return metrics_; }
+
+  /**
+   * @brief Get cache configuration
+   * @return Current cache configuration
+   */
+  const CacheConfig& GetConfig() const;
+
+  /**
+   * @brief Export cache to file
+   * @param filepath Path to export file
+   * @return true if export successful
+   */
+  bool ExportCache(const std::string& filepath);
+
+  /**
+   * @brief Import cache from file
+   * @param filepath Path to import file
+   * @return true if import successful
+   */
+  bool ImportCache(const std::string& filepath);
+
+  CacheMetrics* GetMetricsPtr() { return &metrics_; }
+};
+
+}  // namespace flatpak_plugin
+
+#endif  // PLUGINS_FLATPAK_CACHE_CACHE_MANAGER_H

--- a/plugins/flatpak/cache/cache_manager.h
+++ b/plugins/flatpak/cache/cache_manager.h
@@ -30,17 +30,17 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include "../../common/curl_client/curl_client.h"
 #include "cache_config.h"
 #include "interfaces/cache_observer.h"
 #include "interfaces/cache_storage.h"
 #include "interfaces/network_fetcher.h"
 #include "operations/cache_operation_template.h"
-#include "../../common/curl_client/curl_client.h"
 
 namespace flutter {
-    using EncodableList = std::vector<int>; // Dummy type for testing
+using EncodableList = std::vector<int>;  // Dummy type for testing
 }
-struct Installation {}; // Dummy struct for testing
+struct Installation {};  // Dummy struct for testing
 
 namespace flatpak_plugin {
 
@@ -61,7 +61,7 @@ class CacheManager {
   std::atomic<bool> stop_cleanup_{false};
   std::condition_variable cleanup_cv_;
   std::mutex cleanup_mutex_;
-  
+
   mutable CacheMetrics metrics_;
 
   std::string GenerateKey(const std::string& base_key,
@@ -77,8 +77,6 @@ class CacheManager {
       const std::string& key,
       std::function<std::optional<T>()> network_operation,
       CacheOperationTemplate<T>* cache_operation);
-
-
 
  public:
   class Builder {

--- a/plugins/flatpak/cache/interfaces/cache_observer.h
+++ b/plugins/flatpak/cache/interfaces/cache_observer.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020-2024 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLUGINS_FLATPAK_CACHE_CACHE_OBSERVER_H
+#define PLUGINS_FLATPAK_CACHE_CACHE_OBSERVER_H
+
+#include <cstddef>
+#include <string>
+
+/**
+ * @brief Interface for observing cache operations and events.
+ *
+ * Provides hooks for monitoring cache operations, collecting metrics,
+ * and implementing custom behaviors on cache events.
+ */
+class ICacheObserver {
+ public:
+  virtual ~ICacheObserver() = default;
+
+  /**
+   * @brief Callback invoked when a cache hit occurs.
+   * @param key The cache key that was successfully found
+   * @param data_size The size in bytes of the cached data that was retrieved
+   */
+  virtual void OnCacheHit(const std::string& key, size_t data_size) = 0;
+
+  /**
+   * @brief Called when a cache lookup fails to find the requested key.
+   * @param key The cache key that was not found in the cache
+   */
+  virtual void OnCacheMiss(const std::string& key) = 0;
+
+  /**
+   * @brief Called when a cache entry has expired and needs to be removed or
+   * refreshed.
+   * @param key The unique identifier of the cache entry that has expired
+   */
+  virtual void OnCacheExpired(const std::string& key) = 0;
+
+  /**
+   * @brief Called when the system falls back to network operation due to cache
+   * failure
+   * @param reason A string describing the reason for the network fallback, such
+   * as cache miss, corruption, or other cache-related errors
+   */
+  virtual void OnNetworkFallback(const std::string& reason) = 0;
+
+  /**
+   * @brief Called when a network error occurs during cache operations
+   * @param url The URL that caused the network error
+   * @param error_code The specific error code indicating the type of network
+   * failure (e.g., HTTP status codes, connection timeouts, DNS resolution
+   * failures)
+   */
+  virtual void OnNetworkError(const std::string& url, long error_code) = 0;
+
+  /**
+   * @brief Called when cache cleanup operation completes
+   * @param entries_cleaned The number of cache entries that were successfully
+   *                       removed during the cleanup operation
+   */
+  virtual void OnCacheCleanup(size_t entries_cleaned) = 0;
+};
+
+#endif  // PLUGINS_FLATPAK_CACHE_CACHE_OBSERVER_H

--- a/plugins/flatpak/cache/interfaces/cache_storage.h
+++ b/plugins/flatpak/cache/interfaces/cache_storage.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020-2024 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLUGINS_FLATPAK_CACHE_CACHE_STORAGE_H
+#define PLUGINS_FLATPAK_CACHE_CACHE_STORAGE_H
+
+#include <chrono>
+#include <cstddef>
+#include <optional>
+#include <string>
+
+/**
+ * @brief Cache Storage Strategy interface
+ *
+ * Defines the contract for different cache storage implementations.
+ * Currently supports SQLite, but can be extended for Redis, file-based, etc.
+ */
+class ICacheStorage {
+public:
+  virtual ~ICacheStorage() = default;
+
+  /**
+   * @brief Stores data in the cache with an expiration time.
+   * @param key The unique identifier for the cached data
+   * @param data The data to be stored in the cache
+   * @param expiry The time point when the cached data should expire
+   * @return true if the data was successfully stored, false otherwise
+   */
+  virtual bool Store(const std::string& key,
+                     const std::string& data,
+                     std::chrono::system_clock::time_point expiry) = 0;
+
+  /**
+   * @brief Retrieves a value from the cache storage using the specified key.
+   * @param key The key string used to lookup the cached value
+   * @return std::optional<std::string> The cached value if found, std::nullopt
+   * otherwise
+   */
+  virtual std::optional<std::string> Retrieve(const std::string& key) = 0;
+
+  /**
+   * @brief Checks if a cache entry has expired based on its key.
+   * @param key The unique identifier of the cache entry to check for expiration
+   * @return true if the cache entry has expired or doesn't exist, false if
+   * still valid
+   */
+  virtual bool IsExpired(const std::string& key) = 0;
+
+  /**
+   * @brief Invalidates cached data entries.
+   * @param key The cache key to invalidate. If empty string (default),
+   *            all cache entries will be invalidated.
+   */
+  virtual void Invalidate(const std::string& key = "") = 0;
+
+  /**
+   * @brief Initializes the cache storage system.
+   * @return true if initialization was successful, false otherwise
+   */
+  virtual bool Initialize() = 0;
+
+  /**
+   * @brief Gets the current size of the cache.
+   * @return The cache size in bytes as a size_t value.
+   */
+  virtual size_t GetCacheSize() = 0;
+
+  /**
+   * @brief Removes all expired cache entries from storage
+   * @return The number of cache entries that were removed during cleanup
+   */
+  virtual size_t CleanupExpired() = 0;
+};
+
+#endif  // PLUGINS_FLATPAK_CACHE_CACHE_STORAGE_H

--- a/plugins/flatpak/cache/interfaces/cache_storage.h
+++ b/plugins/flatpak/cache/interfaces/cache_storage.h
@@ -29,7 +29,7 @@
  * Currently supports SQLite, but can be extended for Redis, file-based, etc.
  */
 class ICacheStorage {
-public:
+ public:
   virtual ~ICacheStorage() = default;
 
   /**

--- a/plugins/flatpak/cache/interfaces/network_fetcher.h
+++ b/plugins/flatpak/cache/interfaces/network_fetcher.h
@@ -30,7 +30,7 @@
  * (Curl, system network calls, mock for testing, etc.)
  */
 class INetworkFetcher {
-public:
+ public:
   virtual ~INetworkFetcher() = default;
 
   /**

--- a/plugins/flatpak/cache/interfaces/network_fetcher.h
+++ b/plugins/flatpak/cache/interfaces/network_fetcher.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020-2024 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLUGINS_FLATPAK_CACHE_NETWORK_FETCHER_H
+#define PLUGINS_FLATPAK_CACHE_NETWORK_FETCHER_H
+
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+#include "../../../common/curl_client/curl_client.h"
+
+/**
+ * @brief Network Fetcher Strategy interface
+ *
+ * Abstracts network operations to allow different implementations
+ * (Curl, system network calls, mock for testing, etc.)
+ */
+class INetworkFetcher {
+public:
+  virtual ~INetworkFetcher() = default;
+
+  /**
+   * @brief Performs an HTTP GET request to fetch data from a URL
+   *
+   * @param url The target URL to fetch data from
+   * @param headers Optional HTTP headers to include in the request
+   * @return std::optional<std::string> The response body if successful,
+   * std::nullopt if failed
+   */
+  virtual std::optional<std::string> Fetch(
+      const std::string& url,
+      const std::vector<std::string>& headers = {}) = 0;
+
+  /**
+   * @brief Performs an HTTP POST request with form data
+   *
+   * @param url The target URL to send the POST request to
+   * @param form_data Key-value pairs representing form data to be sent
+   * @param headers Optional HTTP headers to include in the request
+   * @return std::optional<std::string> The response body if successful,
+   * std::nullopt if failed
+   */
+  virtual std::optional<std::string> Post(
+      const std::string& url,
+      const std::vector<std::pair<std::string, std::string>>& form_data,
+      const std::vector<std::string>& headers = {}) = 0;
+
+  /**
+   * @brief Checks if network connectivity is available
+   *
+   * @return bool True if network is available, false otherwise
+   */
+  virtual bool IsNetworkAvailable() = 0;
+
+  /**
+   * @brief Retrieves the HTTP response code from the last network operation
+   *
+   * @return long The HTTP status code (e.g., 200, 404, 500) from the most
+   * recent request
+   */
+  virtual long GetLastResponseCode() = 0;
+
+  /**
+   * @brief Sets the bearer token for HTTP authentication.
+   * @param token The bearer token string to be used for authentication.
+   *              An empty string will clear any previously set token.
+   */
+  virtual void SetBearerToken(const std::string& token) = 0;
+};
+
+#endif  // PLUGINS_FLATPAK_CACHE_NETWORK_FETCHER_H

--- a/plugins/flatpak/cache/network/curl_network_fetcher.cc
+++ b/plugins/flatpak/cache/network/curl_network_fetcher.cc
@@ -1,0 +1,154 @@
+#include "curl_network_fetcher.h"
+#include <chrono>
+#include <cstddef>
+#include <exception>
+#include <memory>
+#include <optional>
+#include <thread>
+
+CurlNetworkFetcher::CurlNetworkFetcher(std::chrono::seconds timeout,
+                                       int max_retries)
+    : timeout_(timeout), max_retries_(max_retries) {
+  curl_client_ = std::make_unique<plugin_common_curl::CurlClient>();
+}
+
+CurlNetworkFetcher::~CurlNetworkFetcher() = default;
+
+template <typename Operation>
+std::optional<std::string> CurlNetworkFetcher::PerformWithRetry(
+    Operation&& operation) {
+  int attempts = 0;
+
+  while (attempts <= max_retries_) {
+    try {
+      auto result = operation();
+      if (result.has_value()) {
+        return result;
+      }
+
+      long response_code = last_response_code_.load();
+      if (response_code >= 200 && response_code < 300) {
+        // success
+        return std::nullopt;
+      }
+
+      if (response_code >= 500 || response_code == 408 ||
+          response_code == 429) {
+        attempts++;
+        if (attempts <= max_retries_) {
+          // exponential backoff
+          std::this_thread::sleep_for(
+              std::chrono::seconds(1 << (attempts - 1)));
+          continue;
+        } else {
+          return std::nullopt;
+        }
+      }
+    } catch (std::exception& e) {
+      spdlog::error("Network operation failed: {}", e.what());
+      attempts++;
+      spdlog::warn("Retrying network operation (attempt {})", attempts);
+      if (attempts <= max_retries_) {
+        // exponential backoff
+        std::this_thread::sleep_for(std::chrono::seconds(1 << (attempts - 1)));
+        continue;
+      }
+      break;
+    }
+  }
+  return std::nullopt;
+}
+
+std::optional<std::string> CurlNetworkFetcher::Fetch(
+    const std::string& url,
+    const std::vector<std::string>& headers) {
+  auto operation = [this, &url, &headers]() -> std::optional<std::string> {
+    try {
+      std::vector<std::string> processed_headers;
+      ProcessHeaders(headers, processed_headers);
+
+      auto response = curl_client_->Get(url);
+      last_response_code_.store(curl_client_->GetHttpCode());
+
+      long response_code = last_response_code_.load();
+      if (response_code >= 200 && response_code < 300) {
+        // success
+        return response;
+      }
+
+      return std::nullopt;
+    } catch (const std::exception& e) {
+      spdlog::error("Network operation failed: {}", e.what());
+      return std::nullopt;
+    }
+  };
+
+  return PerformWithRetry(std::move(operation));
+}
+
+std::optional<std::string> CurlNetworkFetcher::Post(
+    const std::string& url,
+    const std::vector<std::pair<std::string, std::string>>& form_data,
+    const std::vector<std::string>& headers) {
+  auto operation = [this, &url, &form_data,
+                    &headers]() -> std::optional<std::string> {
+    try {
+      std::vector<std::string> processed_headers;
+      ProcessHeaders(headers, processed_headers);
+
+      auto response = curl_client_->Post(url, form_data, headers);
+      last_response_code_.store(curl_client_->GetHttpCode());
+
+      long response_code = last_response_code_.load();
+      if (response_code >= 200 && response_code < 300) {
+        // success
+        return response;
+      }
+
+      return std::nullopt;
+    } catch (const std::exception& e) {
+      spdlog::error("Network operation failed: {}", e.what());
+      return std::nullopt;
+    }
+  };
+
+  return PerformWithRetry(std::move(operation));
+}
+
+bool CurlNetworkFetcher::IsNetworkAvailable() {
+  try {
+    auto result = curl_client_->Get("https://www.google.com");
+    long response_code = curl_client_->GetHttpCode();
+    last_response_code_.store(response_code);
+
+    return response_code > 0;
+  } catch (const std::exception& e) {
+    spdlog::error("Network operation failed: {}", e.what());
+    return false;
+  }
+}
+
+long CurlNetworkFetcher::GetLastResponseCode() {
+  return last_response_code_.load();
+}
+
+void CurlNetworkFetcher::SetBearerToken(const std::string& token) {
+  curl_client_->SetBearerToken(token);
+}
+
+void CurlNetworkFetcher::ProcessHeaders(
+    const std::vector<std::string>& headers,
+    std::vector<std::string>& non_auth_headers) {
+  non_auth_headers.clear();
+
+  for (const auto& header : headers) {
+    if (header.find("Authorization: Bearer ") == 0) {
+      std::string token = header.substr(21);
+      curl_client_->SetBearerToken(token);
+    } else if (header.find("Authorization: ") == 0) {
+      non_auth_headers.push_back(header);
+    } else {
+      non_auth_headers.push_back(header);
+    }
+  }
+}

--- a/plugins/flatpak/cache/network/curl_network_fetcher.h
+++ b/plugins/flatpak/cache/network/curl_network_fetcher.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020-2024 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLUGINS_FLATPAK_CACHE_CURL_NETWORK_FETCHER_H
+#define PLUGINS_FLATPAK_CACHE_CURL_NETWORK_FETCHER_H
+
+#include <spdlog/spdlog.h>
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+#include "../../../common/curl_client/curl_client.h"
+#include "../interfaces/network_fetcher.h"
+
+/**
+ * @brief Curl-based network fetcher implementation
+ *
+ * Integrates with existing CurlClient to provide network operations
+ * with proper error handling and retry logic.
+ */
+class CurlNetworkFetcher : public INetworkFetcher {
+ private:
+  std::unique_ptr<plugin_common_curl::CurlClient> curl_client_;
+  std::atomic<long> last_response_code_{0};
+  std::chrono::seconds timeout_{30};
+  int max_retries_{3};
+
+  /**
+   * @brief Performs a network operation with automatic retry logic
+   * @param operation The operation to be executed with retry logic. Should
+   * return a string on success or indicate failure through the retry mechanism
+   *
+   * @return std::optional<std::string> The result of the operation if
+   * successful, or std::nullopt if all retry attempts failed
+   */
+  template <typename Operation>
+  std::optional<std::string> PerformWithRetry(Operation&& operation);
+
+  void ProcessHeaders(const std::vector<std::string>& headers,
+                      std::vector<std::string>& non_auth_headers);
+
+ public:
+  /**
+   * @brief Constructs a CurlNetworkFetcher with specified timeout and retry
+   * settings.
+   *
+   * @param timeout The timeout duration for network requests in seconds.
+   * Defaults to 30 seconds.
+   * @param max_retries The maximum number of retry attempts for failed
+   * requests. Defaults to 3.
+   */
+  explicit CurlNetworkFetcher(
+      std::chrono::seconds timeout = std::chrono::seconds(30),
+      int max_retries = 3);
+
+  ~CurlNetworkFetcher();
+
+  // INetworkFetcher implementation
+  std::optional<std::string> Fetch(
+      const std::string& url,
+      const std::vector<std::string>& headers = {}) override;
+
+  std::optional<std::string> Post(
+      const std::string& url,
+      const std::vector<std::pair<std::string, std::string>>& form_data,
+      const std::vector<std::string>& headers = {}) override;
+
+  bool IsNetworkAvailable() override;
+
+  long GetLastResponseCode() override;
+
+  void SetBearerToken(const std::string& token) override;
+};
+
+#endif  // PLUGINS_FLATPAK_CACHE_CURL_NETWORK_FETCHER_H

--- a/plugins/flatpak/cache/observers/default_cache_observer.h
+++ b/plugins/flatpak/cache/observers/default_cache_observer.h
@@ -21,22 +21,24 @@
 #include "../interfaces/cache_observer.h"
 
 class DefaultCacheObserver : public ICacheObserver {
-private:
-    std::string component_name_;
-public:
-    explicit DefaultCacheObserver(const std::string& component_name = "CacheManager");
+ private:
+  std::string component_name_;
 
-    void OnCacheHit(const std::string& key, size_t data_size) override;
+ public:
+  explicit DefaultCacheObserver(
+      const std::string& component_name = "CacheManager");
 
-    void OnCacheMiss(const std::string& key) override;
-    
-    void OnCacheExpired(const std::string& key) override;
+  void OnCacheHit(const std::string& key, size_t data_size) override;
 
-    void OnNetworkFallback(const std::string& reason) override;
-    
-    void OnNetworkError(const std::string& url, long error_code) override;
+  void OnCacheMiss(const std::string& key) override;
 
-    void OnCacheCleanup(size_t entries_cleaned) override;
+  void OnCacheExpired(const std::string& key) override;
+
+  void OnNetworkFallback(const std::string& reason) override;
+
+  void OnNetworkError(const std::string& url, long error_code) override;
+
+  void OnCacheCleanup(size_t entries_cleaned) override;
 };
 
-#endif // PLUGINS_FLATPAK_CACHE_DEFAULT_CACHE_OBSERVER_H
+#endif  // PLUGINS_FLATPAK_CACHE_DEFAULT_CACHE_OBSERVER_H

--- a/plugins/flatpak/cache/observers/default_cache_observer.h
+++ b/plugins/flatpak/cache/observers/default_cache_observer.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020-2024 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLUGINS_FLATPAK_CACHE_DEFAULT_CACHE_OBSERVER_H
+#define PLUGINS_FLATPAK_CACHE_DEFAULT_CACHE_OBSERVER_H
+
+#include <string>
+#include "../interfaces/cache_observer.h"
+
+class DefaultCacheObserver : public ICacheObserver {
+private:
+    std::string component_name_;
+public:
+    explicit DefaultCacheObserver(const std::string& component_name = "CacheManager");
+
+    void OnCacheHit(const std::string& key, size_t data_size) override;
+
+    void OnCacheMiss(const std::string& key) override;
+    
+    void OnCacheExpired(const std::string& key) override;
+
+    void OnNetworkFallback(const std::string& reason) override;
+    
+    void OnNetworkError(const std::string& url, long error_code) override;
+
+    void OnCacheCleanup(size_t entries_cleaned) override;
+};
+
+#endif // PLUGINS_FLATPAK_CACHE_DEFAULT_CACHE_OBSERVER_H

--- a/plugins/flatpak/cache/observers/metrics_cache_observer.h
+++ b/plugins/flatpak/cache/observers/metrics_cache_observer.h
@@ -17,30 +17,29 @@
 #ifndef PLUGINS_FLATPAK_CACHE_METRICS_CACHE_OBSERVER_H
 #define PLUGINS_FLATPAK_CACHE_METRICS_CACHE_OBSERVER_H
 
-#include "../cache_config.h"
-#include "../interfaces/cache_observer.h"
 #include <spdlog/spdlog.h>
 #include <sstream>
+#include "../cache_config.h"
+#include "../interfaces/cache_observer.h"
 
+class MetricsCacheObserver : public ICacheObserver {
+ private:
+  flatpak_plugin::CacheMetrics* metrics_;
 
-class MetricsCacheObserver : public ICacheObserver{
-private:
-    flatpak_plugin::CacheMetrics* metrics_;
+ public:
+  explicit MetricsCacheObserver(flatpak_plugin::CacheMetrics* metrics);
 
-public:
-    explicit MetricsCacheObserver(flatpak_plugin::CacheMetrics* metrics);
+  void OnCacheHit(const std::string& key, size_t data_size) override;
 
-    void OnCacheHit(const std::string& key, size_t data_size) override;
+  void OnCacheMiss(const std::string& key) override;
 
-    void OnCacheMiss(const std::string& key) override;
-    
-    void OnCacheExpired(const std::string& key) override;
+  void OnCacheExpired(const std::string& key) override;
 
-    void OnNetworkFallback(const std::string& reason) override;
-    
-    void OnNetworkError(const std::string& url, long error_code) override;
+  void OnNetworkFallback(const std::string& reason) override;
 
-    void OnCacheCleanup(size_t entries_cleaned) override;
-}; 
+  void OnNetworkError(const std::string& url, long error_code) override;
 
-#endif // PLUGINS_FLATPAK_CACHE_METRICS_CACHE_OBSERVER_H
+  void OnCacheCleanup(size_t entries_cleaned) override;
+};
+
+#endif  // PLUGINS_FLATPAK_CACHE_METRICS_CACHE_OBSERVER_H

--- a/plugins/flatpak/cache/observers/metrics_cache_observer.h
+++ b/plugins/flatpak/cache/observers/metrics_cache_observer.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-2024 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLUGINS_FLATPAK_CACHE_METRICS_CACHE_OBSERVER_H
+#define PLUGINS_FLATPAK_CACHE_METRICS_CACHE_OBSERVER_H
+
+#include "../cache_config.h"
+#include "../interfaces/cache_observer.h"
+#include <spdlog/spdlog.h>
+#include <sstream>
+
+
+class MetricsCacheObserver : public ICacheObserver{
+private:
+    flatpak_plugin::CacheMetrics* metrics_;
+
+public:
+    explicit MetricsCacheObserver(flatpak_plugin::CacheMetrics* metrics);
+
+    void OnCacheHit(const std::string& key, size_t data_size) override;
+
+    void OnCacheMiss(const std::string& key) override;
+    
+    void OnCacheExpired(const std::string& key) override;
+
+    void OnNetworkFallback(const std::string& reason) override;
+    
+    void OnNetworkError(const std::string& url, long error_code) override;
+
+    void OnCacheCleanup(size_t entries_cleaned) override;
+}; 
+
+#endif // PLUGINS_FLATPAK_CACHE_METRICS_CACHE_OBSERVER_H

--- a/plugins/flatpak/cache/observers/observers.cc
+++ b/plugins/flatpak/cache/observers/observers.cc
@@ -1,42 +1,47 @@
 #include "metrics_cache_observer.h"
 
 MetricsCacheObserver::MetricsCacheObserver(
-    flatpak_plugin::CacheMetrics* metrics) : metrics_(metrics){}
+    flatpak_plugin::CacheMetrics* metrics)
+    : metrics_(metrics) {}
 
-void MetricsCacheObserver::OnCacheHit(const std::string& key, size_t data_size) {
-    std::ostringstream oss;
-    oss << std::this_thread::get_id();
-    spdlog::debug("Cache hit: key='{}', size={}, thread={}", key, data_size, oss.str());    
-    metrics_->hits++;
-    metrics_->cache_size_bytes += data_size;
-    double hit_ratio = metrics_->GetHitRatio();
-    spdlog::info("Cache hit for key: {}, size: {}. Total hits: {}, Hit ratio: {:.2f}%",
-                 key, data_size, metrics_->hits.load(), hit_ratio);
+void MetricsCacheObserver::OnCacheHit(const std::string& key,
+                                      size_t data_size) {
+  std::ostringstream oss;
+  oss << std::this_thread::get_id();
+  spdlog::debug("Cache hit: key='{}', size={}, thread={}", key, data_size,
+                oss.str());
+  metrics_->hits++;
+  metrics_->cache_size_bytes += data_size;
+  double hit_ratio = metrics_->GetHitRatio();
+  spdlog::info(
+      "Cache hit for key: {}, size: {}. Total hits: {}, Hit ratio: {:.2f}%",
+      key, data_size, metrics_->hits.load(), hit_ratio);
 }
 
 void MetricsCacheObserver::OnCacheMiss(const std::string& key) {
-    std::ostringstream oss;
-    oss << std::this_thread::get_id();
-    spdlog::debug("Cache miss: key='{}', thread={}", key, oss.str());
-    metrics_->misses++;
-    spdlog::info("Cache miss for key: {}", key);
+  std::ostringstream oss;
+  oss << std::this_thread::get_id();
+  spdlog::debug("Cache miss: key='{}', thread={}", key, oss.str());
+  metrics_->misses++;
+  spdlog::info("Cache miss for key: {}", key);
 }
 
 void MetricsCacheObserver::OnCacheExpired(const std::string& key) {
-    metrics_->expired_entries++;
-    spdlog::info("Cache expired for key: {}", key);
+  metrics_->expired_entries++;
+  spdlog::info("Cache expired for key: {}", key);
 }
 
 void MetricsCacheObserver::OnNetworkFallback(const std::string& reason) {
-    metrics_->network_calls++;
-    spdlog::warn("Network fallback triggered: {}", reason);
+  metrics_->network_calls++;
+  spdlog::warn("Network fallback triggered: {}", reason);
 }
 
-void MetricsCacheObserver::OnNetworkError(const std::string& url, long error_code) {
-    metrics_->network_errors++;
-    spdlog::error("Network error for url: {}, error code: {}", url, error_code);
+void MetricsCacheObserver::OnNetworkError(const std::string& url,
+                                          long error_code) {
+  metrics_->network_errors++;
+  spdlog::error("Network error for url: {}, error code: {}", url, error_code);
 }
 
 void MetricsCacheObserver::OnCacheCleanup(size_t entries_cleaned) {
-    spdlog::info("Cache cleanup event, entries cleaned: {}", entries_cleaned);
+  spdlog::info("Cache cleanup event, entries cleaned: {}", entries_cleaned);
 }

--- a/plugins/flatpak/cache/observers/observers.cc
+++ b/plugins/flatpak/cache/observers/observers.cc
@@ -1,0 +1,42 @@
+#include "metrics_cache_observer.h"
+
+MetricsCacheObserver::MetricsCacheObserver(
+    flatpak_plugin::CacheMetrics* metrics) : metrics_(metrics){}
+
+void MetricsCacheObserver::OnCacheHit(const std::string& key, size_t data_size) {
+    std::ostringstream oss;
+    oss << std::this_thread::get_id();
+    spdlog::debug("Cache hit: key='{}', size={}, thread={}", key, data_size, oss.str());    
+    metrics_->hits++;
+    metrics_->cache_size_bytes += data_size;
+    double hit_ratio = metrics_->GetHitRatio();
+    spdlog::info("Cache hit for key: {}, size: {}. Total hits: {}, Hit ratio: {:.2f}%",
+                 key, data_size, metrics_->hits.load(), hit_ratio);
+}
+
+void MetricsCacheObserver::OnCacheMiss(const std::string& key) {
+    std::ostringstream oss;
+    oss << std::this_thread::get_id();
+    spdlog::debug("Cache miss: key='{}', thread={}", key, oss.str());
+    metrics_->misses++;
+    spdlog::info("Cache miss for key: {}", key);
+}
+
+void MetricsCacheObserver::OnCacheExpired(const std::string& key) {
+    metrics_->expired_entries++;
+    spdlog::info("Cache expired for key: {}", key);
+}
+
+void MetricsCacheObserver::OnNetworkFallback(const std::string& reason) {
+    metrics_->network_calls++;
+    spdlog::warn("Network fallback triggered: {}", reason);
+}
+
+void MetricsCacheObserver::OnNetworkError(const std::string& url, long error_code) {
+    metrics_->network_errors++;
+    spdlog::error("Network error for url: {}, error code: {}", url, error_code);
+}
+
+void MetricsCacheObserver::OnCacheCleanup(size_t entries_cleaned) {
+    spdlog::info("Cache cleanup event, entries cleaned: {}", entries_cleaned);
+}

--- a/plugins/flatpak/cache/operations/cache_operation_template.h
+++ b/plugins/flatpak/cache/operations/cache_operation_template.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2020-2024 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLUGINS_FLATPAK_CACHE_CACHE_OPERATION_TEMPLATE_H
+#define PLUGINS_FLATPAK_CACHE_CACHE_OPERATION_TEMPLATE_H
+
+#include <spdlog/spdlog.h>
+#include <chrono>
+#include <exception>
+#include <optional>
+#include <string>
+#include "../interfaces/cache_storage.h"
+
+/**
+ * @brief Template class for cache operations providing a framework for data
+ * caching and retrieval
+ *
+ * This abstract template class defines a common interface for caching
+ * operations with type safety. It provides methods for storing and retrieving
+ * data from cache storage with validation, serialization, and error handling
+ * capabilities.
+ */
+template <typename T>
+class CacheOperationTemplate {
+ protected:
+  /**
+   * @brief Validates if the provided key is acceptable for cache operations.
+   * @param key The string key to validate
+   * @return true if the key is valid and can be used for cache operations,
+   *         false otherwise
+   */
+  virtual bool ValidateKey(const std::string& key) = 0;
+
+  /**
+   * @brief Serializes the given data object into a string representation.
+   * @param data The data object of type T to be serialized
+   * @return std::string The serialized representation of the data object
+   */
+  virtual std::string SerializeData(const T& data) = 0;
+
+  /**
+   * @brief Pure virtual method to deserialize cached data into type T
+   * @return std::optional<T> Returns the deserialized object of type T if
+   *         successful, or std::nullopt if deserialization fails or no
+   *         valid data is available
+   */
+  virtual std::optional<T> DeserializeData() = 0;
+
+  /**
+   * @brief Gets the expiry time for the cache operation.
+   * @return std::chrono::system_clock::time_point The expiry time of the cache
+   * operation
+   */
+  virtual std::chrono::system_clock::time_point GetExpiryTime() = 0;
+
+  /**
+   * @brief Validates the provided data object.
+   * @param data The data object to be validated
+   * @return true if the data is valid and passes all validation checks
+   * @return false if the data is invalid or fails any validation checks
+   */
+  virtual bool ValidateData(const T& data) = 0;
+
+ public:
+  virtual ~CacheOperationTemplate() = default;
+
+  /**
+   * @brief Caches data with the specified key using the provided storage
+   * interface
+   * @tparam T The type of data to be cached (must be serializable)
+   * @param key The unique identifier for the cached data (must pass validation)
+   * @param data The data object to be stored in the cache
+   * @param storage Pointer to the cache storage interface for persistence
+   * operations
+   *
+   * @return true if the data was successfully cached, false if validation
+   * failed or an exception occurred during the caching process
+   */
+  bool CacheData(const std::string& key,
+                 const T& data,
+                 ICacheStorage* storage) {
+    if (!ValidateKey(key) || !ValidateData(data)) {
+      return false;
+    }
+
+    try {
+      auto serialized = SerializeData(data);
+      auto expiry = GetExpiryTime();
+    } catch (const std::exception& e) {
+      spdlog::error("[CacheOperation] Failed to cache data: {}", e.what());
+      return false;
+    }
+  }
+
+  /**
+   * @brief Retrieves and deserializes data from cache storage using the
+   * specified key.
+   * @tparam T The type of data to retrieve and deserialize
+   * @param key The cache key used to identify the stored data
+   * @param storage Pointer to the cache storage interface for data retrieval
+   * @return std::optional<T> The deserialized data if successful, std::nullopt
+   * otherwise
+   */
+  std::optional<T> RetriveData(const std::string& key, ICacheStorage* storage) {
+    if (!ValidateKey(key)) {
+      return std::nullopt;
+    }
+
+    try {
+      auto serialized = storage->Retrieve(key);
+      if (!serialized.has_value()) {
+        return std::nullopt;
+      }
+
+      return DeserializeData(*serialized);
+    } catch (const std::exception& e) {
+      spdlog::error("[CacheOperation] Failed to retrive data: {}", e.what());
+      return std::nullopt;
+    }
+  }
+};
+
+#endif  // PLUGINS_FLATPAK_CACHE_CACHE_OPERATION_TEMPLATE_H

--- a/plugins/flatpak/cache/operations/flatpak_application_cache_operation.h
+++ b/plugins/flatpak/cache/operations/flatpak_application_cache_operation.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020-2024 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLUGINS_FLATPAK_CACHE_APPLICATION_CACHE_OPERATION_H
+#define PLUGINS_FLATPAK_CACHE_APPLICATION_CACHE_OPERATION_H
+
+#include <chrono>
+#include "cache_operation_template.h"
+
+/**
+ * @brief Cache operation class for managing Flatpak application data with
+ * time-to-live functionality.
+ *
+ * This class extends CacheOperationTemplate to provide specialized caching
+ * operations for Flatpak applications. It handles serialization/deserialization
+ * of Flutter EncodableList data and implements time-based cache expiration.
+ * @tparam flutter::EncodableList The data type being cached (Flatpak
+ * application data)
+ */
+class FlatpakApplicationCacheOperation
+    : public CacheOperationTemplate<flutter::EncodableList> {
+ private:
+  std::chrono::seconds ttl_;
+
+ protected:
+  bool ValidateKey(const std::string& key) override;
+
+  std::string SerializeData(const flutter::EncodableList& data) override;
+
+  std::optional<flutter::EncodableList> DeserializeData() override;
+
+  std::chrono::system_clock::time_point GetExpiryTime() override;
+
+  bool ValidateData(const flutter::EncodableList& data) override;
+
+ public:
+  explicit FlatpakApplicationCacheOperation(
+      std::chrono::seconds ttl = std::chrono::hours(2));
+};
+
+#endif  // PLUGINS_FLATPAK_CACHE_APPLICATION_CACHE_OPERATION_H

--- a/plugins/flatpak/cache/operations/flatpak_installation_cache_operation.h
+++ b/plugins/flatpak/cache/operations/flatpak_installation_cache_operation.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020-2024 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLUGINS_FLATPAK_CACHE_INSTALLATION_CACHE_OPERATION_H
+#define PLUGINS_FLATPAK_CACHE_INSTALLATION_CACHE_OPERATION_H
+
+#include <chrono>
+#include "cache_operation_template.h"
+
+/**
+ * @brief Handles caching operations for Flatpak installations with a specified
+ * time-to-live (TTL).
+ *
+ * This class inherits from CacheOperationTemplate specialized for the
+ * Installation type. It provides mechanisms to validate cache keys, serialize
+ * and deserialize Installation data, determine expiry times, and validate
+ * cached data. The TTL for cached entries can be configured, with a default
+ * value of 6 hours.
+ */
+class FlatpakInstallationCacheOperation
+    : public CacheOperationTemplate<Installation> {
+ private:
+  std::chrono::seconds ttl_;
+
+ protected:
+  bool ValidateKey(const std::string& key) override;
+
+  std::string SerializeData(const Installation& data) override;
+
+  std::optional<Installation> DeserializeData() override;
+
+  std::chrono::system_clock::time_point GetExpiryTime() override;
+
+  bool ValidateData(const Installation& data) override;
+
+ public:
+  explicit FlatpakInstallationCacheOperation(
+      std::chrono::seconds ttl = std::chrono::hours(6));
+};
+
+#endif  // PLUGINS_FLATPAK_CACHE_INSTALLATION_CACHE_OPERATION_H

--- a/plugins/flatpak/cache/storage/sqlite_cache_storage.cc
+++ b/plugins/flatpak/cache/storage/sqlite_cache_storage.cc
@@ -1,0 +1,444 @@
+#include "sqlite_cache_storage.h"
+
+SQLiteCacheStorage::SQLiteCacheStorage(std::string db_path,
+                                       bool enable_compression)
+    : db_(nullptr),
+      db_path_(std::move(db_path)),
+      enable_compression_(enable_compression) {}
+
+SQLiteCacheStorage::~SQLiteCacheStorage() {
+  if (db_) {
+    sqlite3_close(db_);
+  }
+}
+
+bool SQLiteCacheStorage::Initialize() {
+  std::lock_guard<std::mutex> lock(db_mutex_);
+
+  int rc = sqlite3_open(db_path_.c_str(), &db_);
+  if (rc != SQLITE_OK) {
+    spdlog::error("Error while opening DB : {}", sqlite3_errmsg(db_));
+    return false;
+  }
+
+  rc = sqlite3_exec(db_, "PRAGMA journal_mode=WAL;", nullptr, nullptr, nullptr);
+  if (rc != SQLITE_OK) {
+    spdlog::error("[SQLiteCacheStorage] Failed to enable WAL mode : {}",
+                  sqlite3_errmsg(db_));
+  }
+
+  rc = sqlite3_exec(db_, "PRAGMA synchronous=NORMAL;", nullptr, nullptr,
+                    nullptr);
+  if (rc != SQLITE_OK) {
+    spdlog::error(
+        "[SQLiteCacheStorage] Failed to enable synchronous mode for DB : {}",
+        sqlite3_errmsg(db_));
+  }
+
+  rc = sqlite3_exec(db_, "PRAGMA foreign_keys=ON;", nullptr, nullptr, nullptr);
+  if (rc != SQLITE_OK) {
+    spdlog::error(
+        "[SQLiteCacheStorage] Failed to enable foreign keys for DB : {}",
+        sqlite3_errmsg(db_));
+  }
+
+  if (!CreateTables()) {
+    spdlog::error("error while creating tables");
+    sqlite3_close(db_);
+    throw std::runtime_error("failed to create database schema");
+  }
+
+  UpdateCacheSize();
+  return true;
+}
+
+bool SQLiteCacheStorage::Store(const std::string& key,
+                               const std::string& data,
+                               std::chrono::system_clock::time_point expiry) {
+  std::lock_guard<std::mutex> lock(db_mutex_);
+
+  std::string processed_data = data;
+  bool is_compressed = false;
+
+  if (enable_compression_) {
+    std::string compressed_data = CompressData(data);
+    if (compressed_data.size() < data.size()) {
+      processed_data = compressed_data;
+      is_compressed = true;
+    }
+  }
+
+  auto expiry_time = std::chrono::duration_cast<std::chrono::seconds>(
+                         expiry.time_since_epoch())
+                         .count();
+  auto created_time = std::chrono::duration_cast<std::chrono::seconds>(
+                          std::chrono::system_clock::now().time_since_epoch())
+                          .count();
+
+  const char* insert_sql = R"(
+        INSERT OR REPLACE INTO cache_entries 
+        (key, data, expiry_time, created_time, data_size, is_compressed) 
+        VALUES (?, ?, ?, ?, ?, ?);
+    )";
+
+  sqlite3_stmt* stmt;
+  int rc = sqlite3_prepare_v2(db_, insert_sql, -1, &stmt, nullptr);
+
+  if (rc != SQLITE_OK) {
+    spdlog::error("[SQLiteCacheStorage] Failed to prepare statement : {} ({})",
+                  sqlite3_errmsg(db_), rc);
+    return false;
+  }
+
+  sqlite3_bind_text(stmt, 1, key.c_str(), -1, SQLITE_STATIC);
+  sqlite3_bind_blob(stmt, 2, processed_data.c_str(), processed_data.size(),
+                    SQLITE_STATIC);
+  sqlite3_bind_int64(stmt, 3, expiry_time);
+  sqlite3_bind_int64(stmt, 4, created_time);
+  sqlite3_bind_int64(stmt, 5, data.size());
+  sqlite3_bind_int(stmt, 6, is_compressed ? 1 : 0);
+
+  rc = sqlite3_step(stmt);
+  sqlite3_finalize(stmt);
+
+  if (rc != SQLITE_DONE) {
+    spdlog::error("[SQLiteCacheStorage] Failed to execute statement : {} ({})",
+                  sqlite3_errmsg(db_), rc);
+    return false;
+  }
+
+  UpdateCacheSize();
+  return true;
+}
+
+std::optional<std::string> SQLiteCacheStorage::Retrieve(
+    const std::string& key) {
+  std::lock_guard<std::mutex> lock(db_mutex_);
+
+  const char* select_sql = R"(
+        SELECT data, expiry_time, is_compressed 
+        FROM cache_entries 
+        WHERE key = ?;
+    )";
+
+  sqlite3_stmt* stmt;
+  int rc = sqlite3_prepare_v2(db_, select_sql, -1, &stmt, nullptr);
+  if (rc != SQLITE_OK) {
+    spdlog::error("[SQLiteCacheStorage] Failed to prepare statement : {} ({})",
+                  sqlite3_errmsg(db_), rc);
+    return std::nullopt;
+  }
+
+  sqlite3_bind_text(stmt, 1, key.c_str(), -1, SQLITE_STATIC);
+
+  std::optional<std::string> result = std::nullopt;
+
+  rc = sqlite3_step(stmt);
+  if (rc == SQLITE_ROW) {
+    auto current_time = std::chrono::duration_cast<std::chrono::seconds>(
+                            std::chrono::system_clock::now().time_since_epoch())
+                            .count();
+
+    int64_t expiry_time = sqlite3_column_int64(stmt, 1);
+
+    if (current_time < expiry_time) {
+      const void* data = sqlite3_column_blob(stmt, 0);
+      int data_size = sqlite3_column_bytes(stmt, 0);
+      bool is_compressed = sqlite3_column_int(stmt, 2) != 0;
+
+      std::string raw_data(static_cast<const char*>(data), data_size);
+
+      if (is_compressed) {
+        std::string decompressed = DecompressData(raw_data);
+        if (!decompressed.empty()) {
+          result = decompressed;
+        } else {
+          spdlog::error(
+              "[SQLiteCacheStorage] Failed to decompress data for key: {}",
+              key);
+        }
+      } else {
+        result = raw_data;
+      }
+    }
+  } else if (rc != SQLITE_DONE) {
+    spdlog::error("[SQLiteCacheStorage] Failed to execute select : {} ({})",
+                  sqlite3_errmsg(db_), rc);
+  }
+
+  sqlite3_finalize(stmt);
+  return result;
+}
+
+bool SQLiteCacheStorage::IsExpired(const std::string& key) {
+  std::lock_guard<std::mutex> lock(db_mutex_);
+
+  const char* select_sql =
+      "SELECT expiry_time FROM cache_entries WHERE key = ?;";
+  sqlite3_stmt* stmt;
+
+  int rc = sqlite3_prepare_v2(db_, select_sql, -1, &stmt, nullptr);
+  if (rc != SQLITE_OK) {
+    spdlog::error("[SQLiteCacheStorage] Failed to prepare statement : {} ({})",
+                  sqlite3_errmsg(db_), rc);
+    return true;
+  }
+
+  sqlite3_bind_text(stmt, 1, key.c_str(), -1, SQLITE_STATIC);
+
+  bool expired = true;
+
+  rc = sqlite3_step(stmt);
+  if (rc == SQLITE_ROW) {
+    auto current_time = std::chrono::duration_cast<std::chrono::seconds>(
+                            std::chrono::system_clock::now().time_since_epoch())
+                            .count();
+
+    int64_t expiry_time = sqlite3_column_int64(stmt, 0);
+    expired = current_time >= expiry_time;
+  } else if (rc != SQLITE_DONE) {
+    spdlog::error("[SQLiteCacheStorage] Failed to execute select : {} ({})",
+                  sqlite3_errmsg(db_), rc);
+  }
+
+  sqlite3_finalize(stmt);
+  return expired;
+}
+
+void SQLiteCacheStorage::Invalidate(const std::string& key) {
+  std::lock_guard<std::mutex> lock(db_mutex_);
+
+  const char* delete_sql;
+  sqlite3_stmt* stmt;
+  int rc;
+
+  if (key.empty()) {
+    // Delete all entries
+    delete_sql = "DELETE FROM cache_entries;";
+    rc = sqlite3_prepare_v2(db_, delete_sql, -1, &stmt, nullptr);
+  } else {
+    // Delete specific entry
+    delete_sql = "DELETE FROM cache_entries WHERE key = ?;";
+    rc = sqlite3_prepare_v2(db_, delete_sql, -1, &stmt, nullptr);
+    if (rc == SQLITE_OK) {
+      sqlite3_bind_text(stmt, 1, key.c_str(), -1, SQLITE_STATIC);
+    }
+  }
+
+  if (rc == SQLITE_OK) {
+    sqlite3_step(stmt);
+  }
+  sqlite3_finalize(stmt);
+
+  UpdateCacheSize();
+}
+
+size_t SQLiteCacheStorage::GetCacheSize() {
+  return cache_size.load();
+}
+
+size_t SQLiteCacheStorage::CleanupExpired() {
+  std::lock_guard<std::mutex> lock(db_mutex_);
+
+  auto current_time = std::chrono::duration_cast<std::chrono::seconds>(
+                          std::chrono::system_clock::now().time_since_epoch())
+                          .count();
+
+  const char* delete_sql = "DELETE FROM cache_entries WHERE expiry_time <= ?;";
+  sqlite3_stmt* stmt;
+
+  int rc = sqlite3_prepare_v2(db_, delete_sql, -1, &stmt, nullptr);
+  if (rc != SQLITE_OK) {
+    spdlog::error("[SQLiteCacheStorage] Failed to prepare statement : {} ({})",
+                  sqlite3_errmsg(db_), rc);
+    return 0;
+  }
+
+  sqlite3_bind_int64(stmt, 1, current_time);
+
+  rc = sqlite3_step(stmt);
+  size_t deleted_count = 0;
+
+  if (rc == SQLITE_DONE) {
+    deleted_count = sqlite3_changes(db_);
+  } else {
+    spdlog::error("[SQLiteCacheStorage] Failed to execute delete : {} ({})",
+                  sqlite3_errmsg(db_), rc);
+  }
+
+  sqlite3_finalize(stmt);
+
+  if (deleted_count > 0) {
+    UpdateCacheSize();
+  }
+
+  return deleted_count;
+}
+
+std::map<std::string, int64_t> SQLiteCacheStorage::GetStatistics() const {
+  std::lock_guard<std::mutex> lock(db_mutex_);
+
+  std::map<std::string, int64_t> stats;
+
+  const char* stats_sql = R"(
+        SELECT 
+            COUNT(*) as entry_count,
+            SUM(data_size) as total_size,
+            AVG(data_size) as avg_size,
+            SUM(CASE WHEN is_compressed = 1 THEN 1 ELSE 0 END) as compressed_count
+        FROM cache_entries;
+    )";
+
+  sqlite3_stmt* stmt;
+  int rc = sqlite3_prepare_v2(db_, stats_sql, -1, &stmt, nullptr);
+  if (rc != SQLITE_OK) {
+    spdlog::error("[SQLiteCacheStorage] Failed to prepare statement : {} ({})",
+                  sqlite3_errmsg(db_), rc);
+    return stats;
+  }
+
+  rc = sqlite3_step(stmt);
+  if (rc == SQLITE_ROW) {
+    stats["entries"] = sqlite3_column_int64(stmt, 0);
+    stats["total_size"] = sqlite3_column_int64(stmt, 1);
+    stats["avg_size"] = sqlite3_column_int64(stmt, 2);
+    stats["compressed_count"] = sqlite3_column_int64(stmt, 3);
+  } else if (rc != SQLITE_DONE) {
+    spdlog::error(
+        "[SQLiteCacheStorage] Failed to execute stats query : {} ({})",
+        sqlite3_errmsg(db_), rc);
+  }
+
+  sqlite3_finalize(stmt);
+
+  auto current_time = std::chrono::duration_cast<std::chrono::seconds>(
+                          std::chrono::system_clock::now().time_since_epoch())
+                          .count();
+
+  const char* expired_sql =
+      "SELECT COUNT(*) FROM cache_entries WHERE expiry_time <= ?;";
+  rc = sqlite3_prepare_v2(db_, expired_sql, -1, &stmt, nullptr);
+  if (rc == SQLITE_OK) {
+    sqlite3_bind_int64(stmt, 1, current_time);
+    rc = sqlite3_step(stmt);
+    if (rc == SQLITE_ROW) {
+      stats["expired_count"] = sqlite3_column_int64(stmt, 0);
+    }
+    sqlite3_finalize(stmt);
+  }
+
+  return stats;
+}
+
+bool SQLiteCacheStorage::CreateTables() {
+  const char* create_table_sql = R"(
+        CREATE TABLE IF NOT EXISTS cache_entries (
+            key TEXT PRIMARY KEY,
+            data BLOB NOT NULL,
+            expiry_time INTEGER NOT NULL,
+            created_time INTEGER NOT NULL,
+            data_size INTEGER NOT NULL,
+            is_compressed INTEGER NOT NULL DEFAULT 0
+        );
+        
+        CREATE INDEX IF NOT EXISTS idx_expiry_time ON cache_entries(expiry_time);
+        CREATE INDEX IF NOT EXISTS idx_created_time ON cache_entries(created_time);
+    )";
+
+  char* error_msg = nullptr;
+  int rc = sqlite3_exec(db_, create_table_sql, nullptr, nullptr, &error_msg);
+
+  if (rc != SQLITE_OK) {
+    spdlog::error("[SQLiteCacheStorage] SQL Error: {}", error_msg);
+    sqlite3_free(error_msg);
+    return false;
+  }
+  return true;
+}
+
+std::string SQLiteCacheStorage::CompressData(const std::string& data) {
+  if (!enable_compression_ || data.empty()) {
+    return data;
+  }
+
+  uLongf compressed_size = compressBound(data.size());
+  std::string compressed_data(compressed_size, '\0');
+
+  int result =
+      compress(reinterpret_cast<Bytef*>(&compressed_data[0]), &compressed_size,
+               reinterpret_cast<const Bytef*>(data.c_str()), data.size());
+
+  if (result != Z_OK) {
+    spdlog::error("[SQLiteCacheStorage] Compression failed with error: {}",
+                  result);
+    return data;
+  }
+
+  compressed_data.resize(compressed_size);
+  return compressed_data;
+}
+
+std::string SQLiteCacheStorage::DecompressData(
+    const std::string& compressed_data) {
+  if (!enable_compression_ || compressed_data.empty()) {
+    return compressed_data;
+  }
+
+  // Try different buffer sizes for decompression
+  std::vector<uLongf> buffer_sizes = {compressed_data.size() * 4,
+                                      compressed_data.size() * 10,
+                                      compressed_data.size() * 50, 1024 * 1024};
+
+  for (uLongf buffer_size : buffer_sizes) {
+    std::string decompressed_data(buffer_size, '\0');
+    uLongf decompressed_size = buffer_size;
+
+    int result = uncompress(
+        reinterpret_cast<Bytef*>(&decompressed_data[0]), &decompressed_size,
+        reinterpret_cast<const Bytef*>(compressed_data.c_str()),
+        compressed_data.size());
+
+    if (result == Z_OK) {
+      decompressed_data.resize(decompressed_size);
+      return decompressed_data;
+    } else if (result == Z_BUF_ERROR) {
+      // Buffer too small
+      continue;
+    } else {
+      // stop trying
+      spdlog::error("[SQLiteCacheStorage] Decompression failed with error: {}",
+                    result);
+      break;
+    }
+  }
+
+  spdlog::error("[SQLiteCacheStorage] All decompression attempts failed");
+  return "";
+}
+
+void SQLiteCacheStorage::UpdateCacheSize() {
+  const char* size_sql =
+      "SELECT COALESCE(SUM(data_size), 0) FROM cache_entries;";
+
+  sqlite3_stmt* stmt;
+
+  int rc = sqlite3_prepare_v2(db_, size_sql, -1, &stmt, nullptr);
+
+  if (rc != SQLITE_OK) {
+    spdlog::error(
+        "[SQLiteCacheStorage] Failed to prepare cache size query: {} ({})",
+        sqlite3_errmsg(db_), rc);
+    return;
+  }
+
+  rc = sqlite3_step(stmt);
+  if (rc == SQLITE_ROW) {
+    cache_size.store(sqlite3_column_int64(stmt, 0));
+  } else if (rc != SQLITE_DONE) {
+    spdlog::error(
+        "[SQLiteCacheStorage] Failed to execute cache size query: {} ({})",
+        sqlite3_errmsg(db_), rc);
+  }
+
+  sqlite3_finalize(stmt);
+}

--- a/plugins/flatpak/cache/storage/sqlite_cache_storage.h
+++ b/plugins/flatpak/cache/storage/sqlite_cache_storage.h
@@ -17,68 +17,69 @@
 #ifndef PLUGINS_FLATPAK_CACHE_SQLITE_CACHE_STORAGE_H
 #define PLUGINS_FLATPAK_CACHE_SQLITE_CACHE_STORAGE_H
 
-#include "../interfaces/cache_storage.h"
-#include <sqlite3.h>
-#include <cstddef>
-#include <map>
-#include <mutex>
-#include <atomic>
 #include <spdlog/spdlog.h>
+#include <sqlite3.h>
 #include <zconf.h>
 #include <zlib.h>
+#include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
+#include <map>
+#include <mutex>
 #include <optional>
-
-
+#include "../interfaces/cache_storage.h"
 
 /**
- * @brief Implements a cache storage backend using SQLite as the underlying database.
+ * @brief Implements a cache storage backend using SQLite as the underlying
+ * database.
  *
- * This class provides persistent cache storage functionality by leveraging SQLite.
- * It supports optional data compression, thread-safe operations, and cache size management.
+ * This class provides persistent cache storage functionality by leveraging
+ * SQLite. It supports optional data compression, thread-safe operations, and
+ * cache size management.
  */
-class SQLiteCacheStorage: public ICacheStorage {
-private:
-    sqlite3* db_;
-    std::string db_path_;
-    mutable std::mutex db_mutex_;
-    std::atomic<size_t> cache_size{0};
-    bool enable_compression_;
+class SQLiteCacheStorage : public ICacheStorage {
+ private:
+  sqlite3* db_;
+  std::string db_path_;
+  mutable std::mutex db_mutex_;
+  std::atomic<size_t> cache_size{0};
+  bool enable_compression_;
 
-    bool CreateTables();
+  bool CreateTables();
 
-    std::string CompressData(const std::string& data);
+  std::string CompressData(const std::string& data);
 
-    std::string DecompressData(const std::string& data);
+  std::string DecompressData(const std::string& data);
 
-    void UpdateCacheSize();
+  void UpdateCacheSize();
 
-public:
-    explicit SQLiteCacheStorage(std::string db_path, bool enable_compression = false);
+ public:
+  explicit SQLiteCacheStorage(std::string db_path,
+                              bool enable_compression = false);
 
-    ~SQLiteCacheStorage();
-    bool Initialize() override;
+  ~SQLiteCacheStorage();
+  bool Initialize() override;
 
-    bool Store(const std::string& key,
-                     const std::string& data,
-                     std::chrono::system_clock::time_point expiry) override;
-                    
-    std::optional<std::string> Retrieve(const std::string& key) override;
+  bool Store(const std::string& key,
+             const std::string& data,
+             std::chrono::system_clock::time_point expiry) override;
 
-    bool IsExpired(const std::string& key) override;
+  std::optional<std::string> Retrieve(const std::string& key) override;
 
-    void Invalidate(const std::string& key = "") override;
-    
-    size_t GetCacheSize() override;
+  bool IsExpired(const std::string& key) override;
 
-    size_t CleanupExpired() override;
-    
-    /**
-    * @brief Retrieves cache statistics such as entry count and total size.
-    * @return A map of statistic names to their values.
-    */
-    std::map<std::string, int64_t> GetStatistics() const;
+  void Invalidate(const std::string& key = "") override;
+
+  size_t GetCacheSize() override;
+
+  size_t CleanupExpired() override;
+
+  /**
+   * @brief Retrieves cache statistics such as entry count and total size.
+   * @return A map of statistic names to their values.
+   */
+  std::map<std::string, int64_t> GetStatistics() const;
 };
 
-#endif // PLUGINS_FLATPAK_CACHE_SQLITE_CACHE_STORAGE_H
+#endif  // PLUGINS_FLATPAK_CACHE_SQLITE_CACHE_STORAGE_H

--- a/plugins/flatpak/cache/storage/sqlite_cache_storage.h
+++ b/plugins/flatpak/cache/storage/sqlite_cache_storage.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020-2024 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLUGINS_FLATPAK_CACHE_SQLITE_CACHE_STORAGE_H
+#define PLUGINS_FLATPAK_CACHE_SQLITE_CACHE_STORAGE_H
+
+#include "../interfaces/cache_storage.h"
+#include <sqlite3.h>
+#include <cstddef>
+#include <map>
+#include <mutex>
+#include <atomic>
+#include <spdlog/spdlog.h>
+#include <zconf.h>
+#include <zlib.h>
+#include <chrono>
+#include <cstdint>
+#include <optional>
+
+
+
+/**
+ * @brief Implements a cache storage backend using SQLite as the underlying database.
+ *
+ * This class provides persistent cache storage functionality by leveraging SQLite.
+ * It supports optional data compression, thread-safe operations, and cache size management.
+ */
+class SQLiteCacheStorage: public ICacheStorage {
+private:
+    sqlite3* db_;
+    std::string db_path_;
+    mutable std::mutex db_mutex_;
+    std::atomic<size_t> cache_size{0};
+    bool enable_compression_;
+
+    bool CreateTables();
+
+    std::string CompressData(const std::string& data);
+
+    std::string DecompressData(const std::string& data);
+
+    void UpdateCacheSize();
+
+public:
+    explicit SQLiteCacheStorage(std::string db_path, bool enable_compression = false);
+
+    ~SQLiteCacheStorage();
+    bool Initialize() override;
+
+    bool Store(const std::string& key,
+                     const std::string& data,
+                     std::chrono::system_clock::time_point expiry) override;
+                    
+    std::optional<std::string> Retrieve(const std::string& key) override;
+
+    bool IsExpired(const std::string& key) override;
+
+    void Invalidate(const std::string& key = "") override;
+    
+    size_t GetCacheSize() override;
+
+    size_t CleanupExpired() override;
+    
+    /**
+    * @brief Retrieves cache statistics such as entry count and total size.
+    * @return A map of statistic names to their values.
+    */
+    std::map<std::string, int64_t> GetStatistics() const;
+};
+
+#endif // PLUGINS_FLATPAK_CACHE_SQLITE_CACHE_STORAGE_H


### PR DESCRIPTION
This PR introduces the initial test suite for the `Curl Client` component, marking the first step in our testing strategy for the plugin system. This is part of the broader Feature #123  and changes in PR #130 .

### Changes

- Added comprehensive unit tests for the CurlClient class
- Implemented test cases for:

1. Basic HTTP GET/POST requests
2. Response handling and error cases
3. Timeout configurations
4. Header management

### Testing

-  All tests pass locally
-  Tests cover both success and error scenarios
-  Mock server responses to test various edge cases

### Related Work
This is the first in a series of test PRs that will include:

- [x] Cache management tests (upcoming)
- [x] Flatpak plugin tests (upcoming)