### PR TITLE
[filament_view] Fixes linking with different build types

### DIFF
--- a/plugins/filament_view/CMakeLists.txt
+++ b/plugins/filament_view/CMakeLists.txt
@@ -69,7 +69,7 @@ target_link_libraries(filament INTERFACE
         toolchain::toolchain
 )
 # Include libmatdbg.a for debug builds
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+if (FILAMENT_BUILD_TYPE STREQUAL "Debug")
         target_link_libraries(filament INTERFACE libmatdbg.a)
 endif ()
 


### PR DESCRIPTION
🛑 **Don't merge before https://github.com/meta-flutter/workspace-automation/pull/128 !**

This is a compatibility fix for when this plugin is built with a different build type from Filament's, eg.:

> `./flutter_workspace.py --enable=filament --build-type desktop-homescreen:release,filament:debug`