### PR TITLE
[filament_view] Fix readiness checks

### DIFF
--- a/plugins/filament_view/core/systems/ecs.cc
+++ b/plugins/filament_view/core/systems/ecs.cc
@@ -47,14 +47,14 @@ ECSManager::ECSManager()
   setupThreadingInternals();
 }
 
-////////////////////////////////////////////////////////////////////////////
+/// NOTE: THIS IS DEPRECATED, temporarily; right now the Wayland callback in ViewTarget calls the main loop
 void ECSManager::StartMainLoop() {
-  if (m_bIsRunning) {
+  if (m_eCurrentState != Initialized) {
     return;
   }
 
   spdlog::info("\n\n\n === Starting ECS main loop ===\n");
-  m_bIsRunning = true;
+  m_eCurrentState = Running;
   m_bSpawnedThreadFinished = false;
 
   // Launch MainLoop in a separate thread
@@ -86,7 +86,7 @@ void ECSManager::MainLoop() {
   auto lastFrameTime = std::chrono::steady_clock::now();
 
   m_eCurrentState = Running;
-  while (m_bIsRunning) {
+  while (m_eCurrentState == Running) {
     auto start = std::chrono::steady_clock::now();
 
     // Calculate the time difference between this frame and the last frame
@@ -156,7 +156,7 @@ void ECSManager::MainLoop() {
 
 ////////////////////////////////////////////////////////////////////////////
 void ECSManager::StopMainLoop() {
-  m_bIsRunning = false;
+  m_eCurrentState = ShutdownStarted;
   if (loopThread_.joinable()) {
     loopThread_.join();
   }

--- a/plugins/filament_view/core/systems/ecs.cc
+++ b/plugins/filament_view/core/systems/ecs.cc
@@ -47,7 +47,8 @@ ECSManager::ECSManager()
   setupThreadingInternals();
 }
 
-/// NOTE: THIS IS DEPRECATED, temporarily; right now the Wayland callback in ViewTarget calls the main loop
+/// NOTE: THIS IS DEPRECATED, temporarily; right now the Wayland callback in ViewTarget calls the
+/// main loop
 void ECSManager::StartMainLoop() {
   if (m_eCurrentState != Initialized) {
     return;
@@ -512,6 +513,9 @@ void ECSManager::removeSystem(TypeID systemTypeId) {
 
 ////////////////////////////////////////////////////////////////////////////
 void ECSManager::update(const double deltaTime) {
+  /// NOTE: this is temporary until the main loop gets refactored
+  m_eCurrentState = Running;
+
   // Copy systems under mutex
   std::map<TypeID, std::shared_ptr<System>> systemsCopy;
   {

--- a/plugins/filament_view/core/systems/ecs.h
+++ b/plugins/filament_view/core/systems/ecs.h
@@ -68,7 +68,6 @@ class ECSManager {
     //
     // Threading
     //
-    std::atomic<bool> m_bIsRunning{false};
     std::atomic<bool> m_bSpawnedThreadFinished{false};
     std::atomic<bool> isHandlerExecuting{false};
 
@@ -81,13 +80,21 @@ class ECSManager {
 
     std::map<std::string, int> m_mapOffThreadCallers;
 
-    RunState m_eCurrentState;
+    std::atomic<RunState> m_eCurrentState{NotInitialized};
     static ECSManager* m_poInstance;
 
     ECSManager();
     ~ECSManager();
 
   public:
+    [[nodiscard]] inline static RunState GetRunState() {
+      if (m_poInstance == nullptr) {
+        return NotInitialized;
+      } else {
+        return m_poInstance->m_eCurrentState;
+      }
+    }
+
     [[nodiscard]] inline RunState getRunState() const { return m_eCurrentState; }
 
     [[nodiscard]] inline static ECSManager* GetInstance() {

--- a/plugins/filament_view/filament_view_plugin.cc
+++ b/plugins/filament_view/filament_view_plugin.cc
@@ -52,6 +52,7 @@ bool m_bHasSetupRegistrar = false;
 void RunOnceCheckAndInitializeECSystems() {
   const auto ecs = ECSManager::GetInstance();
 
+  // Make sure we only initialize once
   if (ecs->getRunState() != ECSManager::RunState::NotInitialized) {
     return;
   }
@@ -366,35 +367,14 @@ void FilamentViewPlugin::setupMessageChannels(flutter::PluginRegistrar* registra
     [&](const flutter::MethodCall<>& call, const std::unique_ptr<flutter::MethodResult<>>& result) {
       if (call.method_name() == "isReady") {
         // Check readiness and respond
-        bool isReady = true;  // Replace with your actual readiness check
+        bool isReady = ECSManager::GetRunState() == ECSManager::RunState::Running;
+        spdlog::debug("Readiness check: {}", static_cast<int>(ECSManager::GetRunState()));
         result->Success(flutter::EncodableValue(isReady));
       } else {
         result->NotImplemented();
       }
     }
   );
-
-  // Setup EventChannel for readiness events
-  const std::string readinessEventChannel = "plugin.filament_view.readiness";
-
-  const auto eventChannel = std::make_unique<flutter::EventChannel<>>(
-    registrar->messenger(), readinessEventChannel, &flutter::StandardMethodCodec::GetInstance()
-  );
-
-  eventChannel->SetStreamHandler(std::make_unique<flutter::StreamHandlerFunctions<>>(
-    [&](
-      const flutter::EncodableValue* /* arguments */, std::unique_ptr<flutter::EventSink<>>&& events
-    ) -> std::unique_ptr<flutter::StreamHandlerError<>> {
-      eventSink_ = std::move(events);
-      sendReadyEvent();  // Proactively send "ready" event
-      return nullptr;
-    },
-    [&](const flutter::EncodableValue* /* arguments */)
-      -> std::unique_ptr<flutter::StreamHandlerError<>> {
-      eventSink_ = nullptr;
-      return nullptr;
-    }
-  ));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Sister PR to: https://github.com/toyota-connected/tcna-packages/pull/52

Fixes readiness checks - before this Flutter would call the core APIs prematurely, causing nullptr crashes

Related to https://github.com/toyota-connected/fluorite/issues/12