### PR TITLE
Fixes Wayland sync issues

### DIFF
--- a/plugins/filament_view/core/scene/view_target.cc
+++ b/plugins/filament_view/core/scene/view_target.cc
@@ -532,7 +532,24 @@ void ViewTarget::DrawFrame(const uint32_t time) {
   if (deltaTime == 0.0) {
     deltaTime += 1.0;
   }
-  float fps = 1.0f / static_cast<float>(deltaTime);  // calculate FPS
+
+  float fps;
+  if (_last_fps_reset_time == 0) {
+    _last_fps_reset_time = time;
+    // calculate from delta time and round to int
+    _prev_fps_counter = static_cast<int>(1.0f / deltaTime);
+  }
+
+  _fps_counter++;
+
+  // Second overflown, reset counter
+  if (time - _last_fps_reset_time >= 1000) {
+    _last_fps_reset_time = time;
+    _prev_fps_counter = _fps_counter;
+    _fps_counter = 0;
+  }
+
+  fps = static_cast<float>(_prev_fps_counter);
 
   // spdlog::debug("[{}] deltaTime: {:.2f}ms", __FUNCTION__, deltaTime * 1000.0f);
 
@@ -612,6 +629,8 @@ void ViewTarget::OnFrame(void* data, wl_callback* callback, const uint32_t time)
   const auto promise = std::make_shared<std::promise<void>>();
   const auto future = promise->get_future();
 
+  // TODO: there's a 0.05ms lag when posting the task - SHOULDN'T HAPPEN!
+  // NOTE: let's use separate strands for work and rendering?
   post(*ECSManager::GetInstance()->getStrand(), [data, obj, callback, time, promise] {
     // spdlog::debug("=== (wl) callback start ===");
     obj->callback_ = nullptr;

--- a/plugins/filament_view/core/scene/view_target.cc
+++ b/plugins/filament_view/core/scene/view_target.cc
@@ -634,7 +634,7 @@ void ViewTarget::OnFrame(void* data, wl_callback* callback, const uint32_t time)
     // wl_subsurface_set_position(obj->subsurface_, obj->left_, obj->top_);
 
     // spdlog::debug("=== (wl) surface commit ===");
-    wl_surface_commit(obj->surface_);
+    // NOTE: DO NOT CALL wl_surface_commit, it already happens elsewhere
 
     // spdlog::debug("=== (wl) callback end ===");
     promise->set_value();

--- a/plugins/filament_view/core/scene/view_target.h
+++ b/plugins/filament_view/core/scene/view_target.h
@@ -160,6 +160,7 @@ class ViewTarget {
     } native_window_{};
 
     ::filament::SwapChain* fswapChain_{};
+    std::mutex frameLock_;
     ::filament::View* fview_{};
 
     // todo to be moved?

--- a/plugins/filament_view/core/scene/view_target.h
+++ b/plugins/filament_view/core/scene/view_target.h
@@ -174,6 +174,9 @@ class ViewTarget {
     static void OnFrame(void* data, wl_callback* callback, uint32_t time);
 
     static const wl_callback_listener frame_listener;
+    int _prev_fps_counter = 0;
+    int _fps_counter = 0;
+    uint32_t _last_fps_reset_time = 0;
 
     void DrawFrame(uint32_t time);
 


### PR DESCRIPTION
Closes https://github.com/toyota-connected/fluorite/issues/15 🥳 💖 
Partially resolves https://github.com/toyota-connected/fluorite/issues/11 🥹

**Summary of issues + solutions:**

- Wayland sync issues
  - `ViewTarget::OnFrame` task on render thread wasn't being awaited (silly mistake) -> added promise+wait to mitiage
  - `ViewTarget::surface_` access wasn't locked, and `OnFrame` would terminate too quickly causing resource contention -> lock surface access
    - Thanks @stransky! (see https://phabricator.services.mozilla.com/D214885)
  - Filament/Flutter/something (not sure!) already commits the surface -> we don't commit the surface post `DrawFrame` again
  
The above resulted in 100% mitigation

**Bonus**! ✨ Improved the FPS counter - now it's fully accurate by counting the individual frames (was being approximated from delta time)