### PR TITLE
[filament_view] Fixes engine init

### DIFF
--- a/plugins/filament_view/core/scene/view_target.cc
+++ b/plugins/filament_view/core/scene/view_target.cc
@@ -213,8 +213,11 @@ void ViewTarget::setupView(uint32_t width, uint32_t height) {
 
   // fview_->setShadowingEnabled(false);
   // fview_->setScreenSpaceRefractionEnabled(false);
-  // fview_->setStencilBufferEnabled(false);
   // fview_->setDynamicLightingOptions(0.01, 1000.0f);
+
+  // NOTE: IMPORTANT! Filament doesn't allow stencil buffers on Metal/Vulkan
+  //       with Post-Processing enabled
+  fview_->setStencilBufferEnabled(false);
 
   ChangeQualitySettings(ViewTarget::ePredefinedQualitySettings::Ultra);
 
@@ -255,7 +258,6 @@ void ViewTarget::ChangeQualitySettings(const ePredefinedQualitySettings qualityS
       settings.dynamicLighting.zLightFar = 100.0f;
       settings.shadowType = filament::View::ShadowType::PCF;
       settings.renderQuality = {.hdrColorBuffer = filament::View::QualityLevel::LOW};
-      fview_->setStencilBufferEnabled(true);
       fview_->setScreenSpaceRefractionEnabled(false);
       break;
 
@@ -270,7 +272,6 @@ void ViewTarget::ChangeQualitySettings(const ePredefinedQualitySettings qualityS
       settings.dynamicLighting.zLightFar = 250.0f;
       settings.shadowType = filament::View::ShadowType::PCF;
       settings.renderQuality = {.hdrColorBuffer = filament::View::QualityLevel::HIGH};
-      fview_->setStencilBufferEnabled(true);
       fview_->setScreenSpaceRefractionEnabled(true);
       break;
 
@@ -288,7 +289,6 @@ void ViewTarget::ChangeQualitySettings(const ePredefinedQualitySettings qualityS
       settings.dynamicLighting.zLightFar = 500.0f;
       settings.shadowType = filament::View::ShadowType::PCF;
       settings.renderQuality = {.hdrColorBuffer = filament::View::QualityLevel::HIGH};
-      fview_->setStencilBufferEnabled(true);
       fview_->setScreenSpaceRefractionEnabled(true);
       break;
 
@@ -324,7 +324,6 @@ void ViewTarget::ChangeQualitySettings(const ePredefinedQualitySettings qualityS
       settings.ssao.bentNormals = true;
       settings.ssao.minHorizonAngleRad = 0.523599f;  // 30 degrees
       settings.ssao.ssct = {.enabled = false};
-      fview_->setStencilBufferEnabled(true);
       fview_->setScreenSpaceRefractionEnabled(true);
       break;
   }

--- a/plugins/filament_view/core/scene/view_target.cc
+++ b/plugins/filament_view/core/scene/view_target.cc
@@ -654,7 +654,12 @@ void ViewTarget::OnFrame(void* data, wl_callback* callback, const uint32_t time)
   // Wait for previous frame to complete
   // NOTE: this HAS to be done here, because the CallEvent above needs to complete on this thread
   //       so we need to give the event loop a chance to process it
-  if (!!obj->framePromise) obj->framePromise->get_future().wait();
+  if (!!obj->framePromise) {
+    // spdlog::debug("[OnFrame], waiting for previous frame to finish...", __FUNCTION__);
+    obj->framePromise->get_future().wait();
+  } else {
+    // spdlog::debug("[OnFrame], first frame!", __FUNCTION__);
+  }
 
   // Post and await promise
   const auto promise = std::make_shared<std::promise<void>>();
@@ -663,7 +668,7 @@ void ViewTarget::OnFrame(void* data, wl_callback* callback, const uint32_t time)
   // TODO: there's a 0.05ms lag when posting the task - SHOULDN'T HAPPEN!
   // NOTE: let's use separate strands for work and rendering?
   post(*ECSManager::GetInstance()->getStrand(), [data, obj, callback, time, promise] {
-    // spdlog::debug("=== (wl) callback start ===");
+    // spdlog::debug("[OnFrame] === (wl) callback start ===");
     obj->callback_ = nullptr;
 
     // std::lock_guard<std::mutex> lock(obj->frameLock_);
@@ -686,7 +691,7 @@ void ViewTarget::OnFrame(void* data, wl_callback* callback, const uint32_t time)
     // spdlog::debug("=== (wl) surface commit ===");
     // NOTE: DO NOT CALL wl_surface_commit, it already happens elsewhere
 
-    // spdlog::debug("=== (wl) callback end ===");
+    // spdlog::debug("[OnFrame] === (wl) callback end ===");
     promise->set_value();
   });
 

--- a/plugins/filament_view/core/scene/view_target.h
+++ b/plugins/filament_view/core/scene/view_target.h
@@ -52,9 +52,13 @@ class ViewTarget {
     ViewTarget& operator=(const ViewTarget&) = delete;
 
     void setInitialized() {
+      spdlog::debug(
+        "ViewTarget::setInitialized (previously {})", initialized_ ? "already true" : "false"
+      );
       if (initialized_) return;
 
       initialized_ = true;
+      spdlog::debug("ViewTarget::setInitialized calling OnFrame for the first time!");
       OnFrame(this, nullptr, 0);
     }
 

--- a/plugins/filament_view/core/systems/derived/view_target_system.cc
+++ b/plugins/filament_view/core/systems/derived/view_target_system.cc
@@ -301,6 +301,7 @@ ViewTarget* ViewTargetSystem::getViewTarget(size_t index) const {
 
 ////////////////////////////////////////////////////////////////////////////////////
 void ViewTargetSystem::KickOffFrameRenderingLoops() const {
+  spdlog::debug("Kicking off frame rendering loops for {} view targets", _viewTargets.size());
   for (const auto& viewTarget : _viewTargets) {
     viewTarget->setInitialized();
   }

--- a/plugins/filament_view/filament_view_plugin_c_api.cc
+++ b/plugins/filament_view/filament_view_plugin_c_api.cc
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
+#include <filament_view_plugin.h>
 #include <include/filament_view/filament_view_plugin_c_api.h>
 
+#include <core/systems/derived/view_target_system.h>
+#include <core/systems/ecs.h>
+
+#include <asio/post.hpp>
 #include <flutter/plugin_registrar.h>
 
-#include <core/systems/ecs.h>
-#include <filament_view_plugin.h>
+#include <future>
 
 void FilamentViewPluginCApiRegisterWithRegistrar(
   FlutterDesktopPluginRegistrarRef registrar,
@@ -63,7 +67,25 @@ void FilamentViewPluginCApiRegisterWithRegistrar(
   if (const auto ecs = plugin_filament_view::ECSManager::GetInstance();
       ecs->getRunState() == plugin_filament_view::ECSManager::RunState::Initialized) {
     ecs->debugPrint();
-    ecs->update(0.16f);
     // ecs->StartMainLoop();
+
+    /*
+     *  Indirectly kicks off the rendering loop by processing ViewTarget init requests
+     *  This has to be done on the rendering thread, so we post a task
+     */
+    // TODO: take care of this as part of https://github.com/toyota-connected/fluorite/issues/10
+    auto viewTargetSystem = ecs->getSystem<plugin_filament_view::ViewTargetSystem>(
+      "FilamentViewPluginCApiRegisterWithRegistrar"
+    );
+    std::promise<void> startupPromise;
+    auto startupFuture = startupPromise.get_future();
+    post(*ecs->getStrand(), [&viewTargetSystem, &startupPromise] {
+      spdlog::debug("== Starting ViewTargetSystem frame rendering loops ==");
+
+      viewTargetSystem->ProcessMessages();
+      startupPromise.set_value();
+    });
+
+    startupFuture.wait();
   }
 }


### PR DESCRIPTION
Fixes the engine not starting correctly due to:
- engine kickoff not happening on the render thread
- stencil buffer enabled with post-processing (not allowed on Vulkan&Metal)

Related to:
- https://github.com/toyota-connected/fluorite/issues/10
- https://github.com/toyota-connected/fluorite/issues/12
- https://github.com/toyota-connected/fluorite/issues/18

Suggested soundtrack for CI: https://www.youtube.com/watch?v=u3Ia847SoEU