### PR TITLE
feat: Prompt apps for permissions on startup similar to mobile

### DIFF
--- a/plugins/flatpak/CMakeLists.txt
+++ b/plugins/flatpak/CMakeLists.txt
@@ -30,6 +30,8 @@ add_library(plugin_flatpak STATIC
         screenshot.cc
         portals/portal_manager.cc
         portals/portal_proxy.cc
+        portals/access_portal/access_portal.cc
+        portals/access_portal/access_portal.h
 )
 target_include_directories(plugin_flatpak PRIVATE include)
 target_compile_options(plugin_flatpak PRIVATE

--- a/plugins/flatpak/flatpak_plugin.cc
+++ b/plugins/flatpak/flatpak_plugin.cc
@@ -16,19 +16,17 @@
 
 #include "flatpak_plugin.h"
 
-#include <filesystem>
 #include <sstream>
 #include <vector>
 
-#include <zlib.h>
 #include <asio/dispatch.hpp>
 #include <asio/post.hpp>
-#include <future>
 
 #include <flutter/plugin_registrar_homescreen.h>
 #include "messages.g.h"
 #include "plugins/common/common.h"
 #include "plugins/common/glib/main_loop.h"
+#include "standard_method_codec.h"
 
 namespace flatpak_plugin {
 
@@ -68,6 +66,8 @@ FlatpakPlugin::FlatpakPlugin(flutter::PluginRegistrar* registrar)
     }
   }
 
+  method_channel_ = std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(registrar_->messenger(),"flatpak_flutter",&flutter::StandardMethodCodec::GetInstance());
+
   shim_ = std::make_shared<FlatpakShim>(this, registrar_->messenger(),
                                         strand_.get());
   portal_manager_ = std::make_shared<PortalManager>(*io_context_);
@@ -94,6 +94,10 @@ FlatpakPlugin::~FlatpakPlugin() {
 void FlatpakPlugin::Init() {
   shim_->SetupTransactionEventChannel(registrar_->messenger());
   shim_->SetupAccessEventChannel(registrar_->messenger(),*strand_,portal_manager_.get());
+  // Setup Method channel to handle responses co
+  method_channel_->SetMethodCallHandler([this](const auto& call,std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
+    this->HandleMethodCall(call,std::move(result));
+  });
   spdlog::info("[FlatpakPlugin] Event channel Setup Complete");
 }
 
@@ -324,4 +328,18 @@ ErrorOr<bool> FlatpakPlugin::ApplicationStop(const std::string& id) {
   return FlatpakShim::ApplicationStop(id);
 }
 
+void FlatpakPlugin::HandleMethodCall(
+    const flutter::MethodCall<flutter::EncodableValue>& method,
+    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) const{
+
+  const auto& method_name = method.method_name();
+  spdlog::debug("[FlatpakPlugin] HandleMethodCall {}", method_name);
+
+  if (method_name == "permissionResponse" ||
+               method_name == "checkPermissions" ||
+               method_name == "grantPermission" ||
+               method_name == "revokePermission") {
+    shim_->HandleMethodCall(method, std::move(result));
+  }
+}
 }  // namespace flatpak_plugin

--- a/plugins/flatpak/flatpak_plugin.cc
+++ b/plugins/flatpak/flatpak_plugin.cc
@@ -66,7 +66,10 @@ FlatpakPlugin::FlatpakPlugin(flutter::PluginRegistrar* registrar)
     }
   }
 
-  method_channel_ = std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(registrar_->messenger(),"flatpak_flutter",&flutter::StandardMethodCodec::GetInstance());
+  method_channel_ =
+      std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+          registrar_->messenger(), "flatpak_flutter",
+          &flutter::StandardMethodCodec::GetInstance());
 
   shim_ = std::make_shared<FlatpakShim>(this, registrar_->messenger(),
                                         strand_.get());
@@ -93,11 +96,13 @@ FlatpakPlugin::~FlatpakPlugin() {
 
 void FlatpakPlugin::Init() {
   shim_->SetupTransactionEventChannel(registrar_->messenger());
-  shim_->SetupAccessEventChannel(registrar_->messenger(),*strand_,portal_manager_.get());
+  shim_->SetupAccessEventChannel(registrar_->messenger(), *strand_,
+                                 portal_manager_.get());
   // Setup Method channel to handle responses co
-  method_channel_->SetMethodCallHandler([this](const auto& call,std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
-    this->HandleMethodCall(call,std::move(result));
-  });
+  method_channel_->SetMethodCallHandler(
+      [this](const auto& call,
+             std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>>
+                 result) { this->HandleMethodCall(call, std::move(result)); });
   spdlog::info("[FlatpakPlugin] Event channel Setup Complete");
 }
 
@@ -330,15 +335,14 @@ ErrorOr<bool> FlatpakPlugin::ApplicationStop(const std::string& id) {
 
 void FlatpakPlugin::HandleMethodCall(
     const flutter::MethodCall<flutter::EncodableValue>& method,
-    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) const{
-
+    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result)
+    const {
   const auto& method_name = method.method_name();
   spdlog::debug("[FlatpakPlugin] HandleMethodCall {}", method_name);
 
   if (method_name == "permissionResponse" ||
-               method_name == "checkPermissions" ||
-               method_name == "grantPermission" ||
-               method_name == "revokePermission") {
+      method_name == "checkPermissions" || method_name == "grantPermission" ||
+      method_name == "revokePermission") {
     shim_->HandleMethodCall(method, std::move(result));
   }
 }

--- a/plugins/flatpak/flatpak_plugin.cc
+++ b/plugins/flatpak/flatpak_plugin.cc
@@ -96,8 +96,7 @@ FlatpakPlugin::~FlatpakPlugin() {
 
 void FlatpakPlugin::Init() {
   shim_->SetupTransactionEventChannel(registrar_->messenger());
-  shim_->SetupAccessEventChannel(registrar_->messenger(), *strand_,
-                                 portal_manager_.get());
+  shim_->SetupAccessEventChannel(registrar_->messenger(), *strand_);
   // Setup Method channel to handle responses co
   method_channel_->SetMethodCallHandler(
       [this](const auto& call,

--- a/plugins/flatpak/flatpak_plugin.cc
+++ b/plugins/flatpak/flatpak_plugin.cc
@@ -93,6 +93,7 @@ FlatpakPlugin::~FlatpakPlugin() {
 
 void FlatpakPlugin::Init() {
   shim_->SetupTransactionEventChannel(registrar_->messenger());
+  shim_->SetupAccessEventChannel(registrar_->messenger(),*strand_,portal_manager_.get());
   spdlog::info("[FlatpakPlugin] Event channel Setup Complete");
 }
 

--- a/plugins/flatpak/flatpak_plugin.h
+++ b/plugins/flatpak/flatpak_plugin.h
@@ -111,10 +111,14 @@ class FlatpakPlugin final : public flutter::Plugin, public FlatpakApi {
   std::unique_ptr<CacheManager> cache_manager_;
   std::shared_ptr<PortalManager> portal_manager_;
   std::shared_ptr<FlatpakShim> shim_;
-  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> method_channel_;
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
+      method_channel_;
   flutter::PluginRegistrar* registrar_;
 
-  void HandleMethodCall(const flutter::MethodCall<flutter::EncodableValue>& method, std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result)const;
+  void HandleMethodCall(
+      const flutter::MethodCall<flutter::EncodableValue>& method,
+      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result)
+      const;
 };
 }  // namespace flatpak_plugin
 

--- a/plugins/flatpak/flatpak_plugin.h
+++ b/plugins/flatpak/flatpak_plugin.h
@@ -24,6 +24,7 @@
 
 #include "flatpak_shim.h"
 #include "messages.g.h"
+#include "method_channel.h"
 #include "plugins/flatpak/cache/cache_manager.h"
 #include "plugins/flatpak/portals/portal_manager.h"
 
@@ -110,7 +111,10 @@ class FlatpakPlugin final : public flutter::Plugin, public FlatpakApi {
   std::unique_ptr<CacheManager> cache_manager_;
   std::shared_ptr<PortalManager> portal_manager_;
   std::shared_ptr<FlatpakShim> shim_;
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> method_channel_;
   flutter::PluginRegistrar* registrar_;
+
+  void HandleMethodCall(const flutter::MethodCall<flutter::EncodableValue>& method, std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result)const;
 };
 }  // namespace flatpak_plugin
 

--- a/plugins/flatpak/flatpak_shim.cc
+++ b/plugins/flatpak/flatpak_shim.cc
@@ -23,7 +23,6 @@
 #include <rapidjson/document.h>
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
 #include <sys/wait.h>
 #include <zlib.h>
 
@@ -1778,9 +1777,15 @@ void FlatpakShim::ApplicationStart(
   }
 
   spdlog::debug("[FlatpakPlugin] Starting application: {}", id);
-  asio::post(*strand_,[weak_self = weak_from_this(),id,portal_manager,completion_callback]() {
-    auto self = weak_self.lock();
-    // Check if the application is installed first
+  auto weak_self = weak_from_this();
+  auto self = weak_self.lock();
+  if (!self) {
+    completion_callback(ErrorOr<bool>(
+        FlutterError("CANCELLED", "Operation cancelled")));
+    return;
+  }
+
+  // Check if the application is installed first
   FlatpakInstalledRef* installed = nullptr;
   GError* error = nullptr;
   auto installation = flatpak_installation_new_user(nullptr, &error);
@@ -1901,13 +1906,14 @@ void FlatpakShim::ApplicationStart(
   g_object_ref(installation);
 
     struct LaunchState {
-            FlatpakInstalledRef* installed;
-            FlatpakInstallation* installation;
+            FlatpakInstalledRef* installed{};
+            FlatpakInstallation* installation{};
             std::string app_name;
             std::string arch;
             std::string branch;
             std::shared_ptr<PortalManager> portal_manager;
             std::function<void(const ErrorOr<bool>&)> callback;
+          asio::io_context::strand* strand{};
 
             ~LaunchState() {
                 if (installed) g_object_unref(installed);
@@ -1923,20 +1929,23 @@ void FlatpakShim::ApplicationStart(
         state->branch = found_branch;
         state->portal_manager = portal_manager;
         state->callback = completion_callback;
+  state->strand = &strand;
 
-  self->RequestAppLaunchPermission(found_app_name,installed,[weak_self,state](std::map<std::string,bool> permissions) {
-    auto self = weak_self.lock();
-                if (!self) {
-                    state->callback(ErrorOr<bool>(
-                        FlutterError("CANCELLED", "Operation cancelled")));
-                    return;
-                }
-
+    self->RequestAppLaunchPermission(
+              found_app_name,
+              installed,
+              [weak_self, state](const std::map<std::string, bool>& permissions) {
+                  auto self = weak_self.lock();
+                  if (!self) {
+                      state->callback(ErrorOr<bool>(
+                          FlutterError("CANCELLED", "Operation cancelled")));
+                      return;
+                  }
                 spdlog::info("[FlatpakPlugin] Permissions granted: {}",
                             permissions.size());
-    self->check_runtime(
-                    state->installed, state->installation, *(self->strand_),
-                    [weak_self, state](const ErrorOr<bool>& runtime_result) {
+                self->check_runtime(
+                                state->installed, state->installation, *(state->strand),
+                                [weak_self, state](const ErrorOr<bool>& runtime_result) {
                         auto self = weak_self.lock();
                         if (!self) {
                             state->callback(ErrorOr<bool>(
@@ -1957,8 +1966,8 @@ void FlatpakShim::ApplicationStart(
                         }
 
                         // Create sandbox
-                        self->create_sandbox(
-                            state->installed, *(self->strand_),
+                        flatpak_plugin::FlatpakShim::create_sandbox(
+                            state->installed, *(state->strand),
                             [weak_self, state](bool sandbox_success) {
                                 auto self = weak_self.lock();
                                 if (!self) {
@@ -2005,14 +2014,14 @@ void FlatpakShim::ApplicationStart(
 
                                     auto app_session =
                                         std::make_shared<MonitorSession>(
-                                            self->strand_, state->app_name,
+                                            state->strand, state->app_name,
                                             pid, state->portal_manager, instance);
 
-                                    // No mutex needed - on strand
-                                    self->active_sessions_[state->app_name] =
+
+                                    flatpak_plugin::FlatpakShim::active_sessions_[state->app_name] =
                                         app_session;
 
-                                    self->monitor_app(app_session);
+                                    flatpak_plugin::FlatpakShim::monitor_app(app_session);
                                     state->callback(ErrorOr<bool>(true));
                                     return;
                                 }
@@ -2024,7 +2033,6 @@ void FlatpakShim::ApplicationStart(
                             state->portal_manager.get());
                     });
             });
-    });
 }
 
 ErrorOr<bool> FlatpakShim::ApplicationStop(const std::string& id) {
@@ -3680,7 +3688,7 @@ void FlatpakShim::SetupTransactionEventChannel(
   }
 }
 
-void FlatpakShim::SetupAccessEventChannel(flutter::BinaryMessenger* messenger,asio::io_context::strand& strand,PortalManager* portal_manager) {
+void FlatpakShim::SetupAccessEventChannel(flutter::BinaryMessenger* messenger,const asio::io_context::strand& strand,PortalManager* portal_manager) {
   if (!messenger) {
     spdlog::error(
         "[FlatpakPlugin] Messenger is null, cannot setup event channel");
@@ -3782,7 +3790,7 @@ void FlatpakShim::SendTransactionEvent(flutter::EncodableMap& event) const {
   }
 }
 
-void FlatpakShim::SendPermissionEvent(const flutter::EncodableMap& event,std::function<void(bool)> callback) {
+void FlatpakShim::SendPermissionEvent(const flutter::EncodableMap& event,const std::function<void(bool)>& callback) {
   if (!access_sink_) {
     spdlog::error(
         "[FlatpakPlugin] Cannot send event - sink is null. "
@@ -4202,74 +4210,113 @@ std::string FlatpakShim::GenerateRequestId() {
 void FlatpakShim::CheckExistingPermissions(
     const std::string& app_id,
     const std::vector<std::string>& permissions,
-    std::function<void(std::map<std::string, bool>)> callback) {
+    const std::function<void(std::map<std::string, bool>)>& callback) const {
   if (permissions.empty()) {
     callback({});
     return;
   }
-    access_portal_->CheckAllPermissions(app_id,permissions,[callback](const std::map<std::string, AccessPortal::PermissionStatus>& statuses) {
-      std::map<std::string, bool> results;
-      for (const auto& [perm, status] : statuses) {
-                switch (status) {
-                    case AccessPortal::PermissionStatus::GRANTED:
-                    results[perm] = true;
-                    break;
 
-                  case AccessPortal::PermissionStatus::DENIED:
-                    results[perm] = false;
-                    break;
-
-                  case AccessPortal::PermissionStatus::ASK:
-
-                  case AccessPortal::PermissionStatus::NOT_SET:
-                    // Don't add to results - will be asked
-                    break;
-            }
-        }
+  access_portal_->CheckAllPermissions(
+      app_id,
+      permissions,
+      [callback](const std::map<std::string, flatpak_plugin::PermissionStatus>& statuses) {
+          std::map<std::string, bool> results;
+          for (const auto& [perm, status] : statuses) {
+              switch (status) {
+                case flatpak_plugin::PermissionStatus::GRANTED:
+                  results[perm] = true;
+                  break;
+                case flatpak_plugin::PermissionStatus::DENIED:
+                  results[perm] = false;
+                  break;
+                case flatpak_plugin::PermissionStatus::ASK:
+                case flatpak_plugin::PermissionStatus::NOT_SET:
+                  // Don't add to results
+                  break;
+          }
+      }
       callback(results);
-    });
+  });
 }
 
 void FlatpakShim::ShowNextDialog(const std::string& request_id) {
   flutter::EncodableMap event;
-    auto it = active_permissions_.find(request_id);
-    if (it == active_permissions_.end()) {
-      spdlog::error("[FlatpakPlugin] Failed to retrieve {} request for permission", request_id);
-      return;
+
+    std::string app_id;
+    std::string current_permission;
+    size_t permission_index;
+    size_t total_requests;
+    bool should_continue = false;
+
+    {
+        std::lock_guard<std::mutex> lock(permissions_mutex_);
+        auto it = active_permissions_.find(request_id);
+        if (it == active_permissions_.end()) {
+            spdlog::error("[FlatpakPlugin] Failed to retrieve {} request for permission",
+                         request_id);
+            return;
+        }
+
+        PermissionRequest& request = it->second;
+
+        // Check if all permissions processed
+        if (request.permission_index >= request.requests.size()) {
+            spdlog::debug("[FlatpakPlugin] All Permissions processed for {}",
+                         request.app_id);
+            auto callback = request.callback;
+            auto result = request.result;
+            active_permissions_.erase(it);
+
+            lock.~lock_guard();
+            callback(result);
+            return;
+        }
+
+        // Get current permission info
+        app_id = request.app_id;
+        current_permission = request.requests[request.permission_index];
+        permission_index = request.permission_index;
+        total_requests = request.requests.size();
+        should_continue = true;
     }
 
-    PermissionRequest& request = it->second;
+    if (!should_continue) return;
 
-    // check for next permission in queue
-    if (request.permission_index >= request.requests.size()) {
-      spdlog::debug("[FlatpakPlugin] All Permissions processed for {}",request.app_id);
-      request.callback(request.result);
-      active_permissions_.erase(it);
-      return;
-    }
+    event[flutter::EncodableValue("type")] =
+        flutter::EncodableValue("permission_dialog");
+    event[flutter::EncodableValue("request_id")] =
+        flutter::EncodableValue(request_id);
+    event[flutter::EncodableValue("app_id")] =
+        flutter::EncodableValue(app_id);
+    event[flutter::EncodableValue("permission")] =
+        flutter::EncodableValue(current_permission);
+    event[flutter::EncodableValue("progress")] =
+        flutter::EncodableValue(static_cast<int>(permission_index + 1));
+    event[flutter::EncodableValue("total")] =
+        flutter::EncodableValue(static_cast<int>(total_requests));
+    event[flutter::EncodableValue("timestamp")] =
+        flutter::EncodableValue(
+            std::chrono::system_clock::now().time_since_epoch().count());
 
-    std::string current_permission = request.requests[request.permission_index];
+    spdlog::debug("[FlatpakPlugin] Showing permission Dialog : {} {}/{}",
+                 current_permission, permission_index + 1, total_requests);
 
-    event[flutter::EncodableValue("type")] = flutter::EncodableValue("permission_dialog");
-    event[flutter::EncodableValue("request_id")] = flutter::EncodableValue(request_id);
-    event[flutter::EncodableValue("app_id")] = flutter::EncodableValue(request.app_id);
-    event[flutter::EncodableValue("permission")] = flutter::EncodableValue(current_permission);
-    event[flutter::EncodableValue("progress")] = flutter::EncodableValue(static_cast<int>(request.permission_index + 1));
-    event[flutter::EncodableValue("total")] = flutter::EncodableValue(static_cast<int>(request.requests.size()));
-    event[flutter::EncodableValue("timestamp")] = flutter::EncodableValue(std::chrono::system_clock::now().time_since_epoch().count());
-    spdlog::debug("[FlatpakPlugin] Showing permission Dialog : {} {}/{}",current_permission,request.permission_index+1,request.requests.size());
-  SendPermissionEvent(event, [weak_self = weak_from_this(), request_id]
-                           (bool success) {
+    SendPermissionEvent(event, [weak_self = weak_from_this(), request_id]
+                        (bool success) {
         if (!success) {
             auto self = weak_self.lock();
             if (!self) return;
 
             spdlog::error("[FlatpakPlugin] Failed to show dialog");
 
+            std::lock_guard<std::mutex> lock(self->permissions_mutex_);
             auto it = self->active_permissions_.find(request_id);
             if (it != self->active_permissions_.end()) {
-                it->second.callback({});
+                auto callback = it->second.callback;
                 self->active_permissions_.erase(it);
+
+                lock.~lock_guard();
+                callback({});
             }
         }
     });
@@ -4290,32 +4337,35 @@ void FlatpakShim::HandlePermissionResponse(const std::string& request_id,
 
   // Retrieve app id from requests
   std::string app_id;
+  {
+   std::lock_guard<std::mutex> lock(permissions_mutex_);
    auto it = active_permissions_.find(request_id);
    if (it != active_permissions_.end()) {
      app_id = it->second.app_id;
      it->second.result[permission] = granted;
      it->second.permission_index++;
    }
+  }
 
   if (!app_id.empty()) {
     access_portal_->SetPermission(
-        table, permission, app_id,
-        {granted ? "yes" : "no"},
-        [weak_self = weak_from_this(), request_id, permission, granted]
-        (bool success) {
-            auto self = weak_self.lock();
-            if (!self) return;
+            table, permission, app_id,
+            {granted ? "yes" : "no"},
+            [weak_self = weak_from_this(), request_id, permission, granted]
+            (bool success) {
+                auto self = weak_self.lock();
+                if (!self) return;
 
-            if (success) {
-                spdlog::debug("[FlatpakPlugin] Stored: {} -> {}",
-                            permission, granted ? "granted" : "denied");
-            } else {
-                spdlog::error("[FlatpakPlugin] Failed to store permission");
-            }
+                if (success) {
+                    spdlog::debug("[FlatpakPlugin] Stored: {} -> {}",
+                                permission, granted ? "granted" : "denied");
+                } else {
+                    spdlog::error("[FlatpakPlugin] Failed to store permission");
+                }
 
-            // Show next dialog
-            self->ShowNextDialog(request_id);
-        });
+                // Show next dialog
+                self->ShowNextDialog(request_id);
+            });
   }
 }
 
@@ -4377,35 +4427,51 @@ void FlatpakShim::RequestAppLaunchPermission(
 
   spdlog::info("[FlatpakPlugin] Check Existing permissions for app : {}",app_id);
 
-  CheckExistingPermissions(app_id,requested_permissions,[this,app_id,requested_permissions,callback](std::map<std::string,bool> permissions) {
-    std::vector<std::string> permissions_to_ask;
-    std::map<std::string,bool> final_results = permissions;
+  CheckExistingPermissions(
+        app_id,
+        requested_permissions,
+        [weak_self = weak_from_this(), app_id, requested_permissions, callback]
+        (std::map<std::string, bool> permissions) {
+            auto self = weak_self.lock();
+            if (!self) {
+                callback({});
+                return;
+            }
 
-    for (const auto& perm: requested_permissions) {
-      if (permissions.find(perm) == permissions.end()) {
-        permissions_to_ask.emplace_back(perm);
-      }
-    }
+            std::vector<std::string> permissions_to_ask;
+            std::map<std::string, bool> final_results = permissions;
 
-    if (permissions_to_ask.empty()) {
-      spdlog::info("[FlatpakPlugin] No permissions needed to ask for app : {}",app_id);
-      callback(final_results);
-      return;
-    }
+            for (const auto& perm: requested_permissions) {
+                if (permissions.find(perm) == permissions.end()) {
+                    permissions_to_ask.emplace_back(perm);
+                }
+            }
 
-    std::string request_id = GenerateRequestId();
+            if (permissions_to_ask.empty()) {
+                spdlog::info("[FlatpakPlugin] No permissions needed to ask for app : {}",
+                           app_id);
+                callback(final_results);
+                return;
+            }
 
-    PermissionRequest request;
-    request.app_id = app_id;
-    request.result = final_results;
-    request.permission_index = 0;
-    request.requests = permissions_to_ask;
-    request.callback = callback;
+            std::string request_id = flatpak_plugin::FlatpakShim::GenerateRequestId();
 
-    active_permissions_[request_id] = std::move(request);
-    spdlog::info("[FlatpakPlugin] Starting Permissions dialog for {} permission",permissions_to_ask.size());
-    ShowNextDialog(request_id);
-  });
+            PermissionRequest request;
+            request.app_id = app_id;
+            request.result = final_results;
+            request.permission_index = 0;
+            request.requests = permissions_to_ask;
+            request.callback = callback;
+
+            {
+                std::lock_guard<std::mutex> lock(self->permissions_mutex_);
+                self->active_permissions_[request_id] = std::move(request);
+            }
+
+            spdlog::info("[FlatpakPlugin] Starting Permissions dialog for {} permission",
+                       permissions_to_ask.size());
+            self->ShowNextDialog(request_id);
+        });
 }
 
 void FlatpakShim::HandleMethodCall(
@@ -4448,6 +4514,21 @@ void FlatpakShim::HandleMethodCall(
     result->Success();
     return;
   }
+    // TODO: Handle other methods.
+    if (method_name == "checkPermissions") {
+            result->NotImplemented();
+            return;
+        }
+
+        if (method_name == "grantPermission") {
+            result->NotImplemented();
+            return;
+        }
+
+        if (method_name == "revokePermission") {
+            result->NotImplemented();
+            return;
+        }
     result->NotImplemented();
   });
 }

--- a/plugins/flatpak/flatpak_shim.cc
+++ b/plugins/flatpak/flatpak_shim.cc
@@ -3680,8 +3680,7 @@ void FlatpakShim::SetupTransactionEventChannel(
 
 void FlatpakShim::SetupAccessEventChannel(
     flutter::BinaryMessenger* messenger,
-    const asio::io_context::strand& strand,
-    PortalManager* portal_manager) {
+    const asio::io_context::strand& strand) {
   if (!messenger) {
     spdlog::error(
         "[FlatpakPlugin] Messenger is null, cannot setup event channel");
@@ -3742,8 +3741,7 @@ void FlatpakShim::SetupAccessEventChannel(
               return nullptr;
             }));
 
-    access_portal_ = std::make_unique<AccessPortal>(
-        portal_manager, strand.context(), *access_event_channel_);
+    access_portal_ = std::make_unique<AccessPortal>(strand.context());
     spdlog::info("[FlatpakPlugin] Access portal created and initialized");
   } catch (const std::exception& e) {
     spdlog::error("[FlatpakPlugin] Exception setting up event channel: {}",

--- a/plugins/flatpak/flatpak_shim.cc
+++ b/plugins/flatpak/flatpak_shim.cc
@@ -1778,8 +1778,9 @@ void FlatpakShim::ApplicationStart(
   }
 
   spdlog::debug("[FlatpakPlugin] Starting application: {}", id);
-
-  // Check if the application is installed first
+  asio::post(*strand_,[weak_self = weak_from_this(),id,portal_manager,completion_callback]() {
+    auto self = weak_self.lock();
+    // Check if the application is installed first
   FlatpakInstalledRef* installed = nullptr;
   GError* error = nullptr;
   auto installation = flatpak_installation_new_user(nullptr, &error);
@@ -1899,93 +1900,131 @@ void FlatpakShim::ApplicationStart(
   g_object_ref(installed);
   g_object_ref(installation);
 
-  check_runtime(
-      installed, installation, strand,
-      [completion_callback, installed, installation, found_app_name, found_arch,
-       found_branch, portal_manager,
-       strand_ptr = &strand](const ErrorOr<bool>& runtime_result) {
-        if (runtime_result.has_error()) {
-          spdlog::error("[FlatpakPlugin] Runtime check failed: {}",
-                        runtime_result.error().message());
-          g_object_unref(installed);
-          g_object_unref(installation);
-          completion_callback(runtime_result);
-          return;
-        }
+    struct LaunchState {
+            FlatpakInstalledRef* installed;
+            FlatpakInstallation* installation;
+            std::string app_name;
+            std::string arch;
+            std::string branch;
+            std::shared_ptr<PortalManager> portal_manager;
+            std::function<void(const ErrorOr<bool>&)> callback;
 
-        if (!runtime_result.value()) {
-          spdlog::error("[FlatpakPlugin] Runtime not available for app");
-          g_object_unref(installed);
-          g_object_unref(installation);
-          completion_callback(ErrorOr<bool>(
-              FlutterError("RUNTIME_ERROR", "Runtime not available for app")));
-          return;
-        }
+            ~LaunchState() {
+                if (installed) g_object_unref(installed);
+                if (installation) g_object_unref(installation);
+            }
+        };
 
-        create_sandbox(
-            installed, *strand_ptr,
-            [completion_callback, installation, found_app_name, found_arch,
-             found_branch, portal_manager, installed,
-             strand_ptr](bool sandbox_success) {
-              if (!sandbox_success) {
-                spdlog::error("[FlatpakPlugin] Failed to create sandbox");
-                g_object_unref(installed);
-                g_object_unref(installation);
-                completion_callback(ErrorOr<bool>(
-                    FlutterError("START_FAILED", "Failed to create sandbox")));
-                return;
-              }
+        auto state = std::make_shared<LaunchState>();
+        state->installed = installed;
+        state->installation = installation;
+        state->app_name = found_app_name;
+        state->arch = found_arch;
+        state->branch = found_branch;
+        state->portal_manager = portal_manager;
+        state->callback = completion_callback;
 
-              // Launch the application
-              GError* error = nullptr;
-              FlatpakInstance* instance = nullptr;
-              flatpak_installation_launch_full(
-                  installation, FLATPAK_LAUNCH_FLAGS_DO_NOT_REAP,
-                  found_app_name.c_str(), found_arch.c_str(),
-                  found_branch.c_str(), nullptr, &instance, nullptr, &error);
-
-              if (error) {
-                spdlog::error("[FlatpakPlugin] Failed to launch app: {}",
-                              error->message);
-                g_clear_error(&error);
-                g_object_unref(installed);
-                g_object_unref(installation);
-                completion_callback(ErrorOr<bool>(FlutterError(
-                    "START_FAILED", "Failed to launch application")));
-                return;
-              }
-
-              if (instance) {
-                pid_t pid = flatpak_instance_get_pid(instance);
-                spdlog::info(
-                    "[FlatpakPlugin] Successfully launched: {} (PID: {})",
-                    found_app_name, pid);
-
-                auto app_session = std::make_shared<MonitorSession>(
-                    strand_ptr, found_app_name, pid, portal_manager, instance);
-
-                {
-                  std::lock_guard<std::mutex> lock(monitor_mutex_);
-                  active_sessions_[found_app_name] = app_session;
+  self->RequestAppLaunchPermission(found_app_name,installed,[weak_self,state](std::map<std::string,bool> permissions) {
+    auto self = weak_self.lock();
+                if (!self) {
+                    state->callback(ErrorOr<bool>(
+                        FlutterError("CANCELLED", "Operation cancelled")));
+                    return;
                 }
 
-                monitor_app(app_session);
+                spdlog::info("[FlatpakPlugin] Permissions granted: {}",
+                            permissions.size());
+    self->check_runtime(
+                    state->installed, state->installation, *(self->strand_),
+                    [weak_self, state](const ErrorOr<bool>& runtime_result) {
+                        auto self = weak_self.lock();
+                        if (!self) {
+                            state->callback(ErrorOr<bool>(
+                                FlutterError("CANCELLED", "Operation cancelled")));
+                            return;
+                        }
 
-                g_object_unref(installed);
-                g_object_unref(installation);
+                        if (runtime_result.has_error()) {
+                            state->callback(runtime_result);
+                            return;
+                        }
 
-                completion_callback(ErrorOr<bool>(true));
-                return;
-              }
+                        if (!runtime_result.value()) {
+                            state->callback(ErrorOr<bool>(
+                                FlutterError("RUNTIME_ERROR",
+                                           "Runtime not available")));
+                            return;
+                        }
 
-              spdlog::error("[FlatpakPlugin] Failed to get instance");
-              g_object_unref(installed);
-              g_object_unref(installation);
-              completion_callback(ErrorOr<bool>(
-                  FlutterError("START_FAILED", "Failed to get instance")));
-            },
-            portal_manager.get());
-      });
+                        // Create sandbox
+                        self->create_sandbox(
+                            state->installed, *(self->strand_),
+                            [weak_self, state](bool sandbox_success) {
+                                auto self = weak_self.lock();
+                                if (!self) {
+                                    state->callback(ErrorOr<bool>(
+                                        FlutterError("CANCELLED",
+                                                   "Operation cancelled")));
+                                    return;
+                                }
+
+                                if (!sandbox_success) {
+                                    state->callback(ErrorOr<bool>(
+                                        FlutterError("START_FAILED",
+                                                   "Failed to create sandbox")));
+                                    return;
+                                }
+
+                                // Launch application
+                                GError* error = nullptr;
+                                FlatpakInstance* instance = nullptr;
+                                flatpak_installation_launch_full(
+                                    state->installation,
+                                    FLATPAK_LAUNCH_FLAGS_DO_NOT_REAP,
+                                    state->app_name.c_str(),
+                                    state->arch.c_str(),
+                                    state->branch.c_str(),
+                                    nullptr, &instance, nullptr, &error);
+
+                                if (error) {
+                                    spdlog::error(
+                                        "[FlatpakShim] Failed to launch: {}",
+                                        error->message);
+                                    g_clear_error(&error);
+                                    state->callback(ErrorOr<bool>(
+                                        FlutterError("START_FAILED",
+                                                   "Failed to launch")));
+                                    return;
+                                }
+
+                                if (instance) {
+                                    pid_t pid = flatpak_instance_get_pid(instance);
+                                    spdlog::info(
+                                        "[FlatpakShim] Launched: {} (PID: {})",
+                                        state->app_name, pid);
+
+                                    auto app_session =
+                                        std::make_shared<MonitorSession>(
+                                            self->strand_, state->app_name,
+                                            pid, state->portal_manager, instance);
+
+                                    // No mutex needed - on strand
+                                    self->active_sessions_[state->app_name] =
+                                        app_session;
+
+                                    self->monitor_app(app_session);
+                                    state->callback(ErrorOr<bool>(true));
+                                    return;
+                                }
+
+                                state->callback(ErrorOr<bool>(
+                                    FlutterError("START_FAILED",
+                                               "Failed to get instance")));
+                            },
+                            state->portal_manager.get());
+                    });
+            });
+    });
 }
 
 ErrorOr<bool> FlatpakShim::ApplicationStop(const std::string& id) {
@@ -2857,7 +2896,19 @@ void FlatpakShim::setup_portal_sessions(
     const std::function<void(ErrorOr<bool>)>& callback) {
   std::vector<PortalInterface> interfaces;
 
+  // setup access portal to launch first
+  PortalInterface access_portal_interface;
+  access_portal_interface.bus_type = BUS_TYPE::SESSION;
+  access_portal_interface.interface_name = "org.freedesktop.impl.portal.Access";
+  access_portal_interface.object_path = "/org/freedesktop/portal/desktop";
+  access_portal_interface.service_name = "org.freedesktop.portal.desktop";
+  interfaces.push_back(access_portal_interface);
+
   for (const auto& interface : configs.session_bus) {
+    if (interface == "org.freedesktop.impl.portal.Access") {
+      continue;
+    }
+
     PortalInterface portal;
     portal.interface_name = interface;
     portal.bus_type = BUS_TYPE::SESSION;
@@ -3629,6 +3680,76 @@ void FlatpakShim::SetupTransactionEventChannel(
   }
 }
 
+void FlatpakShim::SetupAccessEventChannel(flutter::BinaryMessenger* messenger,asio::io_context::strand& strand,PortalManager* portal_manager) {
+  if (!messenger) {
+    spdlog::error(
+        "[FlatpakPlugin] Messenger is null, cannot setup event channel");
+    return;
+  }
+
+  if (access_event_channel_) {
+    spdlog::error(
+        "[FlatpakPlugin] Event channel already exists, "
+        "re-registering stream handler");
+    return;
+  }
+  try {
+    access_event_channel_ =
+        std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
+            messenger, "flutter.io/flatpakPlugin/accessEvents",
+            &flutter::StandardMethodCodec::GetInstance());
+
+    spdlog::info(
+        "[FlatpakPlugin] Channel name: "
+        "flutter.io/flatpakPlugin/accessEvents");
+
+    access_event_channel_->SetStreamHandler(
+        std::make_unique<
+            flutter::StreamHandlerFunctions<flutter::EncodableValue>>(
+            // onListen callback
+            [this](
+                const flutter::EncodableValue* /* arguments */,
+                std::unique_ptr<flutter::EventSink<flutter::EncodableValue>>&&
+                    events)
+                -> std::unique_ptr<
+                    flutter::StreamHandlerError<flutter::EncodableValue>> {
+              {
+                std::lock_guard<std::mutex> lock(access_sink_mutex_);
+                access_sink_ = std::move(events);
+                spdlog::info("[FlatpakPlugin] Event sink connected");
+              }
+
+              // Send connection confirmation event
+              flutter::EncodableMap test_event;
+              test_event[flutter::EncodableValue("type")] =
+                  flutter::EncodableValue("connection_established");
+              test_event[flutter::EncodableValue("message")] =
+                  flutter::EncodableValue("Event channel ready");
+              SendTransactionEvent(test_event);
+
+              return nullptr;
+            },
+            // onCancel callback
+            [this](const flutter::EncodableValue* /* arguments */)
+                -> std::unique_ptr<
+                    flutter::StreamHandlerError<flutter::EncodableValue>> {
+              {
+                std::lock_guard<std::mutex> lock(access_sink_mutex_);
+                access_sink_ = nullptr;
+                spdlog::info("[FlatpakPlugin] Event sink disconnected");
+              }
+              return nullptr;
+            }));
+
+    access_portal_ = std::make_unique<AccessPortal>(portal_manager,strand.context(),*access_event_channel_);
+    spdlog::info("[FlatpakPlugin] Access portal created and initialized");
+  } catch (const std::exception& e) {
+    spdlog::error("[FlatpakPlugin] Exception setting up event channel: {}",
+                  e.what());
+    return;
+  }
+}
+
 void FlatpakShim::SendTransactionEvent(flutter::EncodableMap& event) const {
   std::lock_guard<std::mutex> lock(event_sink_mutex_);
 
@@ -3660,6 +3781,45 @@ void FlatpakShim::SendTransactionEvent(flutter::EncodableMap& event) const {
     spdlog::error("[FlatpakPlugin] Exception sending event: {}", e.what());
   }
 }
+
+void FlatpakShim::SendPermissionEvent(const flutter::EncodableMap& event,std::function<void(bool)> callback) {
+  if (!access_sink_) {
+    spdlog::error(
+        "[FlatpakPlugin] Cannot send event - sink is null. "
+        "Flutter may not be listening yet.");
+    if (event.count(flutter::EncodableValue("request_id"))) {
+      auto request_id = std::get_if<std::string>(
+          &event.at(flutter::EncodableValue("request_id")));
+      auto permission = std::get_if<std::string>(
+          &event.at(flutter::EncodableValue("permission")));
+
+      if (request_id && permission) {
+        HandlePermissionResponse(*request_id, *permission, false);
+      }
+    }
+    if (callback) callback(false);
+    return;
+  }
+
+  try {
+    access_sink_->Success(flutter::EncodableValue(event));
+    if (callback) callback(true);
+  } catch (const std::exception& e) {
+    spdlog::error("[FlatpakPlugin] Exception sending event: {}", e.what());
+    if (event.count(flutter::EncodableValue("request_id"))) {
+      auto request_id = std::get_if<std::string>(
+          &event.at(flutter::EncodableValue("request_id")));
+      auto permission = std::get_if<std::string>(
+          &event.at(flutter::EncodableValue("permission")));
+
+      if (request_id && permission) {
+        HandlePermissionResponse(*request_id, *permission, false);
+      }
+    }
+    if (callback) callback(false);
+  }
+}
+
 
 void FlatpakShim::OnProgressChanged(FlatpakTransactionProgress* progress,
                                     gpointer user_data) {
@@ -4033,4 +4193,262 @@ bool FlatpakShim::check_desk_usage(FlatpakInstallation* installation,
   return true;
 }
 
+std::string FlatpakShim::GenerateRequestId() {
+ auto now = std::chrono::system_clock::now();
+  auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
+  return "req_" + std::to_string(ms);
+}
+
+void FlatpakShim::CheckExistingPermissions(
+    const std::string& app_id,
+    const std::vector<std::string>& permissions,
+    std::function<void(std::map<std::string, bool>)> callback) {
+  if (permissions.empty()) {
+    callback({});
+    return;
+  }
+    access_portal_->CheckAllPermissions(app_id,permissions,[callback](const std::map<std::string, AccessPortal::PermissionStatus>& statuses) {
+      std::map<std::string, bool> results;
+      for (const auto& [perm, status] : statuses) {
+                switch (status) {
+                    case AccessPortal::PermissionStatus::GRANTED:
+                    results[perm] = true;
+                    break;
+
+                  case AccessPortal::PermissionStatus::DENIED:
+                    results[perm] = false;
+                    break;
+
+                  case AccessPortal::PermissionStatus::ASK:
+
+                  case AccessPortal::PermissionStatus::NOT_SET:
+                    // Don't add to results - will be asked
+                    break;
+            }
+        }
+      callback(results);
+    });
+}
+
+void FlatpakShim::ShowNextDialog(const std::string& request_id) {
+  flutter::EncodableMap event;
+    auto it = active_permissions_.find(request_id);
+    if (it == active_permissions_.end()) {
+      spdlog::error("[FlatpakPlugin] Failed to retrieve {} request for permission", request_id);
+      return;
+    }
+
+    PermissionRequest& request = it->second;
+
+    // check for next permission in queue
+    if (request.permission_index >= request.requests.size()) {
+      spdlog::debug("[FlatpakPlugin] All Permissions processed for {}",request.app_id);
+      request.callback(request.result);
+      active_permissions_.erase(it);
+      return;
+    }
+
+    std::string current_permission = request.requests[request.permission_index];
+
+    event[flutter::EncodableValue("type")] = flutter::EncodableValue("permission_dialog");
+    event[flutter::EncodableValue("request_id")] = flutter::EncodableValue(request_id);
+    event[flutter::EncodableValue("app_id")] = flutter::EncodableValue(request.app_id);
+    event[flutter::EncodableValue("permission")] = flutter::EncodableValue(current_permission);
+    event[flutter::EncodableValue("progress")] = flutter::EncodableValue(static_cast<int>(request.permission_index + 1));
+    event[flutter::EncodableValue("total")] = flutter::EncodableValue(static_cast<int>(request.requests.size()));
+    event[flutter::EncodableValue("timestamp")] = flutter::EncodableValue(std::chrono::system_clock::now().time_since_epoch().count());
+    spdlog::debug("[FlatpakPlugin] Showing permission Dialog : {} {}/{}",current_permission,request.permission_index+1,request.requests.size());
+  SendPermissionEvent(event, [weak_self = weak_from_this(), request_id]
+                           (bool success) {
+        if (!success) {
+            auto self = weak_self.lock();
+            if (!self) return;
+
+            spdlog::error("[FlatpakPlugin] Failed to show dialog");
+
+            auto it = self->active_permissions_.find(request_id);
+            if (it != self->active_permissions_.end()) {
+                it->second.callback({});
+                self->active_permissions_.erase(it);
+            }
+        }
+    });
+}
+
+void FlatpakShim::HandlePermissionResponse(const std::string& request_id,
+                                           const std::string& permission,
+                                           bool granted) {
+ spdlog::debug("[FlatpakPlugin] Permission response : {} -> {}" , permission,granted? "granted" : "denied");
+  std::string table = "devices";
+  if (permission == "location") {
+    table = "location";
+  } else if (permission == "notifications") {
+    table = "notifications";
+  } else if (permission == "background") {
+    table = "background";
+  }
+
+  // Retrieve app id from requests
+  std::string app_id;
+   auto it = active_permissions_.find(request_id);
+   if (it != active_permissions_.end()) {
+     app_id = it->second.app_id;
+     it->second.result[permission] = granted;
+     it->second.permission_index++;
+   }
+
+  if (!app_id.empty()) {
+    access_portal_->SetPermission(
+        table, permission, app_id,
+        {granted ? "yes" : "no"},
+        [weak_self = weak_from_this(), request_id, permission, granted]
+        (bool success) {
+            auto self = weak_self.lock();
+            if (!self) return;
+
+            if (success) {
+                spdlog::debug("[FlatpakPlugin] Stored: {} -> {}",
+                            permission, granted ? "granted" : "denied");
+            } else {
+                spdlog::error("[FlatpakPlugin] Failed to store permission");
+            }
+
+            // Show next dialog
+            self->ShowNextDialog(request_id);
+        });
+  }
+}
+
+void FlatpakShim::RequestAppLaunchPermission(
+    const std::string& app_id,
+    FlatpakInstalledRef* installed_ref,
+    const std::function<void(const std::map<std::string, bool>&)>& callback) {
+  if (!access_portal_) {
+    spdlog::error("[FlatpakPlugin] Access portal not initialized");
+    callback({});
+    return;
+  }
+  const std::string metadata = get_metadata_as_string(installed_ref);
+  const FlatpakShim::sandbox sandbox = parse_metadata(metadata);
+  std::vector<std::string> requested_permissions;
+
+  for (const auto& dev: sandbox.context.devices) {
+    if (dev == "all") {
+      requested_permissions.emplace_back("microphone");
+      requested_permissions.emplace_back("speakers");
+      requested_permissions.emplace_back("camera");
+      break;
+    }
+  }
+
+  for (const auto& sock: sandbox.context.sockets) {
+    if (sock == "pulseaudio") {
+      auto it = std::find(requested_permissions.begin(),requested_permissions.end(),"microphone");
+      if (it == requested_permissions.end()) {
+        requested_permissions.emplace_back("microphone");
+        requested_permissions.emplace_back("speakers");
+      }
+      break;
+    }
+  }
+  for (const auto& bus: sandbox.session_bus) {
+    if (bus == "org.freedesktop.Notifications") {
+      requested_permissions.emplace_back("notifications");
+    }
+    else if (bus == "org.freedesktop.portal.Usb") {
+      requested_permissions.emplace_back("usb");
+    }
+    else if (bus == "org.freedesktop.portal.Location") {
+      requested_permissions.emplace_back("location");
+    }
+    else if (bus == "org.freedesktop.portal.Camera") {
+      auto it = std::find(requested_permissions.begin(),requested_permissions.end(),"camera");
+      if (it == requested_permissions.end()) {
+        requested_permissions.emplace_back("camera");
+      }
+    }
+  }
+
+  if (requested_permissions.empty()) {
+    spdlog::info("[FlatpakPlugin] No permissions needed for app : {}",app_id);
+    callback({});
+    return;
+  }
+
+  spdlog::info("[FlatpakPlugin] Check Existing permissions for app : {}",app_id);
+
+  CheckExistingPermissions(app_id,requested_permissions,[this,app_id,requested_permissions,callback](std::map<std::string,bool> permissions) {
+    std::vector<std::string> permissions_to_ask;
+    std::map<std::string,bool> final_results = permissions;
+
+    for (const auto& perm: requested_permissions) {
+      if (permissions.find(perm) == permissions.end()) {
+        permissions_to_ask.emplace_back(perm);
+      }
+    }
+
+    if (permissions_to_ask.empty()) {
+      spdlog::info("[FlatpakPlugin] No permissions needed to ask for app : {}",app_id);
+      callback(final_results);
+      return;
+    }
+
+    std::string request_id = GenerateRequestId();
+
+    PermissionRequest request;
+    request.app_id = app_id;
+    request.result = final_results;
+    request.permission_index = 0;
+    request.requests = permissions_to_ask;
+    request.callback = callback;
+
+    active_permissions_[request_id] = std::move(request);
+    spdlog::info("[FlatpakPlugin] Starting Permissions dialog for {} permission",permissions_to_ask.size());
+    ShowNextDialog(request_id);
+  });
+}
+
+void FlatpakShim::HandleMethodCall(
+    const flutter::MethodCall<flutter::EncodableValue>& method_call,
+    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
+  asio::post(*strand_, [weak_self = weak_from_this(),
+                          method_name = method_call.method_name(),
+                          arguments = method_call.arguments() ?
+                              *method_call.arguments() : flutter::EncodableValue(),
+                          result = std::move(result)]() mutable {
+    auto self = weak_self.lock();
+    if (!self) {
+        result->Error("CANCELLED", "Operation cancelled");
+        return;
+    }
+    const auto* args = std::get_if<flutter::EncodableMap>(&arguments);
+
+  if (method_name == "permissionResponse") {
+    if (!args) {
+      result->Error("INVALID_ARGUMENT","argument is not map");
+      return;
+    }
+    auto request_id_it = args->find(flutter::EncodableValue("request_id"));
+    auto permission_it = args->find(flutter::EncodableValue("permission"));
+    auto granted_it = args->find(flutter::EncodableValue("granted"));
+    if (request_id_it == args->end() || permission_it == args->end() || granted_it == args->end()) {
+      result->Error("MISSING_FIELDS","request_id ,permission or granted is missing");
+      return;
+    }
+
+    auto* request_id = std::get_if<std::string>(&request_id_it->second);
+    auto* permission = std::get_if<std::string>(&permission_it->second);
+    auto* granted = std::get_if<bool>(&granted_it->second);
+
+    if (!request_id || !permission || !granted) {
+      result->Error("INVALID_TYPES","invalid arguments types");
+      return;
+    }
+    self->HandlePermissionResponse(*request_id,*permission,*granted);
+    result->Success();
+    return;
+  }
+    result->NotImplemented();
+  });
+}
 }  // namespace flatpak_plugin

--- a/plugins/flatpak/flatpak_shim.cc
+++ b/plugins/flatpak/flatpak_shim.cc
@@ -1780,8 +1780,8 @@ void FlatpakShim::ApplicationStart(
   auto weak_self = weak_from_this();
   auto self = weak_self.lock();
   if (!self) {
-    completion_callback(ErrorOr<bool>(
-        FlutterError("CANCELLED", "Operation cancelled")));
+    completion_callback(
+        ErrorOr<bool>(FlutterError("CANCELLED", "Operation cancelled")));
     return;
   }
 
@@ -1905,134 +1905,124 @@ void FlatpakShim::ApplicationStart(
   g_object_ref(installed);
   g_object_ref(installation);
 
-    struct LaunchState {
-            FlatpakInstalledRef* installed{};
-            FlatpakInstallation* installation{};
-            std::string app_name;
-            std::string arch;
-            std::string branch;
-            std::shared_ptr<PortalManager> portal_manager;
-            std::function<void(const ErrorOr<bool>&)> callback;
-          asio::io_context::strand* strand{};
+  struct LaunchState {
+    FlatpakInstalledRef* installed{};
+    FlatpakInstallation* installation{};
+    std::string app_name;
+    std::string arch;
+    std::string branch;
+    std::shared_ptr<PortalManager> portal_manager;
+    std::function<void(const ErrorOr<bool>&)> callback;
+    asio::io_context::strand* strand{};
 
-            ~LaunchState() {
-                if (installed) g_object_unref(installed);
-                if (installation) g_object_unref(installation);
-            }
-        };
+    ~LaunchState() {
+      if (installed)
+        g_object_unref(installed);
+      if (installation)
+        g_object_unref(installation);
+    }
+  };
 
-        auto state = std::make_shared<LaunchState>();
-        state->installed = installed;
-        state->installation = installation;
-        state->app_name = found_app_name;
-        state->arch = found_arch;
-        state->branch = found_branch;
-        state->portal_manager = portal_manager;
-        state->callback = completion_callback;
+  auto state = std::make_shared<LaunchState>();
+  state->installed = installed;
+  state->installation = installation;
+  state->app_name = found_app_name;
+  state->arch = found_arch;
+  state->branch = found_branch;
+  state->portal_manager = portal_manager;
+  state->callback = completion_callback;
   state->strand = &strand;
 
-    self->RequestAppLaunchPermission(
-              found_app_name,
-              installed,
-              [weak_self, state](const std::map<std::string, bool>& permissions) {
-                  auto self = weak_self.lock();
-                  if (!self) {
+  self->RequestAppLaunchPermission(
+      found_app_name, installed,
+      [weak_self, state](const std::map<std::string, bool>& permissions) {
+        auto self = weak_self.lock();
+        if (!self) {
+          state->callback(
+              ErrorOr<bool>(FlutterError("CANCELLED", "Operation cancelled")));
+          return;
+        }
+        spdlog::info("[FlatpakPlugin] Permissions granted: {}",
+                     permissions.size());
+        self->check_runtime(
+            state->installed, state->installation, *(state->strand),
+            [weak_self, state](const ErrorOr<bool>& runtime_result) {
+              auto self = weak_self.lock();
+              if (!self) {
+                state->callback(ErrorOr<bool>(
+                    FlutterError("CANCELLED", "Operation cancelled")));
+                return;
+              }
+
+              if (runtime_result.has_error()) {
+                state->callback(runtime_result);
+                return;
+              }
+
+              if (!runtime_result.value()) {
+                state->callback(ErrorOr<bool>(
+                    FlutterError("RUNTIME_ERROR", "Runtime not available")));
+                return;
+              }
+
+              // Create sandbox
+              flatpak_plugin::FlatpakShim::create_sandbox(
+                  state->installed, *(state->strand),
+                  [weak_self, state](bool sandbox_success) {
+                    auto self = weak_self.lock();
+                    if (!self) {
                       state->callback(ErrorOr<bool>(
                           FlutterError("CANCELLED", "Operation cancelled")));
                       return;
-                  }
-                spdlog::info("[FlatpakPlugin] Permissions granted: {}",
-                            permissions.size());
-                self->check_runtime(
-                                state->installed, state->installation, *(state->strand),
-                                [weak_self, state](const ErrorOr<bool>& runtime_result) {
-                        auto self = weak_self.lock();
-                        if (!self) {
-                            state->callback(ErrorOr<bool>(
-                                FlutterError("CANCELLED", "Operation cancelled")));
-                            return;
-                        }
+                    }
 
-                        if (runtime_result.has_error()) {
-                            state->callback(runtime_result);
-                            return;
-                        }
+                    if (!sandbox_success) {
+                      state->callback(ErrorOr<bool>(FlutterError(
+                          "START_FAILED", "Failed to create sandbox")));
+                      return;
+                    }
 
-                        if (!runtime_result.value()) {
-                            state->callback(ErrorOr<bool>(
-                                FlutterError("RUNTIME_ERROR",
-                                           "Runtime not available")));
-                            return;
-                        }
+                    // Launch application
+                    GError* error = nullptr;
+                    FlatpakInstance* instance = nullptr;
+                    flatpak_installation_launch_full(
+                        state->installation, FLATPAK_LAUNCH_FLAGS_DO_NOT_REAP,
+                        state->app_name.c_str(), state->arch.c_str(),
+                        state->branch.c_str(), nullptr, &instance, nullptr,
+                        &error);
 
-                        // Create sandbox
-                        flatpak_plugin::FlatpakShim::create_sandbox(
-                            state->installed, *(state->strand),
-                            [weak_self, state](bool sandbox_success) {
-                                auto self = weak_self.lock();
-                                if (!self) {
-                                    state->callback(ErrorOr<bool>(
-                                        FlutterError("CANCELLED",
-                                                   "Operation cancelled")));
-                                    return;
-                                }
+                    if (error) {
+                      spdlog::error("[FlatpakShim] Failed to launch: {}",
+                                    error->message);
+                      g_clear_error(&error);
+                      state->callback(ErrorOr<bool>(
+                          FlutterError("START_FAILED", "Failed to launch")));
+                      return;
+                    }
 
-                                if (!sandbox_success) {
-                                    state->callback(ErrorOr<bool>(
-                                        FlutterError("START_FAILED",
-                                                   "Failed to create sandbox")));
-                                    return;
-                                }
+                    if (instance) {
+                      pid_t pid = flatpak_instance_get_pid(instance);
+                      spdlog::info("[FlatpakShim] Launched: {} (PID: {})",
+                                   state->app_name, pid);
 
-                                // Launch application
-                                GError* error = nullptr;
-                                FlatpakInstance* instance = nullptr;
-                                flatpak_installation_launch_full(
-                                    state->installation,
-                                    FLATPAK_LAUNCH_FLAGS_DO_NOT_REAP,
-                                    state->app_name.c_str(),
-                                    state->arch.c_str(),
-                                    state->branch.c_str(),
-                                    nullptr, &instance, nullptr, &error);
+                      auto app_session = std::make_shared<MonitorSession>(
+                          state->strand, state->app_name, pid,
+                          state->portal_manager, instance);
 
-                                if (error) {
-                                    spdlog::error(
-                                        "[FlatpakShim] Failed to launch: {}",
-                                        error->message);
-                                    g_clear_error(&error);
-                                    state->callback(ErrorOr<bool>(
-                                        FlutterError("START_FAILED",
-                                                   "Failed to launch")));
-                                    return;
-                                }
+                      flatpak_plugin::FlatpakShim::active_sessions_
+                          [state->app_name] = app_session;
 
-                                if (instance) {
-                                    pid_t pid = flatpak_instance_get_pid(instance);
-                                    spdlog::info(
-                                        "[FlatpakShim] Launched: {} (PID: {})",
-                                        state->app_name, pid);
+                      flatpak_plugin::FlatpakShim::monitor_app(app_session);
+                      state->callback(ErrorOr<bool>(true));
+                      return;
+                    }
 
-                                    auto app_session =
-                                        std::make_shared<MonitorSession>(
-                                            state->strand, state->app_name,
-                                            pid, state->portal_manager, instance);
-
-
-                                    flatpak_plugin::FlatpakShim::active_sessions_[state->app_name] =
-                                        app_session;
-
-                                    flatpak_plugin::FlatpakShim::monitor_app(app_session);
-                                    state->callback(ErrorOr<bool>(true));
-                                    return;
-                                }
-
-                                state->callback(ErrorOr<bool>(
-                                    FlutterError("START_FAILED",
-                                               "Failed to get instance")));
-                            },
-                            state->portal_manager.get());
-                    });
+                    state->callback(ErrorOr<bool>(FlutterError(
+                        "START_FAILED", "Failed to get instance")));
+                  },
+                  state->portal_manager.get());
             });
+      });
 }
 
 ErrorOr<bool> FlatpakShim::ApplicationStop(const std::string& id) {
@@ -3688,7 +3678,10 @@ void FlatpakShim::SetupTransactionEventChannel(
   }
 }
 
-void FlatpakShim::SetupAccessEventChannel(flutter::BinaryMessenger* messenger,const asio::io_context::strand& strand,PortalManager* portal_manager) {
+void FlatpakShim::SetupAccessEventChannel(
+    flutter::BinaryMessenger* messenger,
+    const asio::io_context::strand& strand,
+    PortalManager* portal_manager) {
   if (!messenger) {
     spdlog::error(
         "[FlatpakPlugin] Messenger is null, cannot setup event channel");
@@ -3749,7 +3742,8 @@ void FlatpakShim::SetupAccessEventChannel(flutter::BinaryMessenger* messenger,co
               return nullptr;
             }));
 
-    access_portal_ = std::make_unique<AccessPortal>(portal_manager,strand.context(),*access_event_channel_);
+    access_portal_ = std::make_unique<AccessPortal>(
+        portal_manager, strand.context(), *access_event_channel_);
     spdlog::info("[FlatpakPlugin] Access portal created and initialized");
   } catch (const std::exception& e) {
     spdlog::error("[FlatpakPlugin] Exception setting up event channel: {}",
@@ -3790,7 +3784,9 @@ void FlatpakShim::SendTransactionEvent(flutter::EncodableMap& event) const {
   }
 }
 
-void FlatpakShim::SendPermissionEvent(const flutter::EncodableMap& event,const std::function<void(bool)>& callback) {
+void FlatpakShim::SendPermissionEvent(
+    const flutter::EncodableMap& event,
+    const std::function<void(bool)>& callback) {
   if (!access_sink_) {
     spdlog::error(
         "[FlatpakPlugin] Cannot send event - sink is null. "
@@ -3805,13 +3801,15 @@ void FlatpakShim::SendPermissionEvent(const flutter::EncodableMap& event,const s
         HandlePermissionResponse(*request_id, *permission, false);
       }
     }
-    if (callback) callback(false);
+    if (callback)
+      callback(false);
     return;
   }
 
   try {
     access_sink_->Success(flutter::EncodableValue(event));
-    if (callback) callback(true);
+    if (callback)
+      callback(true);
   } catch (const std::exception& e) {
     spdlog::error("[FlatpakPlugin] Exception sending event: {}", e.what());
     if (event.count(flutter::EncodableValue("request_id"))) {
@@ -3824,10 +3822,10 @@ void FlatpakShim::SendPermissionEvent(const flutter::EncodableMap& event,const s
         HandlePermissionResponse(*request_id, *permission, false);
       }
     }
-    if (callback) callback(false);
+    if (callback)
+      callback(false);
   }
 }
-
 
 void FlatpakShim::OnProgressChanged(FlatpakTransactionProgress* progress,
                                     gpointer user_data) {
@@ -4202,8 +4200,10 @@ bool FlatpakShim::check_desk_usage(FlatpakInstallation* installation,
 }
 
 std::string FlatpakShim::GenerateRequestId() {
- auto now = std::chrono::system_clock::now();
-  auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
+  auto now = std::chrono::system_clock::now();
+  auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                now.time_since_epoch())
+                .count();
   return "req_" + std::to_string(ms);
 }
 
@@ -4217,115 +4217,117 @@ void FlatpakShim::CheckExistingPermissions(
   }
 
   access_portal_->CheckAllPermissions(
-      app_id,
-      permissions,
-      [callback](const std::map<std::string, flatpak_plugin::PermissionStatus>& statuses) {
-          std::map<std::string, bool> results;
-          for (const auto& [perm, status] : statuses) {
-              switch (status) {
-                case flatpak_plugin::PermissionStatus::GRANTED:
-                  results[perm] = true;
-                  break;
-                case flatpak_plugin::PermissionStatus::DENIED:
-                  results[perm] = false;
-                  break;
-                case flatpak_plugin::PermissionStatus::ASK:
-                case flatpak_plugin::PermissionStatus::NOT_SET:
-                  // Don't add to results
-                  break;
+      app_id, permissions,
+      [callback](const std::map<std::string, flatpak_plugin::PermissionStatus>&
+                     statuses) {
+        std::map<std::string, bool> results;
+        for (const auto& [perm, status] : statuses) {
+          switch (status) {
+            case flatpak_plugin::PermissionStatus::GRANTED:
+              results[perm] = true;
+              break;
+            case flatpak_plugin::PermissionStatus::DENIED:
+              results[perm] = false;
+              break;
+            case flatpak_plugin::PermissionStatus::ASK:
+            case flatpak_plugin::PermissionStatus::NOT_SET:
+              // Don't add to results
+              break;
           }
-      }
-      callback(results);
-  });
+        }
+        callback(results);
+      });
 }
 
 void FlatpakShim::ShowNextDialog(const std::string& request_id) {
   flutter::EncodableMap event;
 
-    std::string app_id;
-    std::string current_permission;
-    size_t permission_index;
-    size_t total_requests;
-    bool should_continue = false;
+  std::string app_id;
+  std::string current_permission;
+  size_t permission_index;
+  size_t total_requests;
+  bool should_continue = false;
 
-    {
-        std::lock_guard<std::mutex> lock(permissions_mutex_);
-        auto it = active_permissions_.find(request_id);
-        if (it == active_permissions_.end()) {
-            spdlog::error("[FlatpakPlugin] Failed to retrieve {} request for permission",
-                         request_id);
-            return;
-        }
-
-        PermissionRequest& request = it->second;
-
-        // Check if all permissions processed
-        if (request.permission_index >= request.requests.size()) {
-            spdlog::debug("[FlatpakPlugin] All Permissions processed for {}",
-                         request.app_id);
-            auto callback = request.callback;
-            auto result = request.result;
-            active_permissions_.erase(it);
-
-            lock.~lock_guard();
-            callback(result);
-            return;
-        }
-
-        // Get current permission info
-        app_id = request.app_id;
-        current_permission = request.requests[request.permission_index];
-        permission_index = request.permission_index;
-        total_requests = request.requests.size();
-        should_continue = true;
+  {
+    std::lock_guard<std::mutex> lock(permissions_mutex_);
+    auto it = active_permissions_.find(request_id);
+    if (it == active_permissions_.end()) {
+      spdlog::error(
+          "[FlatpakPlugin] Failed to retrieve {} request for permission",
+          request_id);
+      return;
     }
 
-    if (!should_continue) return;
+    PermissionRequest& request = it->second;
 
-    event[flutter::EncodableValue("type")] =
-        flutter::EncodableValue("permission_dialog");
-    event[flutter::EncodableValue("request_id")] =
-        flutter::EncodableValue(request_id);
-    event[flutter::EncodableValue("app_id")] =
-        flutter::EncodableValue(app_id);
-    event[flutter::EncodableValue("permission")] =
-        flutter::EncodableValue(current_permission);
-    event[flutter::EncodableValue("progress")] =
-        flutter::EncodableValue(static_cast<int>(permission_index + 1));
-    event[flutter::EncodableValue("total")] =
-        flutter::EncodableValue(static_cast<int>(total_requests));
-    event[flutter::EncodableValue("timestamp")] =
-        flutter::EncodableValue(
-            std::chrono::system_clock::now().time_since_epoch().count());
+    // Check if all permissions processed
+    if (request.permission_index >= request.requests.size()) {
+      spdlog::debug("[FlatpakPlugin] All Permissions processed for {}",
+                    request.app_id);
+      auto callback = request.callback;
+      auto result = request.result;
+      active_permissions_.erase(it);
 
-    spdlog::debug("[FlatpakPlugin] Showing permission Dialog : {} {}/{}",
-                 current_permission, permission_index + 1, total_requests);
+      lock.~lock_guard();
+      callback(result);
+      return;
+    }
 
-    SendPermissionEvent(event, [weak_self = weak_from_this(), request_id]
-                        (bool success) {
+    // Get current permission info
+    app_id = request.app_id;
+    current_permission = request.requests[request.permission_index];
+    permission_index = request.permission_index;
+    total_requests = request.requests.size();
+    should_continue = true;
+  }
+
+  if (!should_continue)
+    return;
+
+  event[flutter::EncodableValue("type")] =
+      flutter::EncodableValue("permission_dialog");
+  event[flutter::EncodableValue("request_id")] =
+      flutter::EncodableValue(request_id);
+  event[flutter::EncodableValue("app_id")] = flutter::EncodableValue(app_id);
+  event[flutter::EncodableValue("permission")] =
+      flutter::EncodableValue(current_permission);
+  event[flutter::EncodableValue("progress")] =
+      flutter::EncodableValue(static_cast<int>(permission_index + 1));
+  event[flutter::EncodableValue("total")] =
+      flutter::EncodableValue(static_cast<int>(total_requests));
+  event[flutter::EncodableValue("timestamp")] = flutter::EncodableValue(
+      std::chrono::system_clock::now().time_since_epoch().count());
+
+  spdlog::debug("[FlatpakPlugin] Showing permission Dialog : {} {}/{}",
+                current_permission, permission_index + 1, total_requests);
+
+  SendPermissionEvent(
+      event, [weak_self = weak_from_this(), request_id](bool success) {
         if (!success) {
-            auto self = weak_self.lock();
-            if (!self) return;
+          auto self = weak_self.lock();
+          if (!self)
+            return;
 
-            spdlog::error("[FlatpakPlugin] Failed to show dialog");
+          spdlog::error("[FlatpakPlugin] Failed to show dialog");
 
-            std::lock_guard<std::mutex> lock(self->permissions_mutex_);
-            auto it = self->active_permissions_.find(request_id);
-            if (it != self->active_permissions_.end()) {
-                auto callback = it->second.callback;
-                self->active_permissions_.erase(it);
+          std::lock_guard<std::mutex> lock(self->permissions_mutex_);
+          auto it = self->active_permissions_.find(request_id);
+          if (it != self->active_permissions_.end()) {
+            auto callback = it->second.callback;
+            self->active_permissions_.erase(it);
 
-                lock.~lock_guard();
-                callback({});
-            }
+            lock.~lock_guard();
+            callback({});
+          }
         }
-    });
+      });
 }
 
 void FlatpakShim::HandlePermissionResponse(const std::string& request_id,
                                            const std::string& permission,
                                            bool granted) {
- spdlog::debug("[FlatpakPlugin] Permission response : {} -> {}" , permission,granted? "granted" : "denied");
+  spdlog::debug("[FlatpakPlugin] Permission response : {} -> {}", permission,
+                granted ? "granted" : "denied");
   std::string table = "devices";
   if (permission == "location") {
     table = "location";
@@ -4338,34 +4340,34 @@ void FlatpakShim::HandlePermissionResponse(const std::string& request_id,
   // Retrieve app id from requests
   std::string app_id;
   {
-   std::lock_guard<std::mutex> lock(permissions_mutex_);
-   auto it = active_permissions_.find(request_id);
-   if (it != active_permissions_.end()) {
-     app_id = it->second.app_id;
-     it->second.result[permission] = granted;
-     it->second.permission_index++;
-   }
+    std::lock_guard<std::mutex> lock(permissions_mutex_);
+    auto it = active_permissions_.find(request_id);
+    if (it != active_permissions_.end()) {
+      app_id = it->second.app_id;
+      it->second.result[permission] = granted;
+      it->second.permission_index++;
+    }
   }
 
   if (!app_id.empty()) {
     access_portal_->SetPermission(
-            table, permission, app_id,
-            {granted ? "yes" : "no"},
-            [weak_self = weak_from_this(), request_id, permission, granted]
-            (bool success) {
-                auto self = weak_self.lock();
-                if (!self) return;
+        table, permission, app_id, {granted ? "yes" : "no"},
+        [weak_self = weak_from_this(), request_id, permission,
+         granted](bool success) {
+          auto self = weak_self.lock();
+          if (!self)
+            return;
 
-                if (success) {
-                    spdlog::debug("[FlatpakPlugin] Stored: {} -> {}",
-                                permission, granted ? "granted" : "denied");
-                } else {
-                    spdlog::error("[FlatpakPlugin] Failed to store permission");
-                }
+          if (success) {
+            spdlog::debug("[FlatpakPlugin] Stored: {} -> {}", permission,
+                          granted ? "granted" : "denied");
+          } else {
+            spdlog::error("[FlatpakPlugin] Failed to store permission");
+          }
 
-                // Show next dialog
-                self->ShowNextDialog(request_id);
-            });
+          // Show next dialog
+          self->ShowNextDialog(request_id);
+        });
   }
 }
 
@@ -4382,7 +4384,7 @@ void FlatpakShim::RequestAppLaunchPermission(
   const FlatpakShim::sandbox sandbox = parse_metadata(metadata);
   std::vector<std::string> requested_permissions;
 
-  for (const auto& dev: sandbox.context.devices) {
+  for (const auto& dev : sandbox.context.devices) {
     if (dev == "all") {
       requested_permissions.emplace_back("microphone");
       requested_permissions.emplace_back("speakers");
@@ -4391,9 +4393,10 @@ void FlatpakShim::RequestAppLaunchPermission(
     }
   }
 
-  for (const auto& sock: sandbox.context.sockets) {
+  for (const auto& sock : sandbox.context.sockets) {
     if (sock == "pulseaudio") {
-      auto it = std::find(requested_permissions.begin(),requested_permissions.end(),"microphone");
+      auto it = std::find(requested_permissions.begin(),
+                          requested_permissions.end(), "microphone");
       if (it == requested_permissions.end()) {
         requested_permissions.emplace_back("microphone");
         requested_permissions.emplace_back("speakers");
@@ -4401,18 +4404,16 @@ void FlatpakShim::RequestAppLaunchPermission(
       break;
     }
   }
-  for (const auto& bus: sandbox.session_bus) {
+  for (const auto& bus : sandbox.session_bus) {
     if (bus == "org.freedesktop.Notifications") {
       requested_permissions.emplace_back("notifications");
-    }
-    else if (bus == "org.freedesktop.portal.Usb") {
+    } else if (bus == "org.freedesktop.portal.Usb") {
       requested_permissions.emplace_back("usb");
-    }
-    else if (bus == "org.freedesktop.portal.Location") {
+    } else if (bus == "org.freedesktop.portal.Location") {
       requested_permissions.emplace_back("location");
-    }
-    else if (bus == "org.freedesktop.portal.Camera") {
-      auto it = std::find(requested_permissions.begin(),requested_permissions.end(),"camera");
+    } else if (bus == "org.freedesktop.portal.Camera") {
+      auto it = std::find(requested_permissions.begin(),
+                          requested_permissions.end(), "camera");
       if (it == requested_permissions.end()) {
         requested_permissions.emplace_back("camera");
       }
@@ -4420,115 +4421,121 @@ void FlatpakShim::RequestAppLaunchPermission(
   }
 
   if (requested_permissions.empty()) {
-    spdlog::info("[FlatpakPlugin] No permissions needed for app : {}",app_id);
+    spdlog::info("[FlatpakPlugin] No permissions needed for app : {}", app_id);
     callback({});
     return;
   }
 
-  spdlog::info("[FlatpakPlugin] Check Existing permissions for app : {}",app_id);
+  spdlog::info("[FlatpakPlugin] Check Existing permissions for app : {}",
+               app_id);
 
   CheckExistingPermissions(
-        app_id,
-        requested_permissions,
-        [weak_self = weak_from_this(), app_id, requested_permissions, callback]
-        (std::map<std::string, bool> permissions) {
-            auto self = weak_self.lock();
-            if (!self) {
-                callback({});
-                return;
-            }
+      app_id, requested_permissions,
+      [weak_self = weak_from_this(), app_id, requested_permissions,
+       callback](std::map<std::string, bool> permissions) {
+        auto self = weak_self.lock();
+        if (!self) {
+          callback({});
+          return;
+        }
 
-            std::vector<std::string> permissions_to_ask;
-            std::map<std::string, bool> final_results = permissions;
+        std::vector<std::string> permissions_to_ask;
+        std::map<std::string, bool> final_results = permissions;
 
-            for (const auto& perm: requested_permissions) {
-                if (permissions.find(perm) == permissions.end()) {
-                    permissions_to_ask.emplace_back(perm);
-                }
-            }
+        for (const auto& perm : requested_permissions) {
+          if (permissions.find(perm) == permissions.end()) {
+            permissions_to_ask.emplace_back(perm);
+          }
+        }
 
-            if (permissions_to_ask.empty()) {
-                spdlog::info("[FlatpakPlugin] No permissions needed to ask for app : {}",
-                           app_id);
-                callback(final_results);
-                return;
-            }
+        if (permissions_to_ask.empty()) {
+          spdlog::info(
+              "[FlatpakPlugin] No permissions needed to ask for app : {}",
+              app_id);
+          callback(final_results);
+          return;
+        }
 
-            std::string request_id = flatpak_plugin::FlatpakShim::GenerateRequestId();
+        std::string request_id =
+            flatpak_plugin::FlatpakShim::GenerateRequestId();
 
-            PermissionRequest request;
-            request.app_id = app_id;
-            request.result = final_results;
-            request.permission_index = 0;
-            request.requests = permissions_to_ask;
-            request.callback = callback;
+        PermissionRequest request;
+        request.app_id = app_id;
+        request.result = final_results;
+        request.permission_index = 0;
+        request.requests = permissions_to_ask;
+        request.callback = callback;
 
-            {
-                std::lock_guard<std::mutex> lock(self->permissions_mutex_);
-                self->active_permissions_[request_id] = std::move(request);
-            }
+        {
+          std::lock_guard<std::mutex> lock(self->permissions_mutex_);
+          self->active_permissions_[request_id] = std::move(request);
+        }
 
-            spdlog::info("[FlatpakPlugin] Starting Permissions dialog for {} permission",
-                       permissions_to_ask.size());
-            self->ShowNextDialog(request_id);
-        });
+        spdlog::info(
+            "[FlatpakPlugin] Starting Permissions dialog for {} permission",
+            permissions_to_ask.size());
+        self->ShowNextDialog(request_id);
+      });
 }
 
 void FlatpakShim::HandleMethodCall(
     const flutter::MethodCall<flutter::EncodableValue>& method_call,
     std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
   asio::post(*strand_, [weak_self = weak_from_this(),
-                          method_name = method_call.method_name(),
-                          arguments = method_call.arguments() ?
-                              *method_call.arguments() : flutter::EncodableValue(),
-                          result = std::move(result)]() mutable {
+                        method_name = method_call.method_name(),
+                        arguments = method_call.arguments()
+                                        ? *method_call.arguments()
+                                        : flutter::EncodableValue(),
+                        result = std::move(result)]() mutable {
     auto self = weak_self.lock();
     if (!self) {
-        result->Error("CANCELLED", "Operation cancelled");
-        return;
+      result->Error("CANCELLED", "Operation cancelled");
+      return;
     }
     const auto* args = std::get_if<flutter::EncodableMap>(&arguments);
 
-  if (method_name == "permissionResponse") {
-    if (!args) {
-      result->Error("INVALID_ARGUMENT","argument is not map");
-      return;
-    }
-    auto request_id_it = args->find(flutter::EncodableValue("request_id"));
-    auto permission_it = args->find(flutter::EncodableValue("permission"));
-    auto granted_it = args->find(flutter::EncodableValue("granted"));
-    if (request_id_it == args->end() || permission_it == args->end() || granted_it == args->end()) {
-      result->Error("MISSING_FIELDS","request_id ,permission or granted is missing");
-      return;
-    }
+    if (method_name == "permissionResponse") {
+      if (!args) {
+        result->Error("INVALID_ARGUMENT", "argument is not map");
+        return;
+      }
+      auto request_id_it = args->find(flutter::EncodableValue("request_id"));
+      auto permission_it = args->find(flutter::EncodableValue("permission"));
+      auto granted_it = args->find(flutter::EncodableValue("granted"));
+      if (request_id_it == args->end() || permission_it == args->end() ||
+          granted_it == args->end()) {
+        result->Error("MISSING_FIELDS",
+                      "request_id ,permission or granted is missing");
+        return;
+      }
 
-    auto* request_id = std::get_if<std::string>(&request_id_it->second);
-    auto* permission = std::get_if<std::string>(&permission_it->second);
-    auto* granted = std::get_if<bool>(&granted_it->second);
+      auto* request_id = std::get_if<std::string>(&request_id_it->second);
+      auto* permission = std::get_if<std::string>(&permission_it->second);
+      auto* granted = std::get_if<bool>(&granted_it->second);
 
-    if (!request_id || !permission || !granted) {
-      result->Error("INVALID_TYPES","invalid arguments types");
+      if (!request_id || !permission || !granted) {
+        result->Error("INVALID_TYPES", "invalid arguments types");
+        return;
+      }
+      self->HandlePermissionResponse(*request_id, *permission, *granted);
+      result->Success();
       return;
     }
-    self->HandlePermissionResponse(*request_id,*permission,*granted);
-    result->Success();
-    return;
-  }
     // TODO: Handle other methods.
     if (method_name == "checkPermissions") {
-            result->NotImplemented();
-            return;
-        }
+      result->NotImplemented();
+      return;
+    }
 
-        if (method_name == "grantPermission") {
-            result->NotImplemented();
-            return;
-        }
+    if (method_name == "grantPermission") {
+      result->NotImplemented();
+      return;
+    }
 
-        if (method_name == "revokePermission") {
-            result->NotImplemented();
-            return;
-        }
+    if (method_name == "revokePermission") {
+      result->NotImplemented();
+      return;
+    }
     result->NotImplemented();
   });
 }

--- a/plugins/flatpak/flatpak_shim.h
+++ b/plugins/flatpak/flatpak_shim.h
@@ -358,16 +358,22 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
    * \brief Sets up the event channel for Permissions Access events.
    * \param messenger Pointer to the BinaryMessenger used for communication.
    * \param strand Asio strand to execute async operations.
-   * \param portal_manager Pointer to portal manager used for creating access portal with event callback.
+   * \param portal_manager Pointer to portal manager used for creating access
+   * portal with event callback.
    */
-  void SetupAccessEventChannel(flutter::BinaryMessenger* messenger,const asio::io_context::strand& strand,PortalManager* portal_manager);
+  void SetupAccessEventChannel(flutter::BinaryMessenger* messenger,
+                               const asio::io_context::strand& strand,
+                               PortalManager* portal_manager);
 
   /**
    * \brief Handles All methods responses comes from the flutter side.
    * @param method_call A flutter method call for Method channel implementation.
    * @param result A pointer for result implementation.
    */
-  void HandleMethodCall(const flutter::MethodCall<flutter::EncodableValue>& method_call,std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+  void HandleMethodCall(
+      const flutter::MethodCall<flutter::EncodableValue>& method_call,
+      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+
  private:
   struct sandbox {
     struct application {
@@ -471,7 +477,7 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
       access_event_channel_;
   std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> access_sink_;
   mutable std::mutex access_sink_mutex_;
-  std::map<std::string,PermissionRequest> active_permissions_;
+  std::map<std::string, PermissionRequest> active_permissions_;
   mutable std::mutex permissions_mutex_;
 
   static std::optional<Application> create_component(
@@ -531,7 +537,8 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
   void SendTransactionEvent(flutter::EncodableMap& event) const;
 
   // flutter streaming callback functions
-  void SendPermissionEvent(const flutter::EncodableMap& event,const std::function<void(bool)>& callback);
+  void SendPermissionEvent(const flutter::EncodableMap& event,
+                           const std::function<void(bool)>& callback);
 
   // callback triggered by "changed" signal
   static void OnProgressChanged(FlatpakTransactionProgress* progress,
@@ -562,15 +569,23 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
   bool check_desk_usage(FlatpakInstallation* installation,
                         guint64 estimated_download) const;
 
-  void RequestAppLaunchPermission(const std::string& app_id, FlatpakInstalledRef* installed_ref, const std::function<void(const std::map<std::string,bool>&)>& callback);
+  void RequestAppLaunchPermission(
+      const std::string& app_id,
+      FlatpakInstalledRef* installed_ref,
+      const std::function<void(const std::map<std::string, bool>&)>& callback);
 
-  void HandlePermissionResponse(const std::string& request_id,const std::string& permission,bool granted);
+  void HandlePermissionResponse(const std::string& request_id,
+                                const std::string& permission,
+                                bool granted);
 
   void ShowNextDialog(const std::string& request_id);
 
   static std::string GenerateRequestId();
 
-  void CheckExistingPermissions(const std::string& app_id,const std::vector<std::string>& permissions,const std::function<void(std::map<std::string,bool>)>& callback)const;
+  void CheckExistingPermissions(
+      const std::string& app_id,
+      const std::vector<std::string>& permissions,
+      const std::function<void(std::map<std::string, bool>)>& callback) const;
 };
 
 }  // namespace flatpak_plugin

--- a/plugins/flatpak/flatpak_shim.h
+++ b/plugins/flatpak/flatpak_shim.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020-2025 Toyota Connected North America
+ * Copyright 2025 Ahmed Wafdy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -228,6 +229,7 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
    * \param id Id of the application to start application.
    * \param strand Asio strand to execute async operations.
    * \param portal_manager Ptr to portal manager to execute portal operations.
+   * \param completion_callback Callback function for async operations.
    * \return An ErrorOr object containing the EncodableList or an
    * error.
    */
@@ -358,15 +360,14 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
    * \param strand Asio strand to execute async operations.
    * \param portal_manager Pointer to portal manager used for creating access portal with event callback.
    */
-  void SetupAccessEventChannel(flutter::BinaryMessenger* messenger,asio::io_context::strand& strand,PortalManager* portal_manager);
+  void SetupAccessEventChannel(flutter::BinaryMessenger* messenger,const asio::io_context::strand& strand,PortalManager* portal_manager);
 
-
-  void RequestAppLaunchPermission(const std::string& app_id, FlatpakInstalledRef* installed_ref, const std::function<void(const std::map<std::string,bool>&)>& callback);
-
-  void HandlePermissionResponse(const std::string& request_id,const std::string& permission,bool granted);
-
-  // flutter streaming callback functions
-  void SendPermissionEvent(const flutter::EncodableMap& event,std::function<void(bool)> callback);
+  /**
+   * \brief Handles All methods responses comes from the flutter side.
+   * @param method_call A flutter method call for Method channel implementation.
+   * @param result A pointer for result implementation.
+   */
+  void HandleMethodCall(const flutter::MethodCall<flutter::EncodableValue>& method_call,std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
  private:
   struct sandbox {
     struct application {
@@ -529,6 +530,9 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
   // flutter streaming callback functions
   void SendTransactionEvent(flutter::EncodableMap& event) const;
 
+  // flutter streaming callback functions
+  void SendPermissionEvent(const flutter::EncodableMap& event,const std::function<void(bool)>& callback);
+
   // callback triggered by "changed" signal
   static void OnProgressChanged(FlatpakTransactionProgress* progress,
                                 gpointer user_data);
@@ -558,13 +562,15 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
   bool check_desk_usage(FlatpakInstallation* installation,
                         guint64 estimated_download) const;
 
+  void RequestAppLaunchPermission(const std::string& app_id, FlatpakInstalledRef* installed_ref, const std::function<void(const std::map<std::string,bool>&)>& callback);
+
+  void HandlePermissionResponse(const std::string& request_id,const std::string& permission,bool granted);
+
   void ShowNextDialog(const std::string& request_id);
 
   static std::string GenerateRequestId();
 
-  void CheckExistingPermissions(const std::string& app_id,const std::vector<std::string>& permissions,std::function<void(std::map<std::string,bool>)> callback);
-
-  void HandleMethodCall(const flutter::MethodCall<flutter::EncodableValue>& method_call,std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+  void CheckExistingPermissions(const std::string& app_id,const std::vector<std::string>& permissions,const std::function<void(std::map<std::string,bool>)>& callback)const;
 };
 
 }  // namespace flatpak_plugin

--- a/plugins/flatpak/flatpak_shim.h
+++ b/plugins/flatpak/flatpak_shim.h
@@ -555,6 +555,9 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
   static gboolean OnTransactionReady(FlatpakTransaction* transaction,
                                      gpointer user_data);
 
+  bool check_desk_usage(FlatpakInstallation* installation,
+                        guint64 estimated_download) const;
+
   void ShowNextDialog(const std::string& request_id);
 
   static std::string GenerateRequestId();

--- a/plugins/flatpak/flatpak_shim.h
+++ b/plugins/flatpak/flatpak_shim.h
@@ -358,12 +358,10 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
    * \brief Sets up the event channel for Permissions Access events.
    * \param messenger Pointer to the BinaryMessenger used for communication.
    * \param strand Asio strand to execute async operations.
-   * \param portal_manager Pointer to portal manager used for creating access
    * portal with event callback.
    */
   void SetupAccessEventChannel(flutter::BinaryMessenger* messenger,
-                               const asio::io_context::strand& strand,
-                               PortalManager* portal_manager);
+                               const asio::io_context::strand& strand);
 
   /**
    * \brief Handles All methods responses comes from the flutter side.

--- a/plugins/flatpak/flatpak_shim.h
+++ b/plugins/flatpak/flatpak_shim.h
@@ -33,6 +33,7 @@
 #include "component.h"
 #include "messages.g.h"
 #include "plugins/flatpak/portals/portal_manager.h"
+#include "portals/access_portal/access_portal.h"
 
 namespace flatpak_plugin {
 class FlatpakPlugin;
@@ -268,7 +269,7 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
    * \brief Search for app ID  in all remotes.
    * \param installation Installation that contains the App.
    * \param app_id Application id.
-   * \return A Pair of two strings contains remote name and application ref.
+   * \return A Pair of two strings contains a remote name and application ref.
    */
   static std::pair<std::string, std::string> find_app_in_remotes(
       FlatpakInstallation* installation,
@@ -351,6 +352,21 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
    */
   void SetupTransactionEventChannel(flutter::BinaryMessenger* messenger);
 
+  /**
+   * \brief Sets up the event channel for Permissions Access events.
+   * \param messenger Pointer to the BinaryMessenger used for communication.
+   * \param strand Asio strand to execute async operations.
+   * \param portal_manager Pointer to portal manager used for creating access portal with event callback.
+   */
+  void SetupAccessEventChannel(flutter::BinaryMessenger* messenger,asio::io_context::strand& strand,PortalManager* portal_manager);
+
+
+  void RequestAppLaunchPermission(const std::string& app_id, FlatpakInstalledRef* installed_ref, const std::function<void(const std::map<std::string,bool>&)>& callback);
+
+  void HandlePermissionResponse(const std::string& request_id,const std::string& permission,bool granted);
+
+  // flutter streaming callback functions
+  void SendPermissionEvent(const flutter::EncodableMap& event,std::function<void(bool)> callback);
  private:
   struct sandbox {
     struct application {
@@ -410,6 +426,15 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
     }
   };
 
+  struct PermissionRequest {
+    std::string app_id;
+    std::vector<std::string> requests;
+    std::map<std::string, bool> result;
+    size_t permission_index = 0;
+    std::function<void(const std::map<std::string, bool>&)> callback;
+    std::chrono::steady_clock::time_point created_at;
+  };
+
   template <typename T>
   struct GObjectGuard {
     T* obj;
@@ -438,6 +463,15 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
       event_channel_;
   std::shared_ptr<flutter::EventSink<flutter::EncodableValue>> event_sink_;
   mutable std::mutex event_sink_mutex_;
+
+  // Event channel for streaming permissions access to the flutter widget
+  std::unique_ptr<AccessPortal> access_portal_;
+  std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>
+      access_event_channel_;
+  std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> access_sink_;
+  mutable std::mutex access_sink_mutex_;
+  std::map<std::string,PermissionRequest> active_permissions_;
+  mutable std::mutex permissions_mutex_;
 
   static std::optional<Application> create_component(
       FlatpakRemoteRef* app_ref,
@@ -521,8 +555,13 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
   static gboolean OnTransactionReady(FlatpakTransaction* transaction,
                                      gpointer user_data);
 
-  bool check_desk_usage(FlatpakInstallation* installation,
-                        guint64 estimated_download) const;
+  void ShowNextDialog(const std::string& request_id);
+
+  static std::string GenerateRequestId();
+
+  void CheckExistingPermissions(const std::string& app_id,const std::vector<std::string>& permissions,std::function<void(std::map<std::string,bool>)> callback);
+
+  void HandleMethodCall(const flutter::MethodCall<flutter::EncodableValue>& method_call,std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
 };
 
 }  // namespace flatpak_plugin

--- a/plugins/flatpak/portals/access_portal/access_portal.cc
+++ b/plugins/flatpak/portals/access_portal/access_portal.cc
@@ -17,9 +17,7 @@
 
 #include "access_portal.h"
 
-#include <ctime>
 #include <iomanip>
-#include <numbers>
 #include "asio/post.hpp"
 #include "flatpak/flatpak_shim.h"
 #include "spdlog/spdlog.h"
@@ -35,301 +33,107 @@ namespace flatpak_plugin {
       event_channel_(&event_channel),
       session_bus_(plugin_common_sdbus::SessionDBus::Instance()) {}
 
-AccessPortal::~AccessPortal() {
-   try {
-     // Clean up any remaining requests
-     for (auto& [handle, request] : requests_) {
-       request->request_proxy->callMethod("Close")
-       .onInterface("org.freedesktop.portal.Request");
-     }
-     requests_.clear();
-   } catch (const std::exception& e) {
-     spdlog::error("Failed to clean up portal requests: {}", e.what());
-   }
- }
-
-std::string AccessPortal::GenerateHandle(const std::string& app_id) {
-   const std::string sender = session_bus_.GetConnection().getUniqueName();
-
-   // Format is like ":1.234", Should be like "1_234"
-   std::string token_sender = sender.substr(1);
-   std::replace(token_sender.begin(), token_sender.end(), '.', '_');
-
-   const uint32_t token_id = request_counter_.fetch_add(1);
-   std::string app_id_interface = app_id;
-   std::replace(app_id_interface.begin(), app_id_interface.end(), '.', '_');
-
-   const std::string token = app_id_interface + "_" + std::to_string(token_id);
-
-   // Generate handle
-   std::string handle = "/org/freedesktop/portal/desktop/request/" + token_sender + "/" + token;
-
-   return handle;
- }
-
-std::string AccessPortal::ShowAccessDialog(
-     const std::string& app_id,
-     const std::string& parent_window,
-     const AccessDialogOptions& options) {
-   std::string handle = GenerateHandle(app_id);
-
-   // create a context for the request
-   auto context = std::make_unique<AccessRequest>();
-   context->app_id = app_id;
-   context->options = options;
-   context->handle = handle;
-
-   {
-     std::lock_guard<std::mutex> lock(requests_mutex_);
-     requests_[handle] = std::move(context);
-   }
-   // SetupRequestSignalHandler(handle);
-   // std::map<std::string,sdbus::Variant> portal_options;
-   //
-   // portal_options["modal"] = sdbus::Variant(options.modal);
-   // if (!options.deny_label.empty()) {
-   //   portal_options["deny_label"] = sdbus::Variant(options.deny_label);
-   // }
-   // if (!options.allow_label.empty()) {
-   //   portal_options["grant_label"] = sdbus::Variant(options.allow_label);
-   // }
-   // if (!options.icon.empty()) {
-   //   portal_options["icon"] = sdbus::Variant(options.icon);
-   // }
-
-   PortalInterface access_interface;
-   access_interface.service_name = "org.freedesktop.impl.portal.desktop.gtk";
-   access_interface.object_path = "/org/freedesktop/portal/desktop";
-   access_interface.interface_name = "org.freedesktop.impl.portal.Access";
-   access_interface.bus_type = BUS_TYPE::SESSION;
-   auto proxy = portal_manager_.GetPortalProxy().GetProxy(access_interface);
-
-   try {
-     // call access dialog
-     // proxy->callMethodAsync("AccessDialog")
-     // .onInterface("org.freedesktop.impl.portal.Access")
-     // .withArguments(
-     //  sdbus::ObjectPath(handle),
-     //  app_id,
-     //  parent_window,
-     //  options.title,
-     //  options.subtitle,
-     //  options.body,
-     //  portal_options
-     // )
-     // .uponReplyInvoke([this,handle](std::optional<sdbus::Error> error) {
-     //   if (error) {
-     //     spdlog::error("Failed to show access dialog for {}: {}", handle, error->getMessage());
-     //
-     //
-     //   flutter::EncodableMap event;
-     //                event[flutter::EncodableValue("type")] =
-     //                    flutter::EncodableValue("error");
-     //                event[flutter::EncodableValue("handle")] =
-     //                    flutter::CustomEncodableValue(handle);
-     //                event[flutter::EncodableValue("message")] =
-     //                    flutter::CustomEncodableValue(error->getMessage());
-     //                SendEvent(event);
-     //     std::lock_guard<std::mutex> lock(requests_mutex_);
-     //     requests_.erase(handle);
-     //  }
-     // });
-     spdlog::debug("[AccessPortal] ShowAccessDialog called for {}",handle);
-   } catch (const sdbus::Error& e) {
-     spdlog::error("[AccessPortal] Failed to show access dialog for {}: {}", handle, e.what());
-      requests_.erase(handle);
-     throw;
-   }
-   return handle;
- }
-
-void AccessPortal::SetupRequestSignalHandler(const std::string& handler) {
-std::lock_guard<std::mutex> lock(requests_mutex_);
-
-  const auto it = requests_.find(handler);
-   if (it == requests_.end()) {
-     spdlog::error("[AccessPortal] Request {} not found", handler);
-     return;
-   }
-
-   AccessRequest* request = it->second.get();
-   request->request_proxy = sdbus::createProxy(
-       session_bus_.GetConnection(),
-       sdbus::ServiceName{"org.freedesktop.portal.Desktop"},
-       sdbus::ObjectPath{handler});
-
-   // subscribe to response signal
-   request->request_proxy->uponSignal("Response")
-   .onInterface("org.freedesktop.portal.Request")
-   .call([this,handler](uint32_t response_code, const std::map<std::string, sdbus::Variant>& results) {
-     spdlog::debug("[AccessPortal] Response received for {}", handler);
-     asio::post(io_context_, [this,handler,response_code,results]() {
-       OnPortalResponse(handler, response_code, results);
-     });
-   });
-   //request->request_proxy->finishRegistration();
- }
-
-void AccessPortal::OnPortalResponse(
-    const std::string& handle,
-    uint32_t response_code,
-    const std::map<std::string, sdbus::Variant>& results) {
-spdlog::info("[AccessPortal] Response received for {}: {}", handle, response_code);
-  std::unique_ptr<AccessRequest> request;
-
-   {
-  std::lock_guard<std::mutex> lock(requests_mutex_);
-  auto it = requests_.find(handle);
-  if (it == requests_.end()) {
-    spdlog::error("[AccessPortal] Request {} not found", handle);
-    return;
-  }
-  request = std::move(it->second);
-  requests_.erase(it);
-  }
-
-   flutter::EncodableMap event;
-   event[flutter::EncodableValue("type")] = flutter::EncodableValue("access_response");
-   event[flutter::EncodableValue("handle")] = flutter::EncodableValue(handle);
-   event[flutter::EncodableValue("response_code")] = flutter::EncodableValue(response_code);
-
-  std::string response_status;
-   switch (response_code) {
-    case 0:
-      response_status = "granted";
-      break;
-    case 1:
-      response_status = "denied";
-      break;
-    default:
-      response_status = "error";
-       break;
-   }
-  event[flutter::EncodableValue("response_status")] = flutter::CustomEncodableValue(response_status);
-   flutter::EncodableMap result_map;
-
-for (const auto& [key, variant] : results) {
-  try {
-    if (variant.containsValueOfType<std::string>()) {
-      result_map[flutter::CustomEncodableValue(key)] = flutter::CustomEncodableValue(variant.get<std::string>());
-    }else if (variant.containsValueOfType<bool>()) {
-      result_map[flutter::CustomEncodableValue(key)] = flutter::CustomEncodableValue(variant.get<bool>());
-    }else if (variant.containsValueOfType<int32_t>()) {
-      result_map[flutter::CustomEncodableValue(key)] = flutter::CustomEncodableValue(variant.get<int32_t>());
-    }else if (variant.containsValueOfType<uint32_t>()) {
-      result_map[flutter::CustomEncodableValue(key)] = flutter::CustomEncodableValue(variant.get<uint32_t>());
-    }
-  } catch (const std::exception& e) {
-    spdlog::error("[AccessPortal] Failed to parse response {} : {}", handle ,e.what());
-  }
-}
-
-event[flutter::EncodableValue("results")] = flutter::CustomEncodableValue(result_map);
-   if (request->callback) {
-     request->callback(response_code, results);
-   }
-   SendEvent(event);
-}
-
-
-void AccessPortal::SendEvent(const flutter::EncodableMap& event) {
-if (!event_channel_) {
-  spdlog::error("[AccessPortal] Event channel not set");
-  return;
-}
-   asio::post(io_context_, [this,event]() {
-    //  this->shim_->SendAccessEvent(event);
-   });
-}
-
-void AccessPortal::CancelAccessRequest(const std::string& handle) {
-std::lock_guard<std::mutex> lock(requests_mutex_);
-   auto it = requests_.find(handle);
-   if (it == requests_.end()) {
-     spdlog::error("[AccessPortal] Request {} not found", handle);
-     return;
-   }
-   it->second->request_proxy->callMethod("Close")
-   .onInterface("org.freedesktop.portal.Request");
-   requests_.erase(it);
-   spdlog::debug("[AccessPortal] Request {} canceled", handle);
-}
+AccessPortal::~AccessPortal() = default;
 
 void AccessPortal::CheckAllPermissions(
-    const std::string& app_id,
+    const std::string& app,
     const std::vector<std::string>& permissions,
-    std::function<void(std::map<std::string, PermissionStatus>)> callback) {
+    const std::function<void(std::map<std::string, PermissionStatus>)>& callback) const {
+   if (permissions.empty()) {
+     spdlog::error("[AccessPortal] CheckAllPermissions: empty");
+     callback({});
+     return;
+   }
+
    auto results = std::make_shared<std::map<std::string, PermissionStatus>>();
    auto counter = std::make_shared<std::atomic<int>>(0);
-   int total = permissions.size();
+   auto total = std::make_shared<int>(static_cast<int>(permissions.size()));
+   auto callback_wrapper = std::make_shared<std::function<void(std::map<std::string, PermissionStatus>)>>(callback);
 
    for (const auto& permission : permissions) {
      std::string table = "devices";
      std::string resource_id = permission;
      if (permission == "location") {
-        table = "location";
+       table = "location";
        resource_id = "location";
-     }else if (permission == "notifications") {
+     } else if (permission == "notifications") {
        table = "notifications";
        resource_id = "notifications";
      } else if (permission == "background") {
        table = "background";
-       resource_id = app_id;
+       resource_id = app;
      }
-     GetAllPermissions(table,resource_id,app_id,[results,callback,counter,total,permission](PermissionStatus status) {
-       (*results)[permission] = status;
-         if(++(*counter) == total) {
-           callback(*results);
-         }
+
+     GetAllPermissions(table, resource_id, app,
+       [this, results, callback_wrapper, counter, total, permission]
+       (PermissionStatus status) {
+         asio::post(io_context_, [results, callback_wrapper, counter, total, permission, status]() {
+           (*results)[permission] = status;
+            int current = counter->fetch_add(1, std::memory_order_relaxed) + 1;
+
+            if (current == *total) {
+              (*callback_wrapper)(*results);
+            }
+          });
      });
    }
-}
+ }
 
-void AccessPortal::GetPermission(const std::string& table, const std::string& id, const std::string& app, std::function<void(PermissionStatus status, std::vector<std::string> permissions)> callback) {
+void AccessPortal::GetPermission(const std::string& table, const std::string& id, const std::string& app, const std::function<void(PermissionStatus status, std::vector<std::string> permissions)>& callback) const {
    std::vector<std::string> permissions;
-   PortalInterface access_interface;
-   access_interface.service_name = "org.freedesktop.impl.portal.PermissionStore";
-   access_interface.object_path = "/org/freedesktop/impl/portal/PermissionStore";
-   access_interface.interface_name = "org.freedesktop.impl.portal.PermissionStore";
-   access_interface.bus_type = BUS_TYPE::SESSION;
-   auto proxy = portal_manager_.GetPortalProxy().GetProxy(access_interface);
+   spdlog::debug("[AccessPortal] GetPermission table={}, id={}, app={}",table,id,app);
+   try {
+     auto& conn = session_bus_.GetConnection();
+     auto proxy = std::make_shared<std::unique_ptr<sdbus::IProxy>>(
+          sdbus::createProxy(
+              conn,
+              sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
+              sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}
+          )
+      );
 
-   proxy->callMethodAsync("GetPermission")
+     (*proxy)->callMethodAsync("GetPermission")
       .onInterface("org.freedesktop.impl.portal.PermissionStore")
       .withArguments(table, id, app)
-      .uponReplyInvoke([callback,table,id,app](std::optional<sdbus::Error> error,
+      .uponReplyInvoke([this,callback,table,id,app,proxy](std::optional<sdbus::Error> error,
                                         const std::vector<std::string>& permissions) {
+        asio::post(io_context_,[callback, error, permissions, table, id, app]() {
           if (error) {
-            const std::string error_msg = error->getMessage();
-            if (error_msg.find("No entry") != std::string::npos ||
-                    error_msg.find("not found") != std::string::npos ||
-                    error->getName() == "org.freedesktop.DBus.Error.UnknownMethod" ||
-                    error->getName() == "org.freedesktop.portal.Error.NotFound") {
-              spdlog::debug("[AccessPortal] Permission not set for {}/{}/{}",
-                                 table, id, app);
-              callback(PermissionStatus::NOT_SET,{});
-              return;
+                      const std::string error_msg = error->getMessage();
+                      if (error_msg.find("No entry") != std::string::npos ||
+                              error_msg.find("not found") != std::string::npos ||
+                              error->getName() == "org.freedesktop.DBus.Error.UnknownMethod" ||
+                              error->getName() == "org.freedesktop.portal.Error.NotFound") {
+                        spdlog::debug("[AccessPortal] Permission not set for {}/{}/{}",
+                                           table, id, app);
+                        callback(PermissionStatus::NOT_SET,{});
+                        return;
+                              }
+                        spdlog::error("[AccessPortal] GetPermission failed: {} ({})", error->getMessage(),error->getName());
+                        callback(PermissionStatus::NOT_SET,{});
+                      return;
                     }
-              spdlog::error("[AccessPortal] GetPermission failed: {} ({})", error->getMessage(),error->getName());
-              callback(PermissionStatus::NOT_SET,{});
-            return;
-          }
 
-        // success to retrieve
-        if (permissions.empty()) {
-                callback(PermissionStatus::NOT_SET, {});
-            } else if (permissions[0] == "yes") {
-                callback(PermissionStatus::GRANTED, permissions);
-            } else if (permissions[0] == "no") {
-                callback(PermissionStatus::DENIED, permissions);
-            } else if (permissions[0] == "ask") {
-                callback(PermissionStatus::ASK, permissions);
-            } else {
-                spdlog::warn("[AccessPortal] Unknown permission value: {}",
-                            permissions[0]);
-                callback(PermissionStatus::NOT_SET, permissions);
-            }
+                  // success to retrieve
+                  if (permissions.empty()) {
+                          callback(PermissionStatus::NOT_SET, {});
+                      } else if (permissions[0] == "yes") {
+                          callback(PermissionStatus::GRANTED, permissions);
+                      } else if (permissions[0] == "no") {
+                          callback(PermissionStatus::DENIED, permissions);
+                      } else if (permissions[0] == "ask") {
+                          callback(PermissionStatus::ASK, permissions);
+                      } else {
+                          spdlog::warn("[AccessPortal] Unknown permission value: {}",
+                                      permissions[0]);
+                          callback(PermissionStatus::NOT_SET, permissions);
+                      }
+        });
       });
+   } catch (const std::exception& e) {
+       spdlog::error("[AccessPortal] Exception: {}", e.what());
+     callback(PermissionStatus::NOT_SET,{});
+   }
  }
 
 void AccessPortal::SetPermission(
@@ -337,43 +141,62 @@ void AccessPortal::SetPermission(
     const std::string& id,
     const std::string& app,
     const std::vector<std::string>& permission,
-    std::function<void(bool ready)> callback) {
-   PortalInterface access_interface;
-   access_interface.service_name = "org.freedesktop.impl.portal.PermissionStore";
-   access_interface.object_path = "/org/freedesktop/impl/portal/PermissionStore";
-   access_interface.interface_name = "org.freedesktop.impl.portal.PermissionStore";
-   access_interface.bus_type = BUS_TYPE::SESSION;
-   auto proxy = portal_manager_.GetPortalProxy().GetProxy(access_interface);
+    const std::function<void(bool ready)>& callback) const {
+   spdlog::debug("[AccessPortal] SetPermission: table={}, id={}, app={}, perm={}",
+                 table, id, app, permission.empty() ? "empty" : permission[0]);
+   try {
+     auto& conn = session_bus_.GetConnection();
+     auto proxy = std::make_shared<std::unique_ptr<sdbus::IProxy>>(
+         sdbus::createProxy(
+             conn,
+             sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
+             sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}
+         )
+     );
+     (*proxy)->callMethodAsync("SetPermission")
+        .onInterface("org.freedesktop.impl.portal.PermissionStore")
+        .withArguments(table, true, id, app, permission)
+        .uponReplyInvoke([callback, proxy](std::optional<sdbus::Error> error) {
+          spdlog::debug("[AccessPortal] SetPermission callback received: error={}",
+                       error.has_value());
 
-   proxy->callMethodAsync("SetPermission")
-      .onInterface("org.freedesktop.impl.portal.PermissionStore")
-      .withArguments(table,true,id, app,permission)
-      .uponReplyInvoke([callback](std::optional<sdbus::Error> error) {
-        if (error) {
-          spdlog::error("[AccessPortal] SetPermission failed: {}", error->getMessage());
-          callback(false);
-        } else {
-          spdlog::debug("[AccessPortal] SetPermission successful");
-          callback(true);
-        }
-      });
-}
+          if (error) {
+            spdlog::error("[AccessPortal] SetPermission failed: {}", error->getMessage());
+            callback(false);
+          } else {
+            spdlog::debug("[AccessPortal] SetPermission successful");
+            callback(true);
+          }
+        });
+
+     spdlog::debug("[AccessPortal] SetPermission async call started");
+
+   } catch (const std::exception& e) {
+     spdlog::error("[AccessPortal] SetPermission exception: {}", e.what());
+     callback(false);
+   }
+ }
 
 void AccessPortal::DeletePermission(const std::string& table,
                                     const std::string& id,
                                     const std::string& app,
-                                    std::function<void(bool ready)> callback) {
-   PortalInterface access_interface;
-   access_interface.service_name = "org.freedesktop.impl.portal.PermissionStore";
-   access_interface.object_path = "/org/freedesktop/impl/portal/PermissionStore";
-   access_interface.interface_name = "org.freedesktop.impl.portal.PermissionStore";
-   access_interface.bus_type = BUS_TYPE::SESSION;
-   auto proxy = portal_manager_.GetPortalProxy().GetProxy(access_interface);
+                                    const std::function<void(bool ready)>& callback) const {
+   spdlog::debug("[AccessPortal] DeletePermission: table={}, id={},app={}", table, id,app);
+   try {
+     auto& conn = session_bus_.GetConnection();
+     auto proxy = std::make_shared<std::unique_ptr<sdbus::IProxy>>(
+          sdbus::createProxy(
+              conn,
+              sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
+              sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}
+          )
+      );
 
-   proxy->callMethodAsync("DeletePermission")
+     (*proxy)->callMethodAsync("DeletePermission")
       .onInterface("org.freedesktop.impl.portal.PermissionStore")
       .withArguments(table, id, app)
-      .uponReplyInvoke([callback](std::optional<sdbus::Error> error) {
+      .uponReplyInvoke([this,callback,proxy](std::optional<sdbus::Error> error) {
+        asio::post(io_context_,[callback,error]() {
           if (error) {
               spdlog::error("[AccessPortal] DeletePermission failed: {}", error->getMessage());
               callback(false);
@@ -381,31 +204,40 @@ void AccessPortal::DeletePermission(const std::string& table,
               spdlog::debug("DeletePermission successful");
               callback(true);
           }
+        });
       });
+   } catch (const std::exception& e) {
+       spdlog::error("[AccessPortal] Exception: {}", e.what());
+     callback(false);
+   }
 }
 
 void AccessPortal::SetResource(
     const std::string& table,
     const std::string& id,
     const std::map<std::string, std::vector<std::string>>& permissions,
-    std::function<void(bool ready)> callback) {
+    const std::function<void(bool ready)>& callback) const {
    auto now = std::chrono::system_clock::now();
    auto now_c = std::chrono::system_clock::to_time_t(now);
    std::ostringstream oss;
    oss << std::put_time(std::localtime(&now_c), "%F %T");
    std::string log = oss.str();
+   spdlog::debug("[AccessPortal] SetResource: table={}, id={}", table, id);
+   try {
+     auto& conn = session_bus_.GetConnection();
+     auto proxy = std::make_shared<std::unique_ptr<sdbus::IProxy>>(
+          sdbus::createProxy(
+              conn,
+              sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
+              sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}
+          )
+      );
 
-   PortalInterface access_interface;
-   access_interface.service_name = "org.freedesktop.impl.portal.PermissionStore";
-   access_interface.object_path = "/org/freedesktop/impl/portal/PermissionStore";
-   access_interface.interface_name = "org.freedesktop.impl.portal.PermissionStore";
-   access_interface.bus_type = BUS_TYPE::SESSION;
-   auto proxy = portal_manager_.GetPortalProxy().GetProxy(access_interface);
-
-   proxy->callMethodAsync("Set")
+     (*proxy)->callMethodAsync("Set")
       .onInterface("org.freedesktop.impl.portal.PermissionStore")
       .withArguments(table, true, id, permissions, log)
-      .uponReplyInvoke([callback](std::optional<sdbus::Error> error) {
+      .uponReplyInvoke([this,callback,proxy](std::optional<sdbus::Error> error) {
+        asio::post(io_context_,[callback,error]() {
           if (error) {
               spdlog::error("[AccessPortal] Set Resource failed: {}", error->getMessage());
               callback(false);
@@ -413,125 +245,172 @@ void AccessPortal::SetResource(
               spdlog::debug("Set Resource successfully");
               callback(true);
           }
+        });
       });
+   } catch (const std::exception& e) {
+       spdlog::error("[AccessPortal] Exception: {}", e.what());
+     callback(false);
+   }
  }
 
 void AccessPortal::DeleteResource(const std::string& table,
                                   const std::string& id,
-                                  std::function<void(bool ready)> callback) {
-   PortalInterface access_interface;
-   access_interface.service_name = "org.freedesktop.impl.portal.PermissionStore";
-   access_interface.object_path = "/org/freedesktop/impl/portal/PermissionStore";
-   access_interface.interface_name = "org.freedesktop.impl.portal.PermissionStore";
-   access_interface.bus_type = BUS_TYPE::SESSION;
-   auto proxy = portal_manager_.GetPortalProxy().GetProxy(access_interface);
+                                  const std::function<void(bool ready)>& callback) const {
+   spdlog::debug("[AccessPortal] DeleteResource: table={}, id={}", table, id);
+   try {
+     auto& conn = session_bus_.GetConnection();
+     auto proxy = std::make_shared<std::unique_ptr<sdbus::IProxy>>(
+          sdbus::createProxy(
+              conn,
+              sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
+              sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}
+          )
+      );
 
-   proxy->callMethodAsync("Delete")
+     (*proxy)->callMethodAsync("Delete")
       .onInterface("org.freedesktop.impl.portal.PermissionStore")
       .withArguments(table,id)
-      .uponReplyInvoke([callback](std::optional<sdbus::Error> error) {
+      .uponReplyInvoke([this,callback,proxy](std::optional<sdbus::Error> error) {
+        asio::post(io_context_,[callback,error]() {
           if (error) {
-              spdlog::error("[AccessPortal] Set Resource failed: {}", error->getMessage());
+              spdlog::error("[AccessPortal] Delete Resource failed: {}", error->getMessage());
               callback(false);
           } else {
               spdlog::debug("Delete Resource successfully");
               callback(true);
           }
+        });
       });
+   } catch (const std::exception& e) {
+       spdlog::error("[AccessPortal] Exception: {}", e.what());
+     callback(false);
+   }
 }
 void AccessPortal::GetAllResource(
     const std::string& table,
-     std::function<void(bool success, std::vector<std::string> resources)> callback) {
-   PortalInterface access_interface;
-   access_interface.service_name = "org.freedesktop.impl.portal.PermissionStore";
-   access_interface.object_path = "/org/freedesktop/impl/portal/PermissionStore";
-   access_interface.interface_name = "org.freedesktop.impl.portal.PermissionStore";
-   access_interface.bus_type = BUS_TYPE::SESSION;
-   auto proxy = portal_manager_.GetPortalProxy().GetProxy(access_interface);
+     const std::function<void(bool success, std::vector<std::string> resources)>& callback) const {
+   spdlog::debug("[AccessPortal] GetAllResources: table={}",table);
+   try {
+     auto& conn = session_bus_.GetConnection();
+     auto proxy = std::make_shared<std::unique_ptr<sdbus::IProxy>>(
+          sdbus::createProxy(
+              conn,
+              sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
+              sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}
+          )
+      );
 
-   proxy->callMethodAsync("List")
-      .onInterface("org.freedesktop.impl.portal.PermissionStore")
-      .withArguments(table)
-      .uponReplyInvoke([callback](std::optional<sdbus::Error> error,const std::vector<std::string>& resources) {
-          if (error) {
-              spdlog::error("[AccessPortal] Get all Resource failed: {}", error->getMessage());
-              callback(false,resources);
-          } else {
-              spdlog::debug("Get all Resource successfully fetched {} resource",resources.size());
-              callback(true,resources);
-          }
-      });
+     (*proxy)->callMethodAsync("List")
+     .onInterface("org.freedesktop.impl.portal.PermissionStore")
+     .withArguments(table)
+     .uponReplyInvoke([this,callback,proxy](std::optional<sdbus::Error> error,const std::vector<std::string>& resources) {
+       asio::post(io_context_,[callback,error,resources]() {
+         if (error) {
+            spdlog::error("[AccessPortal] Get all Resource failed: {}", error->getMessage());
+            callback(false,resources);
+        } else {
+            spdlog::debug("Get all Resource successfully fetched {} resource",resources.size());
+            callback(true,resources);
+        }
+       });
+     });
+
+   } catch (const std::exception& e) {
+       spdlog::error("[AccessPortal] Exception: {}", e.what());
+     callback(false,{});
+   }
 }
 
 void AccessPortal::GetAllPermissions(
     const std::string& table,
     const std::string& id,
-    const std::string& app_id,
-    std::function<void(PermissionStatus status)> callback) {
-   PortalInterface access_interface;
-   access_interface.service_name = "org.freedesktop.impl.portal.PermissionStore";
-   access_interface.object_path = "/org/freedesktop/impl/portal/PermissionStore";
-   access_interface.interface_name = "org.freedesktop.impl.portal.PermissionStore";
-   access_interface.bus_type = BUS_TYPE::SESSION;
-   auto proxy = portal_manager_.GetPortalProxy().GetProxy(access_interface);
+    const std::string& app,
+    const std::function<void(PermissionStatus status)>& callback) const {
+   spdlog::debug("[AccessPortal] GetAllPermissions: table={}, id={}, app={}",table,id,app);
 
-   proxy->callMethodAsync("Lookup")
-      .onInterface("org.freedesktop.impl.portal.PermissionStore")
-      .withArguments(table, id)
-      .uponReplyInvoke([callback,app_id](std::optional<sdbus::Error> error,
-                                        const std::map<std::string, std::vector<std::string>>& permissions,const sdbus::Variant& data) {
-          if (error) {
-            if (error->getMessage().find("No table") != std::string::npos ||
+    try {
+       auto& conn = session_bus_.GetConnection();
+       auto proxy = std::make_shared<std::unique_ptr<sdbus::IProxy>>(
+           sdbus::createProxy(
+               conn,
+               sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
+               sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}
+           )
+       );
+       (*proxy)->callMethodAsync("Lookup")
+          .onInterface("org.freedesktop.impl.portal.PermissionStore")
+          .withArguments(table, id)
+          .uponReplyInvoke([callback, app, table, id, proxy]
+                           (std::optional<sdbus::Error> error,
+                            const std::map<std::string, std::vector<std::string>>& permissions,
+                            const sdbus::Variant& data) {
+            spdlog::debug("[AccessPortal] Callback received: table={}, id={}, error={}",
+                         table, id,error.has_value());
+
+            if (error) {
+              // Handle "not found" as NOT_SET
+              if (error->getMessage().find("No table") != std::string::npos ||
                   error->getMessage().find("not found") != std::string::npos) {
-                  spdlog::debug("[AccessPortal] Table/resource not found");
-                  callback(PermissionStatus::NOT_SET);
-                  return;
+                callback(PermissionStatus::NOT_SET);
+                return;
               }
-              spdlog::error("[AccessPortal] Get All Permissions with lookup failed: {}", error->getMessage());
+              spdlog::error("[AccessPortal] Error: {}", error->getMessage());
               callback(PermissionStatus::NOT_SET);
-            return;
-          }
-        auto item = permissions.find(app_id);
-        if (item == permissions.end() || item->second.empty()) {
-          callback(PermissionStatus::NOT_SET);
-          return;
-        }
-        const std::string& perm = item->second[0];
-        if (perm == "yes") {
-          callback(PermissionStatus::GRANTED);
-        }else if (perm == "no") {
-          callback(PermissionStatus::DENIED);
-        }else if (perm == "ask") {
-          callback(PermissionStatus::ASK);
-        }else {
-          callback(PermissionStatus::NOT_SET);
-        }
-      });
+              return;
+            }
+
+            auto item = permissions.find(app);
+            if (item == permissions.end() || item->second.empty()) {
+              callback(PermissionStatus::NOT_SET);
+              return;
+            }
+
+            const std::string& perm = item->second[0];
+            if (perm == "yes") callback(PermissionStatus::GRANTED);
+            else if (perm == "no") callback(PermissionStatus::DENIED);
+            else if (perm == "ask") callback(PermissionStatus::ASK);
+            else callback(PermissionStatus::NOT_SET);
+          });
+   } catch (const std::exception& e) {
+       spdlog::error("[AccessPortal] Exception: {}", e.what());
+       callback(PermissionStatus::NOT_SET);
+   }
 }
+
 
 void AccessPortal::StoreTimestamp(const std::string& table,
                                   const std::string& id,
                                   const std::string& data,
-                                  std::function<void(bool ready)> callback) {
-   PortalInterface access_interface;
-   access_interface.service_name = "org.freedesktop.impl.portal.PermissionStore";
-   access_interface.object_path = "/org/freedesktop/impl/portal/PermissionStore";
-   access_interface.interface_name = "org.freedesktop.impl.portal.PermissionStore";
-   access_interface.bus_type = BUS_TYPE::SESSION;
-   auto proxy = portal_manager_.GetPortalProxy().GetProxy(access_interface);
+                                  const std::function<void(bool ready)>& callback) const{
+  spdlog::debug("[AccessPortal] StoreTimestamp: table={}, id={}, data={}", table, id,data);
+   try {
+     auto& conn = session_bus_.GetConnection();
+     auto proxy = std::make_shared<std::unique_ptr<sdbus::IProxy>>(
+         sdbus::createProxy(
+             conn,
+             sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
+             sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}
+         )
+     );
 
-   proxy->callMethodAsync("SetValue")
-      .onInterface("org.freedesktop.impl.portal.PermissionStore")
-      .withArguments(table,true,id, data)
-      .uponReplyInvoke([callback](std::optional<sdbus::Error> error) {
-        if (error) {
-          spdlog::error("[AccessPortal] SetPermission failed: {}", error->getMessage());
-          callback(false);
-        } else {
-          spdlog::debug("[AccessPortal] SetPermission successful");
-          callback(true);
-        }
-      });
+     (*proxy)->callMethodAsync("SetValue")
+       .onInterface("org.freedesktop.impl.portal.PermissionStore")
+       .withArguments(table,true,id, data)
+       .uponReplyInvoke([this,callback,proxy](std::optional<sdbus::Error> error) {
+         asio::post(io_context_,[callback,error]() {
+           if (error) {
+           spdlog::error("[AccessPortal] StoreTimestamp failed: {}", error->getMessage());
+           callback(false);
+         } else {
+           spdlog::debug("[AccessPortal] SetPermission successful");
+           callback(true);
+         }
+         });
+       });
+   } catch (const std::exception& e) {
+       spdlog::error("[AccessPortal] Exception: {}", e.what());
+     callback(false);
+   }
 }
 
 }  // namespace flatpak_plugin

--- a/plugins/flatpak/portals/access_portal/access_portal.cc
+++ b/plugins/flatpak/portals/access_portal/access_portal.cc
@@ -1,0 +1,534 @@
+/*
+ * Copyright 2023-2025 Toyota Connected North America
+ * Copyright 2025 Ahmed Wafdy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "access_portal.h"
+
+#include <ctime>
+#include <iomanip>
+#include <numbers>
+#include "asio/post.hpp"
+#include "flatpak/flatpak_shim.h"
+#include "spdlog/spdlog.h"
+
+namespace flatpak_plugin {
+
+ AccessPortal::AccessPortal(
+    PortalManager* portal_manager,
+    asio::io_context& io_context,
+    flutter::EventChannel<flutter::EncodableValue>& event_channel)
+    : portal_manager_(*portal_manager),
+      io_context_(io_context),
+      event_channel_(&event_channel),
+      session_bus_(plugin_common_sdbus::SessionDBus::Instance()) {}
+
+AccessPortal::~AccessPortal() {
+   try {
+     // Clean up any remaining requests
+     for (auto& [handle, request] : requests_) {
+       request->request_proxy->callMethod("Close")
+       .onInterface("org.freedesktop.portal.Request");
+     }
+     requests_.clear();
+   } catch (const std::exception& e) {
+     spdlog::error("Failed to clean up portal requests: {}", e.what());
+   }
+ }
+
+std::string AccessPortal::GenerateHandle(const std::string& app_id) {
+   const std::string sender = session_bus_.GetConnection().getUniqueName();
+
+   // Format is like ":1.234", Should be like "1_234"
+   std::string token_sender = sender.substr(1);
+   std::replace(token_sender.begin(), token_sender.end(), '.', '_');
+
+   const uint32_t token_id = request_counter_.fetch_add(1);
+   std::string app_id_interface = app_id;
+   std::replace(app_id_interface.begin(), app_id_interface.end(), '.', '_');
+
+   const std::string token = app_id_interface + "_" + std::to_string(token_id);
+
+   // Generate handle
+   std::string handle = "/org/freedesktop/portal/desktop/request/" + token_sender + "/" + token;
+
+   return handle;
+ }
+
+std::string AccessPortal::ShowAccessDialog(
+     const std::string& app_id,
+     const std::string& parent_window,
+     const AccessDialogOptions& options) {
+   std::string handle = GenerateHandle(app_id);
+
+   // create a context for the request
+   auto context = std::make_unique<AccessRequest>();
+   context->app_id = app_id;
+   context->options = options;
+   context->handle = handle;
+
+   {
+     std::lock_guard<std::mutex> lock(requests_mutex_);
+     requests_[handle] = std::move(context);
+   }
+   // SetupRequestSignalHandler(handle);
+   // std::map<std::string,sdbus::Variant> portal_options;
+   //
+   // portal_options["modal"] = sdbus::Variant(options.modal);
+   // if (!options.deny_label.empty()) {
+   //   portal_options["deny_label"] = sdbus::Variant(options.deny_label);
+   // }
+   // if (!options.allow_label.empty()) {
+   //   portal_options["grant_label"] = sdbus::Variant(options.allow_label);
+   // }
+   // if (!options.icon.empty()) {
+   //   portal_options["icon"] = sdbus::Variant(options.icon);
+   // }
+
+   PortalInterface access_interface;
+   access_interface.service_name = "org.freedesktop.impl.portal.desktop.gtk";
+   access_interface.object_path = "/org/freedesktop/portal/desktop";
+   access_interface.interface_name = "org.freedesktop.impl.portal.Access";
+   access_interface.bus_type = BUS_TYPE::SESSION;
+   auto proxy = portal_manager_.GetPortalProxy().GetProxy(access_interface);
+
+   try {
+     // call access dialog
+     // proxy->callMethodAsync("AccessDialog")
+     // .onInterface("org.freedesktop.impl.portal.Access")
+     // .withArguments(
+     //  sdbus::ObjectPath(handle),
+     //  app_id,
+     //  parent_window,
+     //  options.title,
+     //  options.subtitle,
+     //  options.body,
+     //  portal_options
+     // )
+     // .uponReplyInvoke([this,handle](std::optional<sdbus::Error> error) {
+     //   if (error) {
+     //     spdlog::error("Failed to show access dialog for {}: {}", handle, error->getMessage());
+     //
+     //
+     //   flutter::EncodableMap event;
+     //                event[flutter::EncodableValue("type")] =
+     //                    flutter::EncodableValue("error");
+     //                event[flutter::EncodableValue("handle")] =
+     //                    flutter::CustomEncodableValue(handle);
+     //                event[flutter::EncodableValue("message")] =
+     //                    flutter::CustomEncodableValue(error->getMessage());
+     //                SendEvent(event);
+     //     std::lock_guard<std::mutex> lock(requests_mutex_);
+     //     requests_.erase(handle);
+     //  }
+     // });
+     spdlog::debug("[AccessPortal] ShowAccessDialog called for {}",handle);
+   } catch (const sdbus::Error& e) {
+     spdlog::error("[AccessPortal] Failed to show access dialog for {}: {}", handle, e.what());
+      requests_.erase(handle);
+     throw;
+   }
+   return handle;
+ }
+
+void AccessPortal::SetupRequestSignalHandler(const std::string& handler) {
+std::lock_guard<std::mutex> lock(requests_mutex_);
+
+  const auto it = requests_.find(handler);
+   if (it == requests_.end()) {
+     spdlog::error("[AccessPortal] Request {} not found", handler);
+     return;
+   }
+
+   AccessRequest* request = it->second.get();
+   request->request_proxy = sdbus::createProxy(
+       session_bus_.GetConnection(),
+       sdbus::ServiceName{"org.freedesktop.portal.Desktop"},
+       sdbus::ObjectPath{handler});
+
+   // subscribe to response signal
+   request->request_proxy->uponSignal("Response")
+   .onInterface("org.freedesktop.portal.Request")
+   .call([this,handler](uint32_t response_code, const std::map<std::string, sdbus::Variant>& results) {
+     spdlog::debug("[AccessPortal] Response received for {}", handler);
+     asio::post(io_context_, [this,handler,response_code,results]() {
+       OnPortalResponse(handler, response_code, results);
+     });
+   });
+   //request->request_proxy->finishRegistration();
+ }
+
+void AccessPortal::OnPortalResponse(
+    const std::string& handle,
+    uint32_t response_code,
+    const std::map<std::string, sdbus::Variant>& results) {
+spdlog::info("[AccessPortal] Response received for {}: {}", handle, response_code);
+  std::unique_ptr<AccessRequest> request;
+
+   {
+  std::lock_guard<std::mutex> lock(requests_mutex_);
+  auto it = requests_.find(handle);
+  if (it == requests_.end()) {
+    spdlog::error("[AccessPortal] Request {} not found", handle);
+    return;
+  }
+  request = std::move(it->second);
+  requests_.erase(it);
+  }
+
+   flutter::EncodableMap event;
+   event[flutter::EncodableValue("type")] = flutter::EncodableValue("access_response");
+   event[flutter::EncodableValue("handle")] = flutter::EncodableValue(handle);
+   event[flutter::EncodableValue("response_code")] = flutter::EncodableValue(response_code);
+
+  std::string response_status;
+   switch (response_code) {
+    case 0:
+      response_status = "granted";
+      break;
+    case 1:
+      response_status = "denied";
+      break;
+    default:
+      response_status = "error";
+       break;
+   }
+  event[flutter::EncodableValue("response_status")] = flutter::CustomEncodableValue(response_status);
+   flutter::EncodableMap result_map;
+
+for (const auto& [key, variant] : results) {
+  try {
+    if (variant.containsValueOfType<std::string>()) {
+      result_map[flutter::CustomEncodableValue(key)] = flutter::CustomEncodableValue(variant.get<std::string>());
+    }else if (variant.containsValueOfType<bool>()) {
+      result_map[flutter::CustomEncodableValue(key)] = flutter::CustomEncodableValue(variant.get<bool>());
+    }else if (variant.containsValueOfType<int32_t>()) {
+      result_map[flutter::CustomEncodableValue(key)] = flutter::CustomEncodableValue(variant.get<int32_t>());
+    }else if (variant.containsValueOfType<uint32_t>()) {
+      result_map[flutter::CustomEncodableValue(key)] = flutter::CustomEncodableValue(variant.get<uint32_t>());
+    }
+  } catch (const std::exception& e) {
+    spdlog::error("[AccessPortal] Failed to parse response {} : {}", handle ,e.what());
+  }
+}
+
+event[flutter::EncodableValue("results")] = flutter::CustomEncodableValue(result_map);
+   if (request->callback) {
+     request->callback(response_code, results);
+   }
+   SendEvent(event);
+}
+
+
+void AccessPortal::SendEvent(const flutter::EncodableMap& event) {
+if (!event_channel_) {
+  spdlog::error("[AccessPortal] Event channel not set");
+  return;
+}
+   asio::post(io_context_, [this,event]() {
+    //  this->shim_->SendAccessEvent(event);
+   });
+}
+
+void AccessPortal::CancelAccessRequest(const std::string& handle) {
+std::lock_guard<std::mutex> lock(requests_mutex_);
+   auto it = requests_.find(handle);
+   if (it == requests_.end()) {
+     spdlog::error("[AccessPortal] Request {} not found", handle);
+     return;
+   }
+   it->second->request_proxy->callMethod("Close")
+   .onInterface("org.freedesktop.portal.Request");
+   requests_.erase(it);
+   spdlog::debug("[AccessPortal] Request {} canceled", handle);
+}
+
+void AccessPortal::CheckAllPermissions(
+    const std::string& app_id,
+    const std::vector<std::string>& permissions,
+    std::function<void(std::map<std::string, PermissionStatus>)> callback) {
+   auto results = std::make_shared<std::map<std::string, PermissionStatus>>();
+   auto counter = std::make_shared<std::atomic<int>>(0);
+   int total = permissions.size();
+
+   for (const auto& permission : permissions) {
+     std::string table = "devices";
+     std::string resource_id = permission;
+     if (permission == "location") {
+        table = "location";
+       resource_id = "location";
+     }else if (permission == "notifications") {
+       table = "notifications";
+       resource_id = "notifications";
+     } else if (permission == "background") {
+       table = "background";
+       resource_id = app_id;
+     }
+     GetAllPermissions(table,resource_id,app_id,[results,callback,counter,total,permission](PermissionStatus status) {
+       (*results)[permission] = status;
+         if(++(*counter) == total) {
+           callback(*results);
+         }
+     });
+   }
+}
+
+void AccessPortal::GetPermission(const std::string& table, const std::string& id, const std::string& app, std::function<void(PermissionStatus status, std::vector<std::string> permissions)> callback) {
+   std::vector<std::string> permissions;
+   PortalInterface access_interface;
+   access_interface.service_name = "org.freedesktop.impl.portal.PermissionStore";
+   access_interface.object_path = "/org/freedesktop/impl/portal/PermissionStore";
+   access_interface.interface_name = "org.freedesktop.impl.portal.PermissionStore";
+   access_interface.bus_type = BUS_TYPE::SESSION;
+   auto proxy = portal_manager_.GetPortalProxy().GetProxy(access_interface);
+
+   proxy->callMethodAsync("GetPermission")
+      .onInterface("org.freedesktop.impl.portal.PermissionStore")
+      .withArguments(table, id, app)
+      .uponReplyInvoke([callback,table,id,app](std::optional<sdbus::Error> error,
+                                        const std::vector<std::string>& permissions) {
+          if (error) {
+            const std::string error_msg = error->getMessage();
+            if (error_msg.find("No entry") != std::string::npos ||
+                    error_msg.find("not found") != std::string::npos ||
+                    error->getName() == "org.freedesktop.DBus.Error.UnknownMethod" ||
+                    error->getName() == "org.freedesktop.portal.Error.NotFound") {
+              spdlog::debug("[AccessPortal] Permission not set for {}/{}/{}",
+                                 table, id, app);
+              callback(PermissionStatus::NOT_SET,{});
+              return;
+                    }
+              spdlog::error("[AccessPortal] GetPermission failed: {} ({})", error->getMessage(),error->getName());
+              callback(PermissionStatus::NOT_SET,{});
+            return;
+          }
+
+        // success to retrieve
+        if (permissions.empty()) {
+                callback(PermissionStatus::NOT_SET, {});
+            } else if (permissions[0] == "yes") {
+                callback(PermissionStatus::GRANTED, permissions);
+            } else if (permissions[0] == "no") {
+                callback(PermissionStatus::DENIED, permissions);
+            } else if (permissions[0] == "ask") {
+                callback(PermissionStatus::ASK, permissions);
+            } else {
+                spdlog::warn("[AccessPortal] Unknown permission value: {}",
+                            permissions[0]);
+                callback(PermissionStatus::NOT_SET, permissions);
+            }
+      });
+ }
+
+void AccessPortal::SetPermission(
+    const std::string& table,
+    const std::string& id,
+    const std::string& app,
+    const std::vector<std::string>& permission,
+    std::function<void(bool ready)> callback) {
+   PortalInterface access_interface;
+   access_interface.service_name = "org.freedesktop.impl.portal.PermissionStore";
+   access_interface.object_path = "/org/freedesktop/impl/portal/PermissionStore";
+   access_interface.interface_name = "org.freedesktop.impl.portal.PermissionStore";
+   access_interface.bus_type = BUS_TYPE::SESSION;
+   auto proxy = portal_manager_.GetPortalProxy().GetProxy(access_interface);
+
+   proxy->callMethodAsync("SetPermission")
+      .onInterface("org.freedesktop.impl.portal.PermissionStore")
+      .withArguments(table,true,id, app,permission)
+      .uponReplyInvoke([callback](std::optional<sdbus::Error> error) {
+        if (error) {
+          spdlog::error("[AccessPortal] SetPermission failed: {}", error->getMessage());
+          callback(false);
+        } else {
+          spdlog::debug("[AccessPortal] SetPermission successful");
+          callback(true);
+        }
+      });
+}
+
+void AccessPortal::DeletePermission(const std::string& table,
+                                    const std::string& id,
+                                    const std::string& app,
+                                    std::function<void(bool ready)> callback) {
+   PortalInterface access_interface;
+   access_interface.service_name = "org.freedesktop.impl.portal.PermissionStore";
+   access_interface.object_path = "/org/freedesktop/impl/portal/PermissionStore";
+   access_interface.interface_name = "org.freedesktop.impl.portal.PermissionStore";
+   access_interface.bus_type = BUS_TYPE::SESSION;
+   auto proxy = portal_manager_.GetPortalProxy().GetProxy(access_interface);
+
+   proxy->callMethodAsync("DeletePermission")
+      .onInterface("org.freedesktop.impl.portal.PermissionStore")
+      .withArguments(table, id, app)
+      .uponReplyInvoke([callback](std::optional<sdbus::Error> error) {
+          if (error) {
+              spdlog::error("[AccessPortal] DeletePermission failed: {}", error->getMessage());
+              callback(false);
+          } else {
+              spdlog::debug("DeletePermission successful");
+              callback(true);
+          }
+      });
+}
+
+void AccessPortal::SetResource(
+    const std::string& table,
+    const std::string& id,
+    const std::map<std::string, std::vector<std::string>>& permissions,
+    std::function<void(bool ready)> callback) {
+   auto now = std::chrono::system_clock::now();
+   auto now_c = std::chrono::system_clock::to_time_t(now);
+   auto log = std::put_time(std::localtime(&now_c), "%F %T");
+   PortalInterface access_interface;
+   access_interface.service_name = "org.freedesktop.impl.portal.PermissionStore";
+   access_interface.object_path = "/org/freedesktop/impl/portal/PermissionStore";
+   access_interface.interface_name = "org.freedesktop.impl.portal.PermissionStore";
+   access_interface.bus_type = BUS_TYPE::SESSION;
+   auto proxy = portal_manager_.GetPortalProxy().GetProxy(access_interface);
+
+   proxy->callMethodAsync("Set")
+      .onInterface("org.freedesktop.impl.portal.PermissionStore")
+      .withArguments(table,true,id, permissions,log._M_fmt)
+      .uponReplyInvoke([callback](std::optional<sdbus::Error> error) {
+          if (error) {
+              spdlog::error("[AccessPortal] Set Resource failed: {}", error->getMessage());
+              callback(false);
+          } else {
+              spdlog::debug("Set Resource successfully");
+              callback(true);
+          }
+      });
+}
+
+void AccessPortal::DeleteResource(const std::string& table,
+                                  const std::string& id,
+                                  std::function<void(bool ready)> callback) {
+   PortalInterface access_interface;
+   access_interface.service_name = "org.freedesktop.impl.portal.PermissionStore";
+   access_interface.object_path = "/org/freedesktop/impl/portal/PermissionStore";
+   access_interface.interface_name = "org.freedesktop.impl.portal.PermissionStore";
+   access_interface.bus_type = BUS_TYPE::SESSION;
+   auto proxy = portal_manager_.GetPortalProxy().GetProxy(access_interface);
+
+   proxy->callMethodAsync("Delete")
+      .onInterface("org.freedesktop.impl.portal.PermissionStore")
+      .withArguments(table,id)
+      .uponReplyInvoke([callback](std::optional<sdbus::Error> error) {
+          if (error) {
+              spdlog::error("[AccessPortal] Set Resource failed: {}", error->getMessage());
+              callback(false);
+          } else {
+              spdlog::debug("Delete Resource successfully");
+              callback(true);
+          }
+      });
+}
+void AccessPortal::GetAllResource(
+    const std::string& table,
+     std::function<void(bool success, std::vector<std::string> resources)> callback) {
+   PortalInterface access_interface;
+   access_interface.service_name = "org.freedesktop.impl.portal.PermissionStore";
+   access_interface.object_path = "/org/freedesktop/impl/portal/PermissionStore";
+   access_interface.interface_name = "org.freedesktop.impl.portal.PermissionStore";
+   access_interface.bus_type = BUS_TYPE::SESSION;
+   auto proxy = portal_manager_.GetPortalProxy().GetProxy(access_interface);
+
+   proxy->callMethodAsync("List")
+      .onInterface("org.freedesktop.impl.portal.PermissionStore")
+      .withArguments(table)
+      .uponReplyInvoke([callback](std::optional<sdbus::Error> error,const std::vector<std::string>& resources) {
+          if (error) {
+              spdlog::error("[AccessPortal] Get all Resource failed: {}", error->getMessage());
+              callback(false,resources);
+          } else {
+              spdlog::debug("Get all Resource successfully fetched {} resource",resources.size());
+              callback(true,resources);
+          }
+      });
+}
+
+void AccessPortal::GetAllPermissions(
+    const std::string& table,
+    const std::string& id,
+    const std::string& app_id,
+    std::function<void(PermissionStatus status)> callback) {
+   PortalInterface access_interface;
+   access_interface.service_name = "org.freedesktop.impl.portal.PermissionStore";
+   access_interface.object_path = "/org/freedesktop/impl/portal/PermissionStore";
+   access_interface.interface_name = "org.freedesktop.impl.portal.PermissionStore";
+   access_interface.bus_type = BUS_TYPE::SESSION;
+   auto proxy = portal_manager_.GetPortalProxy().GetProxy(access_interface);
+
+   proxy->callMethodAsync("Lookup")
+      .onInterface("org.freedesktop.impl.portal.PermissionStore")
+      .withArguments(table, id)
+      .uponReplyInvoke([callback,app_id](std::optional<sdbus::Error> error,
+                                        const std::map<std::string, std::vector<std::string>>& permissions,const sdbus::Variant& data) {
+          if (error) {
+            if (error->getMessage().find("No table") != std::string::npos ||
+                  error->getMessage().find("not found") != std::string::npos) {
+                  spdlog::debug("[AccessPortal] Table/resource not found");
+                  callback(PermissionStatus::NOT_SET);
+                  return;
+              }
+              spdlog::error("[AccessPortal] Get All Permissions with lookup failed: {}", error->getMessage());
+              callback(PermissionStatus::NOT_SET);
+            return;
+          }
+        auto item = permissions.find(app_id);
+        if (item == permissions.end() || item->second.empty()) {
+          callback(PermissionStatus::NOT_SET);
+          return;
+        }
+        const std::string& perm = item->second[0];
+        if (perm == "yes") {
+          callback(PermissionStatus::GRANTED);
+        }else if (perm == "no") {
+          callback(PermissionStatus::DENIED);
+        }else if (perm == "ask") {
+          callback(PermissionStatus::ASK);
+        }else {
+          callback(PermissionStatus::NOT_SET);
+        }
+      });
+}
+
+void AccessPortal::StoreTimestamp(const std::string& table,
+                                  const std::string& id,
+                                  const std::string& data,
+                                  std::function<void(bool ready)> callback) {
+   PortalInterface access_interface;
+   access_interface.service_name = "org.freedesktop.impl.portal.PermissionStore";
+   access_interface.object_path = "/org/freedesktop/impl/portal/PermissionStore";
+   access_interface.interface_name = "org.freedesktop.impl.portal.PermissionStore";
+   access_interface.bus_type = BUS_TYPE::SESSION;
+   auto proxy = portal_manager_.GetPortalProxy().GetProxy(access_interface);
+
+   proxy->callMethodAsync("SetValue")
+      .onInterface("org.freedesktop.impl.portal.PermissionStore")
+      .withArguments(table,true,id, data)
+      .uponReplyInvoke([callback](std::optional<sdbus::Error> error) {
+        if (error) {
+          spdlog::error("[AccessPortal] SetPermission failed: {}", error->getMessage());
+          callback(false);
+        } else {
+          spdlog::debug("[AccessPortal] SetPermission successful");
+          callback(true);
+        }
+      });
+}
+
+}  // namespace flatpak_plugin

--- a/plugins/flatpak/portals/access_portal/access_portal.cc
+++ b/plugins/flatpak/portals/access_portal/access_portal.cc
@@ -24,7 +24,7 @@
 
 namespace flatpak_plugin {
 
- AccessPortal::AccessPortal(
+AccessPortal::AccessPortal(
     PortalManager* portal_manager,
     asio::io_context& io_context,
     flutter::EventChannel<flutter::EncodableValue>& event_channel)
@@ -38,103 +38,117 @@ AccessPortal::~AccessPortal() = default;
 void AccessPortal::CheckAllPermissions(
     const std::string& app,
     const std::vector<std::string>& permissions,
-    const std::function<void(std::map<std::string, PermissionStatus>)>& callback) const {
-   if (permissions.empty()) {
-     spdlog::error("[AccessPortal] CheckAllPermissions: empty");
-     callback({});
-     return;
-   }
+    const std::function<void(std::map<std::string, PermissionStatus>)>&
+        callback) const {
+  if (permissions.empty()) {
+    spdlog::error("[AccessPortal] CheckAllPermissions: empty");
+    callback({});
+    return;
+  }
 
-   auto results = std::make_shared<std::map<std::string, PermissionStatus>>();
-   auto counter = std::make_shared<std::atomic<int>>(0);
-   auto total = std::make_shared<int>(static_cast<int>(permissions.size()));
-   auto callback_wrapper = std::make_shared<std::function<void(std::map<std::string, PermissionStatus>)>>(callback);
+  auto results = std::make_shared<std::map<std::string, PermissionStatus>>();
+  auto counter = std::make_shared<std::atomic<int>>(0);
+  auto total = std::make_shared<int>(static_cast<int>(permissions.size()));
+  auto callback_wrapper = std::make_shared<
+      std::function<void(std::map<std::string, PermissionStatus>)>>(callback);
 
-   for (const auto& permission : permissions) {
-     std::string table = "devices";
-     std::string resource_id = permission;
-     if (permission == "location") {
-       table = "location";
-       resource_id = "location";
-     } else if (permission == "notifications") {
-       table = "notifications";
-       resource_id = "notifications";
-     } else if (permission == "background") {
-       table = "background";
-       resource_id = app;
-     }
+  for (const auto& permission : permissions) {
+    std::string table = "devices";
+    std::string resource_id = permission;
+    if (permission == "location") {
+      table = "location";
+      resource_id = "location";
+    } else if (permission == "notifications") {
+      table = "notifications";
+      resource_id = "notifications";
+    } else if (permission == "background") {
+      table = "background";
+      resource_id = app;
+    }
 
-     GetAllPermissions(table, resource_id, app,
-       [this, results, callback_wrapper, counter, total, permission]
-       (PermissionStatus status) {
-         asio::post(io_context_, [results, callback_wrapper, counter, total, permission, status]() {
-           (*results)[permission] = status;
+    GetAllPermissions(
+        table, resource_id, app,
+        [this, results, callback_wrapper, counter, total,
+         permission](PermissionStatus status) {
+          asio::post(io_context_, [results, callback_wrapper, counter, total,
+                                   permission, status]() {
+            (*results)[permission] = status;
             int current = counter->fetch_add(1, std::memory_order_relaxed) + 1;
 
             if (current == *total) {
               (*callback_wrapper)(*results);
             }
           });
-     });
-   }
- }
-
-void AccessPortal::GetPermission(const std::string& table, const std::string& id, const std::string& app, const std::function<void(PermissionStatus status, std::vector<std::string> permissions)>& callback) const {
-   std::vector<std::string> permissions;
-   spdlog::debug("[AccessPortal] GetPermission table={}, id={}, app={}",table,id,app);
-   try {
-     auto& conn = session_bus_.GetConnection();
-     auto proxy = std::make_shared<std::unique_ptr<sdbus::IProxy>>(
-          sdbus::createProxy(
-              conn,
-              sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
-              sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}
-          )
-      );
-
-     (*proxy)->callMethodAsync("GetPermission")
-      .onInterface("org.freedesktop.impl.portal.PermissionStore")
-      .withArguments(table, id, app)
-      .uponReplyInvoke([this,callback,table,id,app,proxy](std::optional<sdbus::Error> error,
-                                        const std::vector<std::string>& permissions) {
-        asio::post(io_context_,[callback, error, permissions, table, id, app]() {
-          if (error) {
-                      const std::string error_msg = error->getMessage();
-                      if (error_msg.find("No entry") != std::string::npos ||
-                              error_msg.find("not found") != std::string::npos ||
-                              error->getName() == "org.freedesktop.DBus.Error.UnknownMethod" ||
-                              error->getName() == "org.freedesktop.portal.Error.NotFound") {
-                        spdlog::debug("[AccessPortal] Permission not set for {}/{}/{}",
-                                           table, id, app);
-                        callback(PermissionStatus::NOT_SET,{});
-                        return;
-                              }
-                        spdlog::error("[AccessPortal] GetPermission failed: {} ({})", error->getMessage(),error->getName());
-                        callback(PermissionStatus::NOT_SET,{});
-                      return;
-                    }
-
-                  // success to retrieve
-                  if (permissions.empty()) {
-                          callback(PermissionStatus::NOT_SET, {});
-                      } else if (permissions[0] == "yes") {
-                          callback(PermissionStatus::GRANTED, permissions);
-                      } else if (permissions[0] == "no") {
-                          callback(PermissionStatus::DENIED, permissions);
-                      } else if (permissions[0] == "ask") {
-                          callback(PermissionStatus::ASK, permissions);
-                      } else {
-                          spdlog::warn("[AccessPortal] Unknown permission value: {}",
-                                      permissions[0]);
-                          callback(PermissionStatus::NOT_SET, permissions);
-                      }
         });
-      });
-   } catch (const std::exception& e) {
-       spdlog::error("[AccessPortal] Exception: {}", e.what());
-     callback(PermissionStatus::NOT_SET,{});
-   }
- }
+  }
+}
+
+void AccessPortal::GetPermission(
+    const std::string& table,
+    const std::string& id,
+    const std::string& app,
+    const std::function<void(PermissionStatus status,
+                             std::vector<std::string> permissions)>& callback)
+    const {
+  std::vector<std::string> permissions;
+  spdlog::debug("[AccessPortal] GetPermission table={}, id={}, app={}", table,
+                id, app);
+  try {
+    auto& conn = session_bus_.GetConnection();
+    auto proxy =
+        std::make_shared<std::unique_ptr<sdbus::IProxy>>(sdbus::createProxy(
+            conn,
+            sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
+            sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}));
+
+    (*proxy)
+        ->callMethodAsync("GetPermission")
+        .onInterface("org.freedesktop.impl.portal.PermissionStore")
+        .withArguments(table, id, app)
+        .uponReplyInvoke([this, callback, table, id, app, proxy](
+                             std::optional<sdbus::Error> error,
+                             const std::vector<std::string>& permissions) {
+          asio::post(io_context_, [callback, error, permissions, table, id,
+                                   app]() {
+            if (error) {
+              const std::string error_msg = error->getMessage();
+              if (error_msg.find("No entry") != std::string::npos ||
+                  error_msg.find("not found") != std::string::npos ||
+                  error->getName() ==
+                      "org.freedesktop.DBus.Error.UnknownMethod" ||
+                  error->getName() == "org.freedesktop.portal.Error.NotFound") {
+                spdlog::debug("[AccessPortal] Permission not set for {}/{}/{}",
+                              table, id, app);
+                callback(PermissionStatus::NOT_SET, {});
+                return;
+              }
+              spdlog::error("[AccessPortal] GetPermission failed: {} ({})",
+                            error->getMessage(), error->getName());
+              callback(PermissionStatus::NOT_SET, {});
+              return;
+            }
+
+            // success to retrieve
+            if (permissions.empty()) {
+              callback(PermissionStatus::NOT_SET, {});
+            } else if (permissions[0] == "yes") {
+              callback(PermissionStatus::GRANTED, permissions);
+            } else if (permissions[0] == "no") {
+              callback(PermissionStatus::DENIED, permissions);
+            } else if (permissions[0] == "ask") {
+              callback(PermissionStatus::ASK, permissions);
+            } else {
+              spdlog::warn("[AccessPortal] Unknown permission value: {}",
+                           permissions[0]);
+              callback(PermissionStatus::NOT_SET, permissions);
+            }
+          });
+        });
+  } catch (const std::exception& e) {
+    spdlog::error("[AccessPortal] Exception: {}", e.what());
+    callback(PermissionStatus::NOT_SET, {});
+  }
+}
 
 void AccessPortal::SetPermission(
     const std::string& table,
@@ -142,26 +156,28 @@ void AccessPortal::SetPermission(
     const std::string& app,
     const std::vector<std::string>& permission,
     const std::function<void(bool ready)>& callback) const {
-   spdlog::debug("[AccessPortal] SetPermission: table={}, id={}, app={}, perm={}",
-                 table, id, app, permission.empty() ? "empty" : permission[0]);
-   try {
-     auto& conn = session_bus_.GetConnection();
-     auto proxy = std::make_shared<std::unique_ptr<sdbus::IProxy>>(
-         sdbus::createProxy(
-             conn,
-             sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
-             sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}
-         )
-     );
-     (*proxy)->callMethodAsync("SetPermission")
+  spdlog::debug(
+      "[AccessPortal] SetPermission: table={}, id={}, app={}, perm={}", table,
+      id, app, permission.empty() ? "empty" : permission[0]);
+  try {
+    auto& conn = session_bus_.GetConnection();
+    auto proxy =
+        std::make_shared<std::unique_ptr<sdbus::IProxy>>(sdbus::createProxy(
+            conn,
+            sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
+            sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}));
+    (*proxy)
+        ->callMethodAsync("SetPermission")
         .onInterface("org.freedesktop.impl.portal.PermissionStore")
         .withArguments(table, true, id, app, permission)
         .uponReplyInvoke([callback, proxy](std::optional<sdbus::Error> error) {
-          spdlog::debug("[AccessPortal] SetPermission callback received: error={}",
-                       error.has_value());
+          spdlog::debug(
+              "[AccessPortal] SetPermission callback received: error={}",
+              error.has_value());
 
           if (error) {
-            spdlog::error("[AccessPortal] SetPermission failed: {}", error->getMessage());
+            spdlog::error("[AccessPortal] SetPermission failed: {}",
+                          error->getMessage());
             callback(false);
           } else {
             spdlog::debug("[AccessPortal] SetPermission successful");
@@ -169,47 +185,50 @@ void AccessPortal::SetPermission(
           }
         });
 
-     spdlog::debug("[AccessPortal] SetPermission async call started");
+    spdlog::debug("[AccessPortal] SetPermission async call started");
 
-   } catch (const std::exception& e) {
-     spdlog::error("[AccessPortal] SetPermission exception: {}", e.what());
-     callback(false);
-   }
- }
+  } catch (const std::exception& e) {
+    spdlog::error("[AccessPortal] SetPermission exception: {}", e.what());
+    callback(false);
+  }
+}
 
-void AccessPortal::DeletePermission(const std::string& table,
-                                    const std::string& id,
-                                    const std::string& app,
-                                    const std::function<void(bool ready)>& callback) const {
-   spdlog::debug("[AccessPortal] DeletePermission: table={}, id={},app={}", table, id,app);
-   try {
-     auto& conn = session_bus_.GetConnection();
-     auto proxy = std::make_shared<std::unique_ptr<sdbus::IProxy>>(
-          sdbus::createProxy(
-              conn,
-              sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
-              sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}
-          )
-      );
+void AccessPortal::DeletePermission(
+    const std::string& table,
+    const std::string& id,
+    const std::string& app,
+    const std::function<void(bool ready)>& callback) const {
+  spdlog::debug("[AccessPortal] DeletePermission: table={}, id={},app={}",
+                table, id, app);
+  try {
+    auto& conn = session_bus_.GetConnection();
+    auto proxy =
+        std::make_shared<std::unique_ptr<sdbus::IProxy>>(sdbus::createProxy(
+            conn,
+            sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
+            sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}));
 
-     (*proxy)->callMethodAsync("DeletePermission")
-      .onInterface("org.freedesktop.impl.portal.PermissionStore")
-      .withArguments(table, id, app)
-      .uponReplyInvoke([this,callback,proxy](std::optional<sdbus::Error> error) {
-        asio::post(io_context_,[callback,error]() {
-          if (error) {
-              spdlog::error("[AccessPortal] DeletePermission failed: {}", error->getMessage());
-              callback(false);
-          } else {
-              spdlog::debug("DeletePermission successful");
-              callback(true);
-          }
-        });
-      });
-   } catch (const std::exception& e) {
-       spdlog::error("[AccessPortal] Exception: {}", e.what());
-     callback(false);
-   }
+    (*proxy)
+        ->callMethodAsync("DeletePermission")
+        .onInterface("org.freedesktop.impl.portal.PermissionStore")
+        .withArguments(table, id, app)
+        .uponReplyInvoke(
+            [this, callback, proxy](std::optional<sdbus::Error> error) {
+              asio::post(io_context_, [callback, error]() {
+                if (error) {
+                  spdlog::error("[AccessPortal] DeletePermission failed: {}",
+                                error->getMessage());
+                  callback(false);
+                } else {
+                  spdlog::debug("DeletePermission successful");
+                  callback(true);
+                }
+              });
+            });
+  } catch (const std::exception& e) {
+    spdlog::error("[AccessPortal] Exception: {}", e.what());
+    callback(false);
+  }
 }
 
 void AccessPortal::SetResource(
@@ -217,108 +236,115 @@ void AccessPortal::SetResource(
     const std::string& id,
     const std::map<std::string, std::vector<std::string>>& permissions,
     const std::function<void(bool ready)>& callback) const {
-   auto now = std::chrono::system_clock::now();
-   auto now_c = std::chrono::system_clock::to_time_t(now);
-   std::ostringstream oss;
-   oss << std::put_time(std::localtime(&now_c), "%F %T");
-   std::string log = oss.str();
-   spdlog::debug("[AccessPortal] SetResource: table={}, id={}", table, id);
-   try {
-     auto& conn = session_bus_.GetConnection();
-     auto proxy = std::make_shared<std::unique_ptr<sdbus::IProxy>>(
-          sdbus::createProxy(
-              conn,
-              sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
-              sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}
-          )
-      );
+  auto now = std::chrono::system_clock::now();
+  auto now_c = std::chrono::system_clock::to_time_t(now);
+  std::ostringstream oss;
+  oss << std::put_time(std::localtime(&now_c), "%F %T");
+  std::string log = oss.str();
+  spdlog::debug("[AccessPortal] SetResource: table={}, id={}", table, id);
+  try {
+    auto& conn = session_bus_.GetConnection();
+    auto proxy =
+        std::make_shared<std::unique_ptr<sdbus::IProxy>>(sdbus::createProxy(
+            conn,
+            sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
+            sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}));
 
-     (*proxy)->callMethodAsync("Set")
-      .onInterface("org.freedesktop.impl.portal.PermissionStore")
-      .withArguments(table, true, id, permissions, log)
-      .uponReplyInvoke([this,callback,proxy](std::optional<sdbus::Error> error) {
-        asio::post(io_context_,[callback,error]() {
-          if (error) {
-              spdlog::error("[AccessPortal] Set Resource failed: {}", error->getMessage());
-              callback(false);
-          } else {
-              spdlog::debug("Set Resource successfully");
-              callback(true);
-          }
-        });
-      });
-   } catch (const std::exception& e) {
-       spdlog::error("[AccessPortal] Exception: {}", e.what());
-     callback(false);
-   }
- }
+    (*proxy)
+        ->callMethodAsync("Set")
+        .onInterface("org.freedesktop.impl.portal.PermissionStore")
+        .withArguments(table, true, id, permissions, log)
+        .uponReplyInvoke(
+            [this, callback, proxy](std::optional<sdbus::Error> error) {
+              asio::post(io_context_, [callback, error]() {
+                if (error) {
+                  spdlog::error("[AccessPortal] Set Resource failed: {}",
+                                error->getMessage());
+                  callback(false);
+                } else {
+                  spdlog::debug("Set Resource successfully");
+                  callback(true);
+                }
+              });
+            });
+  } catch (const std::exception& e) {
+    spdlog::error("[AccessPortal] Exception: {}", e.what());
+    callback(false);
+  }
+}
 
-void AccessPortal::DeleteResource(const std::string& table,
-                                  const std::string& id,
-                                  const std::function<void(bool ready)>& callback) const {
-   spdlog::debug("[AccessPortal] DeleteResource: table={}, id={}", table, id);
-   try {
-     auto& conn = session_bus_.GetConnection();
-     auto proxy = std::make_shared<std::unique_ptr<sdbus::IProxy>>(
-          sdbus::createProxy(
-              conn,
-              sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
-              sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}
-          )
-      );
+void AccessPortal::DeleteResource(
+    const std::string& table,
+    const std::string& id,
+    const std::function<void(bool ready)>& callback) const {
+  spdlog::debug("[AccessPortal] DeleteResource: table={}, id={}", table, id);
+  try {
+    auto& conn = session_bus_.GetConnection();
+    auto proxy =
+        std::make_shared<std::unique_ptr<sdbus::IProxy>>(sdbus::createProxy(
+            conn,
+            sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
+            sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}));
 
-     (*proxy)->callMethodAsync("Delete")
-      .onInterface("org.freedesktop.impl.portal.PermissionStore")
-      .withArguments(table,id)
-      .uponReplyInvoke([this,callback,proxy](std::optional<sdbus::Error> error) {
-        asio::post(io_context_,[callback,error]() {
-          if (error) {
-              spdlog::error("[AccessPortal] Delete Resource failed: {}", error->getMessage());
-              callback(false);
-          } else {
-              spdlog::debug("Delete Resource successfully");
-              callback(true);
-          }
-        });
-      });
-   } catch (const std::exception& e) {
-       spdlog::error("[AccessPortal] Exception: {}", e.what());
-     callback(false);
-   }
+    (*proxy)
+        ->callMethodAsync("Delete")
+        .onInterface("org.freedesktop.impl.portal.PermissionStore")
+        .withArguments(table, id)
+        .uponReplyInvoke(
+            [this, callback, proxy](std::optional<sdbus::Error> error) {
+              asio::post(io_context_, [callback, error]() {
+                if (error) {
+                  spdlog::error("[AccessPortal] Delete Resource failed: {}",
+                                error->getMessage());
+                  callback(false);
+                } else {
+                  spdlog::debug("Delete Resource successfully");
+                  callback(true);
+                }
+              });
+            });
+  } catch (const std::exception& e) {
+    spdlog::error("[AccessPortal] Exception: {}", e.what());
+    callback(false);
+  }
 }
 void AccessPortal::GetAllResource(
     const std::string& table,
-     const std::function<void(bool success, std::vector<std::string> resources)>& callback) const {
-   spdlog::debug("[AccessPortal] GetAllResources: table={}",table);
-   try {
-     auto& conn = session_bus_.GetConnection();
-     auto proxy = std::make_shared<std::unique_ptr<sdbus::IProxy>>(
-          sdbus::createProxy(
-              conn,
-              sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
-              sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}
-          )
-      );
+    const std::function<void(bool success, std::vector<std::string> resources)>&
+        callback) const {
+  spdlog::debug("[AccessPortal] GetAllResources: table={}", table);
+  try {
+    auto& conn = session_bus_.GetConnection();
+    auto proxy =
+        std::make_shared<std::unique_ptr<sdbus::IProxy>>(sdbus::createProxy(
+            conn,
+            sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
+            sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}));
 
-     (*proxy)->callMethodAsync("List")
-     .onInterface("org.freedesktop.impl.portal.PermissionStore")
-     .withArguments(table)
-     .uponReplyInvoke([this,callback,proxy](std::optional<sdbus::Error> error,const std::vector<std::string>& resources) {
-       asio::post(io_context_,[callback,error,resources]() {
-         if (error) {
-            spdlog::error("[AccessPortal] Get all Resource failed: {}", error->getMessage());
-            callback(false,resources);
-        } else {
-            spdlog::debug("Get all Resource successfully fetched {} resource",resources.size());
-            callback(true,resources);
-        }
-       });
-     });
+    (*proxy)
+        ->callMethodAsync("List")
+        .onInterface("org.freedesktop.impl.portal.PermissionStore")
+        .withArguments(table)
+        .uponReplyInvoke([this, callback, proxy](
+                             std::optional<sdbus::Error> error,
+                             const std::vector<std::string>& resources) {
+          asio::post(io_context_, [callback, error, resources]() {
+            if (error) {
+              spdlog::error("[AccessPortal] Get all Resource failed: {}",
+                            error->getMessage());
+              callback(false, resources);
+            } else {
+              spdlog::debug("Get all Resource successfully fetched {} resource",
+                            resources.size());
+              callback(true, resources);
+            }
+          });
+        });
 
-   } catch (const std::exception& e) {
-       spdlog::error("[AccessPortal] Exception: {}", e.what());
-     callback(false,{});
-   }
+  } catch (const std::exception& e) {
+    spdlog::error("[AccessPortal] Exception: {}", e.what());
+    callback(false, {});
+  }
 }
 
 void AccessPortal::GetAllPermissions(
@@ -326,91 +352,101 @@ void AccessPortal::GetAllPermissions(
     const std::string& id,
     const std::string& app,
     const std::function<void(PermissionStatus status)>& callback) const {
-   spdlog::debug("[AccessPortal] GetAllPermissions: table={}, id={}, app={}",table,id,app);
+  spdlog::debug("[AccessPortal] GetAllPermissions: table={}, id={}, app={}",
+                table, id, app);
 
-    try {
-       auto& conn = session_bus_.GetConnection();
-       auto proxy = std::make_shared<std::unique_ptr<sdbus::IProxy>>(
-           sdbus::createProxy(
-               conn,
-               sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
-               sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}
-           )
-       );
-       (*proxy)->callMethodAsync("Lookup")
-          .onInterface("org.freedesktop.impl.portal.PermissionStore")
-          .withArguments(table, id)
-          .uponReplyInvoke([callback, app, table, id, proxy]
-                           (std::optional<sdbus::Error> error,
-                            const std::map<std::string, std::vector<std::string>>& permissions,
-                            const sdbus::Variant& data) {
-            spdlog::debug("[AccessPortal] Callback received: table={}, id={}, error={}",
-                         table, id,error.has_value());
+  try {
+    auto& conn = session_bus_.GetConnection();
+    auto proxy =
+        std::make_shared<std::unique_ptr<sdbus::IProxy>>(sdbus::createProxy(
+            conn,
+            sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
+            sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}));
+    (*proxy)
+        ->callMethodAsync("Lookup")
+        .onInterface("org.freedesktop.impl.portal.PermissionStore")
+        .withArguments(table, id)
+        .uponReplyInvoke(
+            [callback, app, table, id, proxy](
+                std::optional<sdbus::Error> error,
+                const std::map<std::string, std::vector<std::string>>&
+                    permissions,
+                const sdbus::Variant& data) {
+              spdlog::debug(
+                  "[AccessPortal] Callback received: table={}, id={}, error={}",
+                  table, id, error.has_value());
 
-            if (error) {
-              // Handle "not found" as NOT_SET
-              if (error->getMessage().find("No table") != std::string::npos ||
-                  error->getMessage().find("not found") != std::string::npos) {
+              if (error) {
+                // Handle "not found" as NOT_SET
+                if (error->getMessage().find("No table") != std::string::npos ||
+                    error->getMessage().find("not found") !=
+                        std::string::npos) {
+                  callback(PermissionStatus::NOT_SET);
+                  return;
+                }
+                spdlog::error("[AccessPortal] Error: {}", error->getMessage());
                 callback(PermissionStatus::NOT_SET);
                 return;
               }
-              spdlog::error("[AccessPortal] Error: {}", error->getMessage());
-              callback(PermissionStatus::NOT_SET);
-              return;
-            }
 
-            auto item = permissions.find(app);
-            if (item == permissions.end() || item->second.empty()) {
-              callback(PermissionStatus::NOT_SET);
-              return;
-            }
+              auto item = permissions.find(app);
+              if (item == permissions.end() || item->second.empty()) {
+                callback(PermissionStatus::NOT_SET);
+                return;
+              }
 
-            const std::string& perm = item->second[0];
-            if (perm == "yes") callback(PermissionStatus::GRANTED);
-            else if (perm == "no") callback(PermissionStatus::DENIED);
-            else if (perm == "ask") callback(PermissionStatus::ASK);
-            else callback(PermissionStatus::NOT_SET);
-          });
-   } catch (const std::exception& e) {
-       spdlog::error("[AccessPortal] Exception: {}", e.what());
-       callback(PermissionStatus::NOT_SET);
-   }
+              const std::string& perm = item->second[0];
+              if (perm == "yes")
+                callback(PermissionStatus::GRANTED);
+              else if (perm == "no")
+                callback(PermissionStatus::DENIED);
+              else if (perm == "ask")
+                callback(PermissionStatus::ASK);
+              else
+                callback(PermissionStatus::NOT_SET);
+            });
+  } catch (const std::exception& e) {
+    spdlog::error("[AccessPortal] Exception: {}", e.what());
+    callback(PermissionStatus::NOT_SET);
+  }
 }
 
+void AccessPortal::StoreTimestamp(
+    const std::string& table,
+    const std::string& id,
+    const std::string& data,
+    const std::function<void(bool ready)>& callback) const {
+  spdlog::debug("[AccessPortal] StoreTimestamp: table={}, id={}, data={}",
+                table, id, data);
+  try {
+    auto& conn = session_bus_.GetConnection();
+    auto proxy =
+        std::make_shared<std::unique_ptr<sdbus::IProxy>>(sdbus::createProxy(
+            conn,
+            sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
+            sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}));
 
-void AccessPortal::StoreTimestamp(const std::string& table,
-                                  const std::string& id,
-                                  const std::string& data,
-                                  const std::function<void(bool ready)>& callback) const{
-  spdlog::debug("[AccessPortal] StoreTimestamp: table={}, id={}, data={}", table, id,data);
-   try {
-     auto& conn = session_bus_.GetConnection();
-     auto proxy = std::make_shared<std::unique_ptr<sdbus::IProxy>>(
-         sdbus::createProxy(
-             conn,
-             sdbus::ServiceName{"org.freedesktop.impl.portal.PermissionStore"},
-             sdbus::ObjectPath{"/org/freedesktop/impl/portal/PermissionStore"}
-         )
-     );
-
-     (*proxy)->callMethodAsync("SetValue")
-       .onInterface("org.freedesktop.impl.portal.PermissionStore")
-       .withArguments(table,true,id, data)
-       .uponReplyInvoke([this,callback,proxy](std::optional<sdbus::Error> error) {
-         asio::post(io_context_,[callback,error]() {
-           if (error) {
-           spdlog::error("[AccessPortal] StoreTimestamp failed: {}", error->getMessage());
-           callback(false);
-         } else {
-           spdlog::debug("[AccessPortal] SetPermission successful");
-           callback(true);
-         }
-         });
-       });
-   } catch (const std::exception& e) {
-       spdlog::error("[AccessPortal] Exception: {}", e.what());
-     callback(false);
-   }
+    (*proxy)
+        ->callMethodAsync("SetValue")
+        .onInterface("org.freedesktop.impl.portal.PermissionStore")
+        .withArguments(table, true, id, data)
+        .uponReplyInvoke(
+            [this, callback, proxy](std::optional<sdbus::Error> error) {
+              asio::post(io_context_, [callback, error]() {
+                if (error) {
+                  spdlog::error("[AccessPortal] StoreTimestamp failed: {}",
+                                error->getMessage());
+                  callback(false);
+                } else {
+                  spdlog::debug("[AccessPortal] SetPermission successful");
+                  callback(true);
+                }
+              });
+            });
+  } catch (const std::exception& e) {
+    spdlog::error("[AccessPortal] Exception: {}", e.what());
+    callback(false);
+  }
 }
 
 }  // namespace flatpak_plugin

--- a/plugins/flatpak/portals/access_portal/access_portal.cc
+++ b/plugins/flatpak/portals/access_portal/access_portal.cc
@@ -24,13 +24,8 @@
 
 namespace flatpak_plugin {
 
-AccessPortal::AccessPortal(
-    PortalManager* portal_manager,
-    asio::io_context& io_context,
-    flutter::EventChannel<flutter::EncodableValue>& event_channel)
-    : portal_manager_(*portal_manager),
-      io_context_(io_context),
-      event_channel_(&event_channel),
+AccessPortal::AccessPortal(asio::io_context& io_context)
+    : io_context_(io_context),
       session_bus_(plugin_common_sdbus::SessionDBus::Instance()) {}
 
 AccessPortal::~AccessPortal() = default;
@@ -370,8 +365,7 @@ void AccessPortal::GetAllPermissions(
             [callback, app, table, id, proxy](
                 std::optional<sdbus::Error> error,
                 const std::map<std::string, std::vector<std::string>>&
-                    permissions,
-                const sdbus::Variant& data) {
+                    permissions) {
               spdlog::debug(
                   "[AccessPortal] Callback received: table={}, id={}, error={}",
                   table, id, error.has_value());

--- a/plugins/flatpak/portals/access_portal/access_portal.cc
+++ b/plugins/flatpak/portals/access_portal/access_portal.cc
@@ -391,7 +391,10 @@ void AccessPortal::SetResource(
     std::function<void(bool ready)> callback) {
    auto now = std::chrono::system_clock::now();
    auto now_c = std::chrono::system_clock::to_time_t(now);
-   auto log = std::put_time(std::localtime(&now_c), "%F %T");
+   std::ostringstream oss;
+   oss << std::put_time(std::localtime(&now_c), "%F %T");
+   std::string log = oss.str();
+
    PortalInterface access_interface;
    access_interface.service_name = "org.freedesktop.impl.portal.PermissionStore";
    access_interface.object_path = "/org/freedesktop/impl/portal/PermissionStore";
@@ -401,7 +404,7 @@ void AccessPortal::SetResource(
 
    proxy->callMethodAsync("Set")
       .onInterface("org.freedesktop.impl.portal.PermissionStore")
-      .withArguments(table,true,id, permissions,log._M_fmt)
+      .withArguments(table, true, id, permissions, log)
       .uponReplyInvoke([callback](std::optional<sdbus::Error> error) {
           if (error) {
               spdlog::error("[AccessPortal] Set Resource failed: {}", error->getMessage());
@@ -411,7 +414,7 @@ void AccessPortal::SetResource(
               callback(true);
           }
       });
-}
+ }
 
 void AccessPortal::DeleteResource(const std::string& table,
                                   const std::string& id,

--- a/plugins/flatpak/portals/access_portal/access_portal.cc
+++ b/plugins/flatpak/portals/access_portal/access_portal.cc
@@ -28,8 +28,6 @@ AccessPortal::AccessPortal(asio::io_context& io_context)
     : io_context_(io_context),
       session_bus_(plugin_common_sdbus::SessionDBus::Instance()) {}
 
-AccessPortal::~AccessPortal() = default;
-
 void AccessPortal::CheckAllPermissions(
     const std::string& app,
     const std::vector<std::string>& permissions,
@@ -100,45 +98,50 @@ void AccessPortal::GetPermission(
         ->callMethodAsync("GetPermission")
         .onInterface("org.freedesktop.impl.portal.PermissionStore")
         .withArguments(table, id, app)
-        .uponReplyInvoke([this, callback, table, id, app, proxy](
-                             std::optional<sdbus::Error> error,
-                             const std::vector<std::string>& permissions) {
-          asio::post(io_context_, [callback, error, permissions, table, id,
-                                   app]() {
-            if (error) {
-              const std::string error_msg = error->getMessage();
-              if (error_msg.find("No entry") != std::string::npos ||
-                  error_msg.find("not found") != std::string::npos ||
-                  error->getName() ==
-                      "org.freedesktop.DBus.Error.UnknownMethod" ||
-                  error->getName() == "org.freedesktop.portal.Error.NotFound") {
-                spdlog::debug("[AccessPortal] Permission not set for {}/{}/{}",
-                              table, id, app);
-                callback(PermissionStatus::NOT_SET, {});
-                return;
-              }
-              spdlog::error("[AccessPortal] GetPermission failed: {} ({})",
-                            error->getMessage(), error->getName());
-              callback(PermissionStatus::NOT_SET, {});
-              return;
-            }
+        .uponReplyInvoke(
+            [this, callback, table, id, app,
+             proxy](  // proxy captured to extend lifetime
+                std::optional<sdbus::Error>
+                    error,  // NOLINT(performance-unnecessary-value-param)
+                const std::vector<std::string>& permissions) {
+              asio::post(io_context_, [callback, error, permissions, table, id,
+                                       app]() {
+                if (error) {
+                  const std::string error_msg = error->getMessage();
+                  if (error_msg.find("No entry") != std::string::npos ||
+                      error_msg.find("not found") != std::string::npos ||
+                      error->getName() ==
+                          "org.freedesktop.DBus.Error.UnknownMethod" ||
+                      error->getName() ==
+                          "org.freedesktop.portal.Error.NotFound") {
+                    spdlog::debug(
+                        "[AccessPortal] Permission not set for {}/{}/{}", table,
+                        id, app);
+                    callback(PermissionStatus::NOT_SET, {});
+                    return;
+                  }
+                  spdlog::error("[AccessPortal] GetPermission failed: {} ({})",
+                                error->getMessage(), error->getName());
+                  callback(PermissionStatus::NOT_SET, {});
+                  return;
+                }
 
-            // success to retrieve
-            if (permissions.empty()) {
-              callback(PermissionStatus::NOT_SET, {});
-            } else if (permissions[0] == "yes") {
-              callback(PermissionStatus::GRANTED, permissions);
-            } else if (permissions[0] == "no") {
-              callback(PermissionStatus::DENIED, permissions);
-            } else if (permissions[0] == "ask") {
-              callback(PermissionStatus::ASK, permissions);
-            } else {
-              spdlog::warn("[AccessPortal] Unknown permission value: {}",
-                           permissions[0]);
-              callback(PermissionStatus::NOT_SET, permissions);
-            }
-          });
-        });
+                // success to retrieve
+                if (permissions.empty()) {
+                  callback(PermissionStatus::NOT_SET, {});
+                } else if (permissions[0] == "yes") {
+                  callback(PermissionStatus::GRANTED, permissions);
+                } else if (permissions[0] == "no") {
+                  callback(PermissionStatus::DENIED, permissions);
+                } else if (permissions[0] == "ask") {
+                  callback(PermissionStatus::ASK, permissions);
+                } else {
+                  spdlog::warn("[AccessPortal] Unknown permission value: {}",
+                               permissions[0]);
+                  callback(PermissionStatus::NOT_SET, permissions);
+                }
+              });
+            });
   } catch (const std::exception& e) {
     spdlog::error("[AccessPortal] Exception: {}", e.what());
     callback(PermissionStatus::NOT_SET, {});
@@ -165,20 +168,23 @@ void AccessPortal::SetPermission(
         ->callMethodAsync("SetPermission")
         .onInterface("org.freedesktop.impl.portal.PermissionStore")
         .withArguments(table, true, id, app, permission)
-        .uponReplyInvoke([callback, proxy](std::optional<sdbus::Error> error) {
-          spdlog::debug(
-              "[AccessPortal] SetPermission callback received: error={}",
-              error.has_value());
+        .uponReplyInvoke(
+            [callback, proxy]  // proxy captured to extend lifetime
+            (std::optional<sdbus::Error>
+                 error) {  // NOLINT(performance-unnecessary-value-param)
+              spdlog::debug(
+                  "[AccessPortal] SetPermission callback received: error={}",
+                  error.has_value());
 
-          if (error) {
-            spdlog::error("[AccessPortal] SetPermission failed: {}",
-                          error->getMessage());
-            callback(false);
-          } else {
-            spdlog::debug("[AccessPortal] SetPermission successful");
-            callback(true);
-          }
-        });
+              if (error) {
+                spdlog::error("[AccessPortal] SetPermission failed: {}",
+                              error->getMessage());
+                callback(false);
+              } else {
+                spdlog::debug("[AccessPortal] SetPermission successful");
+                callback(true);
+              }
+            });
 
     spdlog::debug("[AccessPortal] SetPermission async call started");
 
@@ -208,7 +214,9 @@ void AccessPortal::DeletePermission(
         .onInterface("org.freedesktop.impl.portal.PermissionStore")
         .withArguments(table, id, app)
         .uponReplyInvoke(
-            [this, callback, proxy](std::optional<sdbus::Error> error) {
+            [this, callback, proxy]  // proxy captured to extend lifetime
+            (std::optional<sdbus::Error>
+                 error) {  // NOLINT(performance-unnecessary-value-param)
               asio::post(io_context_, [callback, error]() {
                 if (error) {
                   spdlog::error("[AccessPortal] DeletePermission failed: {}",
@@ -250,7 +258,9 @@ void AccessPortal::SetResource(
         .onInterface("org.freedesktop.impl.portal.PermissionStore")
         .withArguments(table, true, id, permissions, log)
         .uponReplyInvoke(
-            [this, callback, proxy](std::optional<sdbus::Error> error) {
+            [this, callback, proxy]  // proxy captured to extend lifetime
+            (std::optional<sdbus::Error>
+                 error) {  // NOLINT(performance-unnecessary-value-param)
               asio::post(io_context_, [callback, error]() {
                 if (error) {
                   spdlog::error("[AccessPortal] Set Resource failed: {}",
@@ -286,7 +296,9 @@ void AccessPortal::DeleteResource(
         .onInterface("org.freedesktop.impl.portal.PermissionStore")
         .withArguments(table, id)
         .uponReplyInvoke(
-            [this, callback, proxy](std::optional<sdbus::Error> error) {
+            [this, callback, proxy]  // proxy captured to extend lifetime
+            (std::optional<sdbus::Error>
+                 error) {  // NOLINT(performance-unnecessary-value-param)
               asio::post(io_context_, [callback, error]() {
                 if (error) {
                   spdlog::error("[AccessPortal] Delete Resource failed: {}",
@@ -320,21 +332,24 @@ void AccessPortal::GetAllResource(
         ->callMethodAsync("List")
         .onInterface("org.freedesktop.impl.portal.PermissionStore")
         .withArguments(table)
-        .uponReplyInvoke([this, callback, proxy](
-                             std::optional<sdbus::Error> error,
-                             const std::vector<std::string>& resources) {
-          asio::post(io_context_, [callback, error, resources]() {
-            if (error) {
-              spdlog::error("[AccessPortal] Get all Resource failed: {}",
-                            error->getMessage());
-              callback(false, resources);
-            } else {
-              spdlog::debug("Get all Resource successfully fetched {} resource",
-                            resources.size());
-              callback(true, resources);
-            }
-          });
-        });
+        .uponReplyInvoke(
+            [this, callback, proxy]  // proxy captured to extend lifetime
+            (std::optional<sdbus::Error>
+                 error,  // NOLINT(performance-unnecessary-value-param)
+             const std::vector<std::string>& resources) {
+              asio::post(io_context_, [callback, error, resources]() {
+                if (error) {
+                  spdlog::error("[AccessPortal] Get all Resource failed: {}",
+                                error->getMessage());
+                  callback(false, resources);
+                } else {
+                  spdlog::debug(
+                      "Get all Resource successfully fetched {} resource",
+                      resources.size());
+                  callback(true, resources);
+                }
+              });
+            });
 
   } catch (const std::exception& e) {
     spdlog::error("[AccessPortal] Exception: {}", e.what());
@@ -362,10 +377,12 @@ void AccessPortal::GetAllPermissions(
         .onInterface("org.freedesktop.impl.portal.PermissionStore")
         .withArguments(table, id)
         .uponReplyInvoke(
-            [callback, app, table, id, proxy](
-                std::optional<sdbus::Error> error,
-                const std::map<std::string, std::vector<std::string>>&
-                    permissions) {
+            [callback, app, table, id,
+             proxy]  // proxy captured to extend lifetime
+            (std::optional<sdbus::Error>
+                 error,  // NOLINT(performance-unnecessary-value-param)
+             const std::map<std::string, std::vector<std::string>>&
+                 permissions) {
               spdlog::debug(
                   "[AccessPortal] Callback received: table={}, id={}, error={}",
                   table, id, error.has_value());
@@ -425,7 +442,9 @@ void AccessPortal::StoreTimestamp(
         .onInterface("org.freedesktop.impl.portal.PermissionStore")
         .withArguments(table, true, id, data)
         .uponReplyInvoke(
-            [this, callback, proxy](std::optional<sdbus::Error> error) {
+            [this, callback, proxy]  // proxy captured to extend lifetime
+            (std::optional<sdbus::Error>
+                 error) {  // NOLINT(performance-unnecessary-value-param)
               asio::post(io_context_, [callback, error]() {
                 if (error) {
                   spdlog::error("[AccessPortal] StoreTimestamp failed: {}",

--- a/plugins/flatpak/portals/access_portal/access_portal.h
+++ b/plugins/flatpak/portals/access_portal/access_portal.h
@@ -26,34 +26,27 @@
 #include "plugins/common/sdbus/sdbus.h"
 
 namespace flatpak_plugin {
-struct AccessDialogOptions {
-  std::string title;
-  std::string icon;
-  bool modal = true;
-};
-
-struct AccessRequest {
-  std::string handle;
-  std::string app_id;
-  AccessDialogOptions options;
-  std::unique_ptr<sdbus::IProxy> request_proxy;
-  std::function<void(uint32_t,std::map<std::string,sdbus::Variant>)> callback;
+enum PermissionStatus {
+  GRANTED,      // "yes"
+  DENIED,       // "no"
+  ASK,          // "ask"
+  NOT_SET       // No entry exists
 };
 
 class AccessPortal {
 public:
-  enum class PermissionStatus {
-    GRANTED,      // "yes"
-    DENIED,       // "no"
-    ASK,          // "ask"
-    NOT_SET       // No entry exists
-  };
   explicit AccessPortal(PortalManager* portal_manager,asio::io_context& io_context,flutter::EventChannel<flutter::EncodableValue>& event_channel);
 
   ~AccessPortal();
 
+  /**
+   * \brief Check all permissions for app to launch.
+   * \param app Application that needs access to a resource.
+   * \param permissions Permission assigned to app could be 'yes','no' or 'ask'.
+   * \param callback Callback function for async operations.
+   */
+void CheckAllPermissions(const std::string& app,const std::vector<std::string>& permissions,const std::function<void(std::map<std::string,PermissionStatus>)>& callback)const;
 
-  void CheckAllPermissions(const std::string& app_id,const std::vector<std::string>& permissions,std::function<void(std::map<std::string,PermissionStatus>)> callback);
   /**
    * \brief Sets permission for app.
    * \param table Table of resources for apps which could be either a device or a feature.
@@ -63,7 +56,7 @@ public:
    * \param callback Callback function for async operations.
    * \return String of Stored permission.
    */
-  void SetPermission(const std::string& table,const std::string& id,const std::string& app,const std::vector<std::string>& permission,std::function<void(bool ready)> callback);
+  void SetPermission(const std::string& table,const std::string& id,const std::string& app,const std::vector<std::string>& permission,const std::function<void(bool ready)>& callback) const;
 
   /**
    * \brief Retrieves permission for app.
@@ -73,30 +66,31 @@ public:
    * \param callback Callback function for async operations.
    * \return String of Stored permission.
    */
-  void GetPermission(const std::string& table,const std::string& id,const std::string& app,std::function<void(PermissionStatus status, std::vector<std::string> permissions)> callback);
+  void GetPermission(const std::string& table,const std::string& id,const std::string& app,const std::function<void(PermissionStatus status, std::vector<std::string> permissions)>& callback) const;
 
   /**
    * \brief Delete permission for app.
    * \param table Table of resources for apps which could be either a device or a feature.
    * \param id Identifier for the resource in the table.
    * \param app Application that needs access to a resource.
-   * \param ready_callback Callback function for async operations.
+   * \param callback Callback function for async operations.
    * \return String of Stored permission.
    */
-  void DeletePermission(const std::string& table,const std::string& id,const std::string& app,std::function<void(bool ready)> callback);
+  void DeletePermission(const std::string& table,const std::string& id,const std::string& app,const std::function<void(bool ready)>& callback)const;
 
   /**
    * \brief Retrieves all permissions for a specific resource.
    * \param table Table of resources for apps which could be either a device or a feature.
    * \param id Identifier for the resource in the table.
+   * \param app Application that needs access to a resource
    * \param callback Callback function for async operations.
    * \return Map of Stored permissions to a resource.
    */
   void GetAllPermissions(
     const std::string& table,
     const std::string& id,
-    const std::string& app_id,
-    std::function<void(PermissionStatus status)> callback);
+    const std::string& app,
+    const std::function<void(PermissionStatus status)>& callback)const;
 
   /**
    * \brief Sets an entire resource entry with multiple app permissions at once.
@@ -105,52 +99,36 @@ public:
    * \param permissions Permissions assigned to apps in a resource could be 'yes','no' or 'ask'.
    * \param callback Callback function for async operations.
    */
-  void SetResource(const std::string& table,const std::string& id,const std::map<std::string, std::vector<std::string>>& permissions,std::function<void(bool ready)> callback);
+  void SetResource(const std::string& table,const std::string& id,const std::map<std::string, std::vector<std::string>>& permissions,const std::function<void(bool ready)>& callback)const;
 
   /**
    * \brief Delete an entire resource and ALL associated app permissions.
    * \param table Table of resources for apps which could be either a device or a feature.
    * \param id Identifier for the resource in the table.
-   * \param ready_callback Callback function for async operations.
+   * \param callback Callback function for async operations.
    */
-  void DeleteResource(const std::string& table,const std::string& id,std::function<void(bool ready)> callback);
+  void DeleteResource(const std::string& table,const std::string& id,const std::function<void(bool ready)>& callback)const;
 
   /**
    * \brief Get all device types that have any permissions set.
    * \param table Table of resources for apps which could be either a device or a feature.
    * \param callback Callback function for async operations.
    */
-  void GetAllResource(const std::string& table, std::function<void(bool success, std::vector<std::string> resources)> callback);
+  void GetAllResource(const std::string& table, const std::function<void(bool success, std::vector<std::string> resources)>& callback)const;
 
   /**
    * \brief Storing timestamps of when a resource was last accessed.
    * \param table Table of resources for apps which could be either a device or a feature.
    * \param id Identifier for the resource in the table.
-   * \param timestamp A human-readable descriptions, or storing state information that multiple apps might need to know about the resource.
+   * \param data A human-readable descriptions, or storing state information that multiple apps might need to know about the resource.
    * \param callback Callback function for async operations.
    */
-  void StoreTimestamp(const std::string& table,const std::string& id,const std::string& data,std::function<void(bool ready)> callback);
-
-  std::string ShowAccessDialog(const std::string& app_id,const std::string& parent_window,const AccessDialogOptions& options);
-
-  void CancelAccessRequest(const std::string& handle);
+  void StoreTimestamp(const std::string& table,const std::string& id,const std::string& data,const std::function<void(bool ready)>& callback)const;
 
 private:
-  std::string GenerateHandle(const std::string& app_id);
-
-  void SetupRequestSignalHandler(const std::string& handler);
-
-  void OnPortalResponse(const std::string& handle, uint32_t response_code, const std::map<std::string,sdbus::Variant>& results);
-
-  void SendEvent(const flutter::EncodableMap& event);
-
   PortalManager& portal_manager_;
   asio::io_context& io_context_;
-  //std::shared_ptr<FlatpakShim> shim_;
   flutter::EventChannel<flutter::EncodableValue>* event_channel_;
-  std::unordered_map<std::string,std::unique_ptr<AccessRequest>> requests_;
-  std::mutex requests_mutex_;
-  std::atomic<uint32_t> request_counter_{0};
   plugin_common_sdbus::SessionDBus& session_bus_;
 };
 }

--- a/plugins/flatpak/portals/access_portal/access_portal.h
+++ b/plugins/flatpak/portals/access_portal/access_portal.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2023-2025 Toyota Connected North America
+ * Copyright 2025 Ahmed Wafdy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IVI_HOMESCREEN_ACCESS_PORTAL_H
+#define IVI_HOMESCREEN_ACCESS_PORTAL_H
+
+#include <string>
+
+#include <flutter/event_channel.h>
+#include "flatpak/messages.g.h"
+#include "flatpak/portals/portal_manager.h"
+#include "plugins/common/sdbus/sdbus.h"
+
+namespace flatpak_plugin {
+struct AccessDialogOptions {
+  std::string title;
+  std::string icon;
+  bool modal = true;
+};
+
+struct AccessRequest {
+  std::string handle;
+  std::string app_id;
+  AccessDialogOptions options;
+  std::unique_ptr<sdbus::IProxy> request_proxy;
+  std::function<void(uint32_t,std::map<std::string,sdbus::Variant>)> callback;
+};
+
+class AccessPortal {
+public:
+  enum class PermissionStatus {
+    GRANTED,      // "yes"
+    DENIED,       // "no"
+    ASK,          // "ask"
+    NOT_SET       // No entry exists
+  };
+  explicit AccessPortal(PortalManager* portal_manager,asio::io_context& io_context,flutter::EventChannel<flutter::EncodableValue>& event_channel);
+
+  ~AccessPortal();
+
+
+  void CheckAllPermissions(const std::string& app_id,const std::vector<std::string>& permissions,std::function<void(std::map<std::string,PermissionStatus>)> callback);
+  /**
+   * \brief Sets permission for app.
+   * \param table Table of resources for apps which could be either a device or a feature.
+   * \param id Identifier for the resource in the table.
+   * \param app Application that needs access to a resource.
+   * \param permission Permission assigned to app could be 'yes','no' or 'ask'.
+   * \param callback Callback function for async operations.
+   * \return String of Stored permission.
+   */
+  void SetPermission(const std::string& table,const std::string& id,const std::string& app,const std::vector<std::string>& permission,std::function<void(bool ready)> callback);
+
+  /**
+   * \brief Retrieves permission for app.
+   * \param table Table of resources for apps which could be either a device or a feature.
+   * \param id Identifier for the resource in the table.
+   * \param app Application that needs access to a resource.
+   * \param callback Callback function for async operations.
+   * \return String of Stored permission.
+   */
+  void GetPermission(const std::string& table,const std::string& id,const std::string& app,std::function<void(PermissionStatus status, std::vector<std::string> permissions)> callback);
+
+  /**
+   * \brief Delete permission for app.
+   * \param table Table of resources for apps which could be either a device or a feature.
+   * \param id Identifier for the resource in the table.
+   * \param app Application that needs access to a resource.
+   * \param ready_callback Callback function for async operations.
+   * \return String of Stored permission.
+   */
+  void DeletePermission(const std::string& table,const std::string& id,const std::string& app,std::function<void(bool ready)> callback);
+
+  /**
+   * \brief Retrieves all permissions for a specific resource.
+   * \param table Table of resources for apps which could be either a device or a feature.
+   * \param id Identifier for the resource in the table.
+   * \param callback Callback function for async operations.
+   * \return Map of Stored permissions to a resource.
+   */
+  void GetAllPermissions(
+    const std::string& table,
+    const std::string& id,
+    const std::string& app_id,
+    std::function<void(PermissionStatus status)> callback);
+
+  /**
+   * \brief Sets an entire resource entry with multiple app permissions at once.
+   * \param table Table of resources for apps which could be either a device or a feature.
+   * \param id Identifier for the resource in the table.
+   * \param permissions Permissions assigned to apps in a resource could be 'yes','no' or 'ask'.
+   * \param callback Callback function for async operations.
+   */
+  void SetResource(const std::string& table,const std::string& id,const std::map<std::string, std::vector<std::string>>& permissions,std::function<void(bool ready)> callback);
+
+  /**
+   * \brief Delete an entire resource and ALL associated app permissions.
+   * \param table Table of resources for apps which could be either a device or a feature.
+   * \param id Identifier for the resource in the table.
+   * \param ready_callback Callback function for async operations.
+   */
+  void DeleteResource(const std::string& table,const std::string& id,std::function<void(bool ready)> callback);
+
+  /**
+   * \brief Get all device types that have any permissions set.
+   * \param table Table of resources for apps which could be either a device or a feature.
+   * \param callback Callback function for async operations.
+   */
+  void GetAllResource(const std::string& table, std::function<void(bool success, std::vector<std::string> resources)> callback);
+
+  /**
+   * \brief Storing timestamps of when a resource was last accessed.
+   * \param table Table of resources for apps which could be either a device or a feature.
+   * \param id Identifier for the resource in the table.
+   * \param timestamp A human-readable descriptions, or storing state information that multiple apps might need to know about the resource.
+   * \param callback Callback function for async operations.
+   */
+  void StoreTimestamp(const std::string& table,const std::string& id,const std::string& data,std::function<void(bool ready)> callback);
+
+  std::string ShowAccessDialog(const std::string& app_id,const std::string& parent_window,const AccessDialogOptions& options);
+
+  void CancelAccessRequest(const std::string& handle);
+
+private:
+  std::string GenerateHandle(const std::string& app_id);
+
+  void SetupRequestSignalHandler(const std::string& handler);
+
+  void OnPortalResponse(const std::string& handle, uint32_t response_code, const std::map<std::string,sdbus::Variant>& results);
+
+  void SendEvent(const flutter::EncodableMap& event);
+
+  PortalManager& portal_manager_;
+  asio::io_context& io_context_;
+  //std::shared_ptr<FlatpakShim> shim_;
+  flutter::EventChannel<flutter::EncodableValue>* event_channel_;
+  std::unordered_map<std::string,std::unique_ptr<AccessRequest>> requests_;
+  std::mutex requests_mutex_;
+  std::atomic<uint32_t> request_counter_{0};
+  plugin_common_sdbus::SessionDBus& session_bus_;
+};
+}
+#endif  // IVI_HOMESCREEN_ACCESS_PORTAL_H

--- a/plugins/flatpak/portals/access_portal/access_portal.h
+++ b/plugins/flatpak/portals/access_portal/access_portal.h
@@ -37,7 +37,7 @@ class AccessPortal {
  public:
   explicit AccessPortal(asio::io_context& io_context);
 
-  ~AccessPortal();
+  ~AccessPortal() = default;
 
   /**
    * \brief Check all permissions for app to launch.

--- a/plugins/flatpak/portals/access_portal/access_portal.h
+++ b/plugins/flatpak/portals/access_portal/access_portal.h
@@ -27,15 +27,18 @@
 
 namespace flatpak_plugin {
 enum PermissionStatus {
-  GRANTED,      // "yes"
-  DENIED,       // "no"
-  ASK,          // "ask"
-  NOT_SET       // No entry exists
+  GRANTED,  // "yes"
+  DENIED,   // "no"
+  ASK,      // "ask"
+  NOT_SET   // No entry exists
 };
 
 class AccessPortal {
-public:
-  explicit AccessPortal(PortalManager* portal_manager,asio::io_context& io_context,flutter::EventChannel<flutter::EncodableValue>& event_channel);
+ public:
+  explicit AccessPortal(
+      PortalManager* portal_manager,
+      asio::io_context& io_context,
+      flutter::EventChannel<flutter::EncodableValue>& event_channel);
 
   ~AccessPortal();
 
@@ -45,91 +48,119 @@ public:
    * \param permissions Permission assigned to app could be 'yes','no' or 'ask'.
    * \param callback Callback function for async operations.
    */
-void CheckAllPermissions(const std::string& app,const std::vector<std::string>& permissions,const std::function<void(std::map<std::string,PermissionStatus>)>& callback)const;
+  void CheckAllPermissions(
+      const std::string& app,
+      const std::vector<std::string>& permissions,
+      const std::function<void(std::map<std::string, PermissionStatus>)>&
+          callback) const;
 
   /**
    * \brief Sets permission for app.
-   * \param table Table of resources for apps which could be either a device or a feature.
-   * \param id Identifier for the resource in the table.
-   * \param app Application that needs access to a resource.
-   * \param permission Permission assigned to app could be 'yes','no' or 'ask'.
-   * \param callback Callback function for async operations.
-   * \return String of Stored permission.
+   * \param table Table of resources for apps which could be either a device or
+   * a feature. \param id Identifier for the resource in the table. \param app
+   * Application that needs access to a resource. \param permission Permission
+   * assigned to app could be 'yes','no' or 'ask'. \param callback Callback
+   * function for async operations. \return String of Stored permission.
    */
-  void SetPermission(const std::string& table,const std::string& id,const std::string& app,const std::vector<std::string>& permission,const std::function<void(bool ready)>& callback) const;
+  void SetPermission(const std::string& table,
+                     const std::string& id,
+                     const std::string& app,
+                     const std::vector<std::string>& permission,
+                     const std::function<void(bool ready)>& callback) const;
 
   /**
    * \brief Retrieves permission for app.
-   * \param table Table of resources for apps which could be either a device or a feature.
-   * \param id Identifier for the resource in the table.
-   * \param app Application that needs access to a resource.
-   * \param callback Callback function for async operations.
-   * \return String of Stored permission.
+   * \param table Table of resources for apps which could be either a device or
+   * a feature. \param id Identifier for the resource in the table. \param app
+   * Application that needs access to a resource. \param callback Callback
+   * function for async operations. \return String of Stored permission.
    */
-  void GetPermission(const std::string& table,const std::string& id,const std::string& app,const std::function<void(PermissionStatus status, std::vector<std::string> permissions)>& callback) const;
+  void GetPermission(
+      const std::string& table,
+      const std::string& id,
+      const std::string& app,
+      const std::function<void(PermissionStatus status,
+                               std::vector<std::string> permissions)>& callback)
+      const;
 
   /**
    * \brief Delete permission for app.
-   * \param table Table of resources for apps which could be either a device or a feature.
-   * \param id Identifier for the resource in the table.
-   * \param app Application that needs access to a resource.
-   * \param callback Callback function for async operations.
-   * \return String of Stored permission.
+   * \param table Table of resources for apps which could be either a device or
+   * a feature. \param id Identifier for the resource in the table. \param app
+   * Application that needs access to a resource. \param callback Callback
+   * function for async operations. \return String of Stored permission.
    */
-  void DeletePermission(const std::string& table,const std::string& id,const std::string& app,const std::function<void(bool ready)>& callback)const;
+  void DeletePermission(const std::string& table,
+                        const std::string& id,
+                        const std::string& app,
+                        const std::function<void(bool ready)>& callback) const;
 
   /**
    * \brief Retrieves all permissions for a specific resource.
-   * \param table Table of resources for apps which could be either a device or a feature.
-   * \param id Identifier for the resource in the table.
-   * \param app Application that needs access to a resource
-   * \param callback Callback function for async operations.
-   * \return Map of Stored permissions to a resource.
+   * \param table Table of resources for apps which could be either a device or
+   * a feature. \param id Identifier for the resource in the table. \param app
+   * Application that needs access to a resource \param callback Callback
+   * function for async operations. \return Map of Stored permissions to a
+   * resource.
    */
   void GetAllPermissions(
-    const std::string& table,
-    const std::string& id,
-    const std::string& app,
-    const std::function<void(PermissionStatus status)>& callback)const;
+      const std::string& table,
+      const std::string& id,
+      const std::string& app,
+      const std::function<void(PermissionStatus status)>& callback) const;
 
   /**
    * \brief Sets an entire resource entry with multiple app permissions at once.
-   * \param table Table of resources for apps which could be either a device or a feature.
-   * \param id Identifier for the resource in the table.
-   * \param permissions Permissions assigned to apps in a resource could be 'yes','no' or 'ask'.
-   * \param callback Callback function for async operations.
+   * \param table Table of resources for apps which could be either a device or
+   * a feature. \param id Identifier for the resource in the table. \param
+   * permissions Permissions assigned to apps in a resource could be 'yes','no'
+   * or 'ask'. \param callback Callback function for async operations.
    */
-  void SetResource(const std::string& table,const std::string& id,const std::map<std::string, std::vector<std::string>>& permissions,const std::function<void(bool ready)>& callback)const;
+  void SetResource(
+      const std::string& table,
+      const std::string& id,
+      const std::map<std::string, std::vector<std::string>>& permissions,
+      const std::function<void(bool ready)>& callback) const;
 
   /**
    * \brief Delete an entire resource and ALL associated app permissions.
-   * \param table Table of resources for apps which could be either a device or a feature.
-   * \param id Identifier for the resource in the table.
-   * \param callback Callback function for async operations.
+   * \param table Table of resources for apps which could be either a device or
+   * a feature. \param id Identifier for the resource in the table. \param
+   * callback Callback function for async operations.
    */
-  void DeleteResource(const std::string& table,const std::string& id,const std::function<void(bool ready)>& callback)const;
+  void DeleteResource(const std::string& table,
+                      const std::string& id,
+                      const std::function<void(bool ready)>& callback) const;
 
   /**
    * \brief Get all device types that have any permissions set.
-   * \param table Table of resources for apps which could be either a device or a feature.
-   * \param callback Callback function for async operations.
+   * \param table Table of resources for apps which could be either a device or
+   * a feature. \param callback Callback function for async operations.
    */
-  void GetAllResource(const std::string& table, const std::function<void(bool success, std::vector<std::string> resources)>& callback)const;
+  void GetAllResource(
+      const std::string& table,
+      const std::function<void(bool success,
+                               std::vector<std::string> resources)>& callback)
+      const;
 
   /**
    * \brief Storing timestamps of when a resource was last accessed.
-   * \param table Table of resources for apps which could be either a device or a feature.
-   * \param id Identifier for the resource in the table.
-   * \param data A human-readable descriptions, or storing state information that multiple apps might need to know about the resource.
-   * \param callback Callback function for async operations.
+   * \param table Table of resources for apps which could be either a device or
+   * a feature. \param id Identifier for the resource in the table. \param data
+   * A human-readable descriptions, or storing state information that multiple
+   * apps might need to know about the resource. \param callback Callback
+   * function for async operations.
    */
-  void StoreTimestamp(const std::string& table,const std::string& id,const std::string& data,const std::function<void(bool ready)>& callback)const;
+  void StoreTimestamp(const std::string& table,
+                      const std::string& id,
+                      const std::string& data,
+                      const std::function<void(bool ready)>& callback) const;
 
-private:
+ private:
   PortalManager& portal_manager_;
   asio::io_context& io_context_;
   flutter::EventChannel<flutter::EncodableValue>* event_channel_;
   plugin_common_sdbus::SessionDBus& session_bus_;
 };
-}
+}  // namespace flatpak_plugin
 #endif  // IVI_HOMESCREEN_ACCESS_PORTAL_H

--- a/plugins/flatpak/portals/access_portal/access_portal.h
+++ b/plugins/flatpak/portals/access_portal/access_portal.h
@@ -35,10 +35,7 @@ enum PermissionStatus {
 
 class AccessPortal {
  public:
-  explicit AccessPortal(
-      PortalManager* portal_manager,
-      asio::io_context& io_context,
-      flutter::EventChannel<flutter::EncodableValue>& event_channel);
+  explicit AccessPortal(asio::io_context& io_context);
 
   ~AccessPortal();
 
@@ -112,9 +109,11 @@ class AccessPortal {
   /**
    * \brief Sets an entire resource entry with multiple app permissions at once.
    * \param table Table of resources for apps which could be either a device or
-   * a feature. \param id Identifier for the resource in the table. \param
-   * permissions Permissions assigned to apps in a resource could be 'yes','no'
-   * or 'ask'. \param callback Callback function for async operations.
+   * a feature.
+   * \param id Identifier for the resource in the table.
+   * \param permissions Permissions assigned to apps in a resource could be
+   * 'yes','no' or 'ask'. \param callback Callback function for async
+   * operations.
    */
   void SetResource(
       const std::string& table,
@@ -125,8 +124,9 @@ class AccessPortal {
   /**
    * \brief Delete an entire resource and ALL associated app permissions.
    * \param table Table of resources for apps which could be either a device or
-   * a feature. \param id Identifier for the resource in the table. \param
-   * callback Callback function for async operations.
+   * a feature.
+   * \param id Identifier for the resource in the table.
+   * \param callback Callback function for async operations.
    */
   void DeleteResource(const std::string& table,
                       const std::string& id,
@@ -157,9 +157,7 @@ class AccessPortal {
                       const std::function<void(bool ready)>& callback) const;
 
  private:
-  PortalManager& portal_manager_;
   asio::io_context& io_context_;
-  flutter::EventChannel<flutter::EncodableValue>* event_channel_;
   plugin_common_sdbus::SessionDBus& session_bus_;
 };
 }  // namespace flatpak_plugin

--- a/plugins/flatpak/portals/portal_interface.h
+++ b/plugins/flatpak/portals/portal_interface.h
@@ -52,4 +52,11 @@ struct PortalInterfaceHash {
   }
 };
 
+static struct PortalInterface RequestInterface{
+  "org.freedesktop.portal.Desktop",
+  "",
+  "org.freedesktop.portal.Request",
+  BUS_TYPE::SESSION
+};
+
 #endif  // PORTAL_INTERFACE_H

--- a/plugins/flatpak/portals/portal_interface.h
+++ b/plugins/flatpak/portals/portal_interface.h
@@ -52,11 +52,9 @@ struct PortalInterfaceHash {
   }
 };
 
-static struct PortalInterface RequestInterface{
-  "org.freedesktop.portal.Desktop",
-  "",
-  "org.freedesktop.portal.Request",
-  BUS_TYPE::SESSION
+static struct PortalInterface RequestInterface {
+  "org.freedesktop.portal.Desktop", "", "org.freedesktop.portal.Request",
+      BUS_TYPE::SESSION
 };
 
 #endif  // PORTAL_INTERFACE_H

--- a/plugins/flatpak/portals/portal_manager.h
+++ b/plugins/flatpak/portals/portal_manager.h
@@ -41,13 +41,14 @@ class PortalManager {
                    ResultCallback&& callback,
                    Args&&... args);
 
+  PortalProxy& GetPortalProxy();
+
  private:
   asio::io_context& io_context_;
   std::unique_ptr<PortalProxy> portal_proxy_;
   std::map<std::string, PortalContext> app_context_;
   std::mutex app_mutex_;
 
-  PortalProxy& GetPortalProxy();
   PortalContext& get_app_context(const std::string& app_id);
 };
 }  // namespace flatpak_plugin

--- a/plugins/flatpak/test/test_flatpak.cc
+++ b/plugins/flatpak/test/test_flatpak.cc
@@ -288,7 +288,7 @@ TEST_F(FlatpakPluginTest, ApplicationInstallTest) {
 
   auto shim = std::make_shared<FlatpakShim>(nullptr, messenger, strand.get());
 
-  auto app_id = "com.stremio.Stremio";
+  auto app_id = "org.telegram.desktop";
 
   shim->ApplicationInstall(app_id, [guard](const ErrorOr<bool>& result) {
     guard->set_value(result);
@@ -555,17 +555,17 @@ TEST_F(FlatpakPluginTest, RunAppTest) {
   auto messenger = GetTestMessenger();
   auto shim = std::make_shared<FlatpakShim>(nullptr, messenger, strand.get());
 
-  auto id = "com.spotify.Client";  // net.lutris.Lutris // com.spotify.Client //
+  auto id = "org.telegram.desktop";  // net.lutris.Lutris // com.spotify.Client //
                                    // com.valvesoftware.Steam
-
+shim->SetupAccessEventChannel(messenger,*strand,portal_manager.get());
   shim->ApplicationStart(
       id, *strand, portal_manager,
       [guard](const ErrorOr<bool>& result) { guard->set_value(result); });
 
-  auto status = future.wait_for(std::chrono::minutes(2));
-
-  ASSERT_NE(status, std::future_status::timeout)
-      << "Installation timed out after 2 minutes";
+  // auto status = future.wait_for(std::chrono::minutes(2));
+  //
+  // ASSERT_NE(status, std::future_status::timeout)
+  //     << "Installation timed out after 2 minutes";
 
   auto result = future.get();
 

--- a/plugins/flatpak/test/test_flatpak.cc
+++ b/plugins/flatpak/test/test_flatpak.cc
@@ -563,10 +563,10 @@ TEST_F(FlatpakPluginTest, RunAppTest) {
       id, *strand, portal_manager,
       [guard](const ErrorOr<bool>& result) { guard->set_value(result); });
 
-  // auto status = future.wait_for(std::chrono::minutes(2));
-  //
-  // ASSERT_NE(status, std::future_status::timeout)
-  //     << "Installation timed out after 2 minutes";
+  auto status = future.wait_for(std::chrono::minutes(2));
+
+  ASSERT_NE(status, std::future_status::timeout)
+      << "Installation timed out after 2 minutes";
 
   auto result = future.get();
 

--- a/plugins/flatpak/test/test_flatpak.cc
+++ b/plugins/flatpak/test/test_flatpak.cc
@@ -555,9 +555,10 @@ TEST_F(FlatpakPluginTest, RunAppTest) {
   auto messenger = GetTestMessenger();
   auto shim = std::make_shared<FlatpakShim>(nullptr, messenger, strand.get());
 
-  auto id = "com.visualstudio.code";  // net.lutris.Lutris // com.spotify.Client //
-                                   // com.valvesoftware.Steam // org.telegram.desktop
-shim->SetupAccessEventChannel(messenger,*strand,portal_manager.get());
+  auto id = "com.visualstudio.code";  // net.lutris.Lutris // com.spotify.Client
+                                      // // com.valvesoftware.Steam //
+                                      // org.telegram.desktop
+  shim->SetupAccessEventChannel(messenger, *strand, portal_manager.get());
   shim->ApplicationStart(
       id, *strand, portal_manager,
       [guard](const ErrorOr<bool>& result) { guard->set_value(result); });

--- a/plugins/flatpak/test/test_flatpak.cc
+++ b/plugins/flatpak/test/test_flatpak.cc
@@ -558,7 +558,7 @@ TEST_F(FlatpakPluginTest, RunAppTest) {
   auto id = "com.visualstudio.code";  // net.lutris.Lutris // com.spotify.Client
                                       // // com.valvesoftware.Steam //
                                       // org.telegram.desktop
-  shim->SetupAccessEventChannel(messenger, *strand, portal_manager.get());
+  shim->SetupAccessEventChannel(messenger, *strand);
   shim->ApplicationStart(
       id, *strand, portal_manager,
       [guard](const ErrorOr<bool>& result) { guard->set_value(result); });

--- a/plugins/flatpak/test/test_flatpak.cc
+++ b/plugins/flatpak/test/test_flatpak.cc
@@ -15,9 +15,9 @@
 using namespace flatpak_plugin;
 class TestBinaryMessenger : public flutter::BinaryMessenger {
  public:
-  void Send(const std::string& channel,
-            const uint8_t* message,
-            size_t message_size,
+  void Send(const std::string& /*channel*/,
+            const uint8_t* /*message*/,
+            size_t /*message_size*/,
             flutter::BinaryReply reply) const override {
     // No-op for tests
     if (reply) {
@@ -555,8 +555,8 @@ TEST_F(FlatpakPluginTest, RunAppTest) {
   auto messenger = GetTestMessenger();
   auto shim = std::make_shared<FlatpakShim>(nullptr, messenger, strand.get());
 
-  auto id = "org.telegram.desktop";  // net.lutris.Lutris // com.spotify.Client //
-                                   // com.valvesoftware.Steam
+  auto id = "com.visualstudio.code";  // net.lutris.Lutris // com.spotify.Client //
+                                   // com.valvesoftware.Steam // org.telegram.desktop
 shim->SetupAccessEventChannel(messenger,*strand,portal_manager.get());
   shim->ApplicationStart(
       id, *strand, portal_manager,


### PR DESCRIPTION
This PR addresses feature request #202 by implementing all permissions interfaces for the [xdg-permissionsStore portal](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.impl.portal.PermissionStore.html) in Flatpak portals. This implementation enables us to control all app permissions. The request is to provide mobile-like permissions for starting applications. The plugin checks and retrieves permissions from the Flatpak Database, which previously stored d-bus permissions. It sends permission requests in dialogs one by one to the Flutter side through a proper Flutter event channel. The user responds to the Flutter UI by granting or denying permissions, and Flutter sends these responses via a Flutter Method call. The plugin handles these Method call responses in a dedicated method call channel, stores the permissions, shows the next dialog, and finally launches the application reliably.