### PR TITLE
codeql warning fix

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,9 @@
 name: "CodeQL Advanced"
 
 on:
+  push:
+    branches:
+      - v2.0
   pull_request:
     types: [ opened, synchronize, reopened, closed ]
   release:


### PR DESCRIPTION
-Resolve Unable to validate code scanning workflow: MissingPushHook