### PR TITLE
flatpak: Track transactions operations and serialize to flutter channels

### DIFF
--- a/plugins/flatpak/CMakeLists.txt
+++ b/plugins/flatpak/CMakeLists.txt
@@ -32,6 +32,8 @@ add_library(plugin_flatpak STATIC
         portals/portal_proxy.cc
         portals/access_portal/access_portal.cc
         portals/access_portal/access_portal.h
+        operation_tracker.cc
+        operation_tracker.h
 )
 target_include_directories(plugin_flatpak PRIVATE include)
 target_compile_options(plugin_flatpak PRIVATE

--- a/plugins/flatpak/flatpak_shim.cc
+++ b/plugins/flatpak/flatpak_shim.cc
@@ -964,6 +964,7 @@ void FlatpakShim::ApplicationInstall(
 
   spdlog::info("[FlatpakPlugin] Starting TWO-PHASE installation for: {}", id);
 
+  operation_tracker_->TrackOperationStart(id,"install");
   FlatpakTransaction* transaction =
       flatpak_transaction_new_for_installation(installation, nullptr, &error);
 
@@ -1055,7 +1056,7 @@ void FlatpakShim::ApplicationInstall(
 
   // run transaction in a detached thread
   std::thread([self, transaction_raw, callback, ref_name, remote_name,
-               strand_ptr = strand_, installation_raw, found_ref_raw]() {
+               strand_ptr = strand_, installation_raw, found_ref_raw,id]() {
     pthread_setname_np(pthread_self(), "flatpak-install");
 
     GError* error = nullptr;
@@ -1077,7 +1078,9 @@ void FlatpakShim::ApplicationInstall(
     if (!success) {
       spdlog::error("[FlatpakPlugin] Phase 1 (dependencies) failed");
       asio::post(*strand_ptr, [self, callback, err_msg, transaction_raw,
-                               found_ref_raw, installation_raw]() {
+                               found_ref_raw, installation_raw,id]() {
+        self->operation_tracker_->SendOperationFinish(id,"install",false);
+
         callback(ErrorOr<bool>(FlutterError(
             "INSTALL_FAILED", "Dependency installation failed: " + err_msg)));
         g_object_unref(transaction_raw);
@@ -1208,7 +1211,8 @@ void FlatpakShim::ApplicationInstall(
 
     if (!phase2_success) {
       asio::post(*strand_ptr, [self, callback, phase2_err_msg, transaction_raw,
-                               found_ref_raw, installation_raw]() {
+                               found_ref_raw, installation_raw,id]() {
+        self->operation_tracker_->SendOperationFinish(id,"install",false);
         callback(ErrorOr<bool>(FlutterError(
             "INSTALL_FAILED", "App installation failed: " + phase2_err_msg)));
         g_object_unref(transaction_raw);
@@ -1248,16 +1252,18 @@ void FlatpakShim::ApplicationInstall(
 
     asio::post(*strand_ptr, [self, callback, verified, ref_name,
                              transaction_raw, found_ref_raw,
-                             installation_raw]() {
+                             installation_raw,id]() {
       if (verified) {
         spdlog::info(
             "[FlatpakPlugin] Application '{}' successfully installed and "
             "verified",
             ref_name);
+        self->operation_tracker_->SendOperationFinish(id,"install",true);
         callback(ErrorOr<bool>(true));
       } else {
         spdlog::error(
             "[FlatpakPlugin] Installation completed but verification failed");
+        self->operation_tracker_->SendOperationFinish(id,"install",false);
         callback(ErrorOr<bool>(
             FlutterError("INSTALL_VERIFICATION_FAILED",
                          "Installation completed but app not found")));
@@ -3981,31 +3987,67 @@ void FlatpakShim::OnOperationComplete(FlatpakTransaction* /* transaction */,
   const char* ref = flatpak_transaction_operation_get_ref(operation);
   auto type = flatpak_transaction_operation_get_operation_type(operation);
 
-  std::string type_str =
-      (type == FLATPAK_TRANSACTION_OPERATION_INSTALL) ? "install" : "other";
+  std::string type_str;
+  switch (type) {
+    case FLATPAK_TRANSACTION_OPERATION_INSTALL:
+      type_str = "install";
+      break;
+    case FLATPAK_TRANSACTION_OPERATION_UPDATE:
+      type_str = "update";
+      break;
+    case FLATPAK_TRANSACTION_OPERATION_UNINSTALL:
+      type_str = "uninstall";
+      break;
+    default:
+      type_str = "other";
+      break;
+  }
+
+  std::string ref_str = ref ? std::string(ref) : std::string("");
 
   if (ref) {
     spdlog::info(
         "[FlatpakPlugin] Operation completed: {} {} (result: {})", type_str,
-        std::string(ref),
+        ref_str,
         result == FLATPAK_TYPE_TRANSACTION_RESULT ? "SUCCESS" : "FAILED");
+  }
+
+  std::string app_id;
+  auto active_ops = handler->operation_tracker_->GetActiveOperations();
+
+  for (const auto& [id, op_info] : active_ops) {
+    if (ref_str.find(id) != std::string::npos || op_info.op_type == type_str) {
+      app_id = id;
+      handler->operation_tracker_->TrackOperationComplete(app_id, ref_str);
+      break;
+    }
   }
 
   if (handler->strand_) {
     asio::post(
         *handler->strand_,
-        [handler, ref = ref ? std::string(ref) : std::string(""),
-         commit = commit ? std::string(commit) : std::string(""), result]() {
+        [handler, ref_str,
+         commit = commit ? std::string(commit) : std::string(""),
+         result, type_str, app_id]() {
           try {
             flutter::EncodableMap OperationCompleteMap;
             OperationCompleteMap[flutter::EncodableValue("type")] =
                 flutter::EncodableValue("operation_complete");
             OperationCompleteMap[flutter::EncodableValue("operation_ref")] =
-                flutter::EncodableValue(ref);
+                flutter::EncodableValue(ref_str);
             OperationCompleteMap[flutter::EncodableValue("commit")] =
                 flutter::EncodableValue(commit);
             OperationCompleteMap[flutter::EncodableValue("success")] =
                 flutter::EncodableValue(static_cast<int32_t>(result));
+            OperationCompleteMap[flutter::EncodableValue("operation_type")] =
+                flutter::EncodableValue(type_str);
+
+            // Determine if this is the main app
+            bool is_main_app = ref_str.find("app/") == 0 &&
+                              !app_id.empty() &&
+                              ref_str.find(app_id) != std::string::npos;
+            OperationCompleteMap[flutter::EncodableValue("is_main_app")] =
+                flutter::EncodableValue(is_main_app);
 
             handler->SendTransactionEvent(OperationCompleteMap);
           } catch (const std::exception& e) {
@@ -4067,6 +4109,7 @@ gboolean FlatpakShim::OnTransactionReady(FlatpakTransaction* transaction,
 
   spdlog::info("[FlatpakPlugin] Total operations to perform: {}", total_ops);
 
+  std::string app_id;
   flutter::EncodableList ops_list;
   for (GList* l = operations; l != nullptr; l = l->next) {
     auto* op = static_cast<FlatpakTransactionOperation*>(l->data);
@@ -4097,8 +4140,17 @@ gboolean FlatpakShim::OnTransactionReady(FlatpakTransaction* transaction,
     spdlog::info("[FlatpakPlugin] - Operation: {} {}", type_str, ref_str);
 
     std::string kind = "unknown";
+    bool is_main_app{false};
     if (ref_str.find("app/") == 0) {
       kind = "app";
+      is_main_app = true;
+
+      // extract app to pass
+      size_t first_slash = ref_str.find('/') + 1;
+      size_t second_slash = ref_str.find('/', first_slash);
+      if (second_slash != std::string::npos) {
+        app_id = ref_str.substr(first_slash, second_slash - first_slash);
+      }
     } else if (ref_str.find("runtime/") == 0) {
       kind = "runtime";
     }
@@ -4111,8 +4163,11 @@ gboolean FlatpakShim::OnTransactionReady(FlatpakTransaction* transaction,
     ops_list.emplace_back(op_map);
   }
 
+  if (app_id.empty()) {
+    handler->operation_tracker_->UpdateTotalOperations(app_id,total_ops);
+  }
   if (handler->strand_) {
-    asio::post(*handler->strand_, [handler, total_ops,
+    asio::post(*handler->strand_, [handler, app_id,total_ops,
                                    ops_list = std::move(ops_list)]() {
       try {
         flutter::EncodableMap ready_event;
@@ -4122,7 +4177,8 @@ gboolean FlatpakShim::OnTransactionReady(FlatpakTransaction* transaction,
             flutter::EncodableValue(total_ops);
         ready_event[flutter::EncodableValue("operations")] =
             flutter::EncodableValue(ops_list);
-
+        ready_event[flutter::EncodableValue("main_app_id")] =
+                    flutter::EncodableValue(app_id);
         handler->SendTransactionEvent(ready_event);
       } catch (const std::exception& e) {
         spdlog::error("[FlatpakPlugin] Error sending ready event: {}",

--- a/plugins/flatpak/flatpak_shim.cc
+++ b/plugins/flatpak/flatpak_shim.cc
@@ -4138,10 +4138,8 @@ gboolean FlatpakShim::OnTransactionReady(FlatpakTransaction* transaction,
     spdlog::info("[FlatpakPlugin] - Operation: {} {}", type_str, ref_str);
 
     std::string kind = "unknown";
-    bool is_main_app{false};
     if (ref_str.find("app/") == 0) {
       kind = "app";
-      is_main_app = true;
 
       // extract app to pass
       size_t first_slash = ref_str.find('/') + 1;

--- a/plugins/flatpak/flatpak_shim.cc
+++ b/plugins/flatpak/flatpak_shim.cc
@@ -964,7 +964,7 @@ void FlatpakShim::ApplicationInstall(
 
   spdlog::info("[FlatpakPlugin] Starting TWO-PHASE installation for: {}", id);
 
-  operation_tracker_->TrackOperationStart(id,"install");
+  operation_tracker_->TrackOperationStart(id, "install");
   FlatpakTransaction* transaction =
       flatpak_transaction_new_for_installation(installation, nullptr, &error);
 
@@ -1056,7 +1056,7 @@ void FlatpakShim::ApplicationInstall(
 
   // run transaction in a detached thread
   std::thread([self, transaction_raw, callback, ref_name, remote_name,
-               strand_ptr = strand_, installation_raw, found_ref_raw,id]() {
+               strand_ptr = strand_, installation_raw, found_ref_raw, id]() {
     pthread_setname_np(pthread_self(), "flatpak-install");
 
     GError* error = nullptr;
@@ -1078,8 +1078,8 @@ void FlatpakShim::ApplicationInstall(
     if (!success) {
       spdlog::error("[FlatpakPlugin] Phase 1 (dependencies) failed");
       asio::post(*strand_ptr, [self, callback, err_msg, transaction_raw,
-                               found_ref_raw, installation_raw,id]() {
-        self->operation_tracker_->SendOperationFinish(id,"install",false);
+                               found_ref_raw, installation_raw, id]() {
+        self->operation_tracker_->SendOperationFinish(id, "install", false);
 
         callback(ErrorOr<bool>(FlutterError(
             "INSTALL_FAILED", "Dependency installation failed: " + err_msg)));
@@ -1211,8 +1211,8 @@ void FlatpakShim::ApplicationInstall(
 
     if (!phase2_success) {
       asio::post(*strand_ptr, [self, callback, phase2_err_msg, transaction_raw,
-                               found_ref_raw, installation_raw,id]() {
-        self->operation_tracker_->SendOperationFinish(id,"install",false);
+                               found_ref_raw, installation_raw, id]() {
+        self->operation_tracker_->SendOperationFinish(id, "install", false);
         callback(ErrorOr<bool>(FlutterError(
             "INSTALL_FAILED", "App installation failed: " + phase2_err_msg)));
         g_object_unref(transaction_raw);
@@ -1251,19 +1251,19 @@ void FlatpakShim::ApplicationInstall(
     }
 
     asio::post(*strand_ptr, [self, callback, verified, ref_name,
-                             transaction_raw, found_ref_raw,
-                             installation_raw,id]() {
+                             transaction_raw, found_ref_raw, installation_raw,
+                             id]() {
       if (verified) {
         spdlog::info(
             "[FlatpakPlugin] Application '{}' successfully installed and "
             "verified",
             ref_name);
-        self->operation_tracker_->SendOperationFinish(id,"install",true);
+        self->operation_tracker_->SendOperationFinish(id, "install", true);
         callback(ErrorOr<bool>(true));
       } else {
         spdlog::error(
             "[FlatpakPlugin] Installation completed but verification failed");
-        self->operation_tracker_->SendOperationFinish(id,"install",false);
+        self->operation_tracker_->SendOperationFinish(id, "install", false);
         callback(ErrorOr<bool>(
             FlutterError("INSTALL_VERIFICATION_FAILED",
                          "Installation completed but app not found")));
@@ -4024,37 +4024,35 @@ void FlatpakShim::OnOperationComplete(FlatpakTransaction* /* transaction */,
   }
 
   if (handler->strand_) {
-    asio::post(
-        *handler->strand_,
-        [handler, ref_str,
-         commit = commit ? std::string(commit) : std::string(""),
-         result, type_str, app_id]() {
-          try {
-            flutter::EncodableMap OperationCompleteMap;
-            OperationCompleteMap[flutter::EncodableValue("type")] =
-                flutter::EncodableValue("operation_complete");
-            OperationCompleteMap[flutter::EncodableValue("operation_ref")] =
-                flutter::EncodableValue(ref_str);
-            OperationCompleteMap[flutter::EncodableValue("commit")] =
-                flutter::EncodableValue(commit);
-            OperationCompleteMap[flutter::EncodableValue("success")] =
-                flutter::EncodableValue(static_cast<int32_t>(result));
-            OperationCompleteMap[flutter::EncodableValue("operation_type")] =
-                flutter::EncodableValue(type_str);
+    asio::post(*handler->strand_, [handler, ref_str,
+                                   commit = commit ? std::string(commit)
+                                                   : std::string(""),
+                                   result, type_str, app_id]() {
+      try {
+        flutter::EncodableMap OperationCompleteMap;
+        OperationCompleteMap[flutter::EncodableValue("type")] =
+            flutter::EncodableValue("operation_complete");
+        OperationCompleteMap[flutter::EncodableValue("operation_ref")] =
+            flutter::EncodableValue(ref_str);
+        OperationCompleteMap[flutter::EncodableValue("commit")] =
+            flutter::EncodableValue(commit);
+        OperationCompleteMap[flutter::EncodableValue("success")] =
+            flutter::EncodableValue(static_cast<int32_t>(result));
+        OperationCompleteMap[flutter::EncodableValue("operation_type")] =
+            flutter::EncodableValue(type_str);
 
-            // Determine if this is the main app
-            bool is_main_app = ref_str.find("app/") == 0 &&
-                              !app_id.empty() &&
-                              ref_str.find(app_id) != std::string::npos;
-            OperationCompleteMap[flutter::EncodableValue("is_main_app")] =
-                flutter::EncodableValue(is_main_app);
+        // Determine if this is the main app
+        bool is_main_app = ref_str.find("app/") == 0 && !app_id.empty() &&
+                           ref_str.find(app_id) != std::string::npos;
+        OperationCompleteMap[flutter::EncodableValue("is_main_app")] =
+            flutter::EncodableValue(is_main_app);
 
-            handler->SendTransactionEvent(OperationCompleteMap);
-          } catch (const std::exception& e) {
-            spdlog::error("[FlatpakPlugin] Error sending complete event: {}",
-                          e.what());
-          }
-        });
+        handler->SendTransactionEvent(OperationCompleteMap);
+      } catch (const std::exception& e) {
+        spdlog::error("[FlatpakPlugin] Error sending complete event: {}",
+                      e.what());
+      }
+    });
   }
 }
 
@@ -4164,10 +4162,10 @@ gboolean FlatpakShim::OnTransactionReady(FlatpakTransaction* transaction,
   }
 
   if (app_id.empty()) {
-    handler->operation_tracker_->UpdateTotalOperations(app_id,total_ops);
+    handler->operation_tracker_->UpdateTotalOperations(app_id, total_ops);
   }
   if (handler->strand_) {
-    asio::post(*handler->strand_, [handler, app_id,total_ops,
+    asio::post(*handler->strand_, [handler, app_id, total_ops,
                                    ops_list = std::move(ops_list)]() {
       try {
         flutter::EncodableMap ready_event;
@@ -4178,7 +4176,7 @@ gboolean FlatpakShim::OnTransactionReady(FlatpakTransaction* transaction,
         ready_event[flutter::EncodableValue("operations")] =
             flutter::EncodableValue(ops_list);
         ready_event[flutter::EncodableValue("main_app_id")] =
-                    flutter::EncodableValue(app_id);
+            flutter::EncodableValue(app_id);
         handler->SendTransactionEvent(ready_event);
       } catch (const std::exception& e) {
         spdlog::error("[FlatpakPlugin] Error sending ready event: {}",

--- a/plugins/flatpak/flatpak_shim.h
+++ b/plugins/flatpak/flatpak_shim.h
@@ -33,11 +33,13 @@
 #include "asio/steady_timer.hpp"
 #include "component.h"
 #include "messages.g.h"
+#include "operation_tracker.h"
 #include "plugins/flatpak/portals/portal_manager.h"
 #include "portals/access_portal/access_portal.h"
 
 namespace flatpak_plugin {
 class FlatpakPlugin;
+class OperationTracker;
 
 /**
  * \brief A utility class providing various helper functions for interacting
@@ -50,7 +52,12 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
   explicit FlatpakShim(FlatpakPlugin* plugin = nullptr,
                        flutter::BinaryMessenger* messenger = nullptr,
                        asio::io_context::strand* strand = nullptr)
-      : plugin_(plugin), messenger_(messenger), strand_(strand) {}
+  : plugin_(plugin), messenger_(messenger), strand_(strand),operation_tracker_(std::make_unique<OperationTracker>(
+        strand_->context(),
+        [this](const flutter::EncodableMap& event) {
+          this->SendTransactionEvent(const_cast<flutter::EncodableMap&>(event));
+        }
+    )) {}
 
   ~FlatpakShim() {
     plugin_ = nullptr;
@@ -463,6 +470,8 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
   flutter::BinaryMessenger* messenger_;
   asio::io_context::strand* strand_;
 
+  std::unique_ptr<OperationTracker> operation_tracker_;
+
   // Event channel for streaming transaction progress to Flutter
   std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>
       event_channel_;
@@ -550,10 +559,10 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
 
   // callback when transaction operation completed
   static void OnOperationComplete(FlatpakTransaction* transaction,
-                                  FlatpakTransactionOperation* operation,
-                                  const char* commit,
-                                  FlatpakTransactionResult result,
-                                  gpointer user_data);
+                                      FlatpakTransactionOperation* operation,
+                                      const char* commit,
+                                      FlatpakTransactionResult result,
+                                      gpointer user_data);
 
   // callback when transaction operation reports an error
   static gboolean OnOperationError(FlatpakTransaction* transaction,

--- a/plugins/flatpak/flatpak_shim.h
+++ b/plugins/flatpak/flatpak_shim.h
@@ -52,15 +52,15 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
   explicit FlatpakShim(FlatpakPlugin* plugin = nullptr,
                        flutter::BinaryMessenger* messenger = nullptr,
                        asio::io_context::strand* strand = nullptr)
-      : plugin_(plugin),
-        messenger_(messenger),
-        strand_(strand),
-        operation_tracker_(std::make_unique<OperationTracker>(
-            strand_->context(),
-            [this](const flutter::EncodableMap& event) {
-              this->SendTransactionEvent(
-                  const_cast<flutter::EncodableMap&>(event));
-            })) {}
+      : plugin_(plugin), messenger_(messenger), strand_(strand) {
+    if (strand_) {
+      operation_tracker_ = std::make_unique<OperationTracker>(
+          strand_->context(), [this](const flutter::EncodableMap& event) {
+            this->SendTransactionEvent(
+                const_cast<flutter::EncodableMap&>(event));
+          });
+    }
+  }
 
   ~FlatpakShim() {
     plugin_ = nullptr;

--- a/plugins/flatpak/flatpak_shim.h
+++ b/plugins/flatpak/flatpak_shim.h
@@ -52,12 +52,15 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
   explicit FlatpakShim(FlatpakPlugin* plugin = nullptr,
                        flutter::BinaryMessenger* messenger = nullptr,
                        asio::io_context::strand* strand = nullptr)
-  : plugin_(plugin), messenger_(messenger), strand_(strand),operation_tracker_(std::make_unique<OperationTracker>(
-        strand_->context(),
-        [this](const flutter::EncodableMap& event) {
-          this->SendTransactionEvent(const_cast<flutter::EncodableMap&>(event));
-        }
-    )) {}
+      : plugin_(plugin),
+        messenger_(messenger),
+        strand_(strand),
+        operation_tracker_(std::make_unique<OperationTracker>(
+            strand_->context(),
+            [this](const flutter::EncodableMap& event) {
+              this->SendTransactionEvent(
+                  const_cast<flutter::EncodableMap&>(event));
+            })) {}
 
   ~FlatpakShim() {
     plugin_ = nullptr;
@@ -559,10 +562,10 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
 
   // callback when transaction operation completed
   static void OnOperationComplete(FlatpakTransaction* transaction,
-                                      FlatpakTransactionOperation* operation,
-                                      const char* commit,
-                                      FlatpakTransactionResult result,
-                                      gpointer user_data);
+                                  FlatpakTransactionOperation* operation,
+                                  const char* commit,
+                                  FlatpakTransactionResult result,
+                                  gpointer user_data);
 
   // callback when transaction operation reports an error
   static gboolean OnOperationError(FlatpakTransaction* transaction,

--- a/plugins/flatpak/operation_tracker.cc
+++ b/plugins/flatpak/operation_tracker.cc
@@ -22,7 +22,11 @@
 
 namespace flatpak_plugin {
 
-OperationTracker::OperationTracker(asio::io_context& io_context,std::function<void(const flutter::EncodableMap&)> send_event_callback) : io_context_(io_context),send_event_callback_(std::move(send_event_callback)){}
+OperationTracker::OperationTracker(
+    asio::io_context& io_context,
+    std::function<void(const flutter::EncodableMap&)> send_event_callback)
+    : io_context_(io_context),
+      send_event_callback_(std::move(send_event_callback)) {}
 
 std::map<std::string, OperationTracker::OperationInfo>
 OperationTracker::GetActiveOperations() const {
@@ -33,45 +37,53 @@ void OperationTracker::TrackOperationStart(const std::string& app_id,
                                            const std::string& op_type) {
   asio::post(io_context_, [this, app_id, op_type]() {
     OperationInfo op_info;
-  op_info.app_id = app_id;
-  op_info.op_type = op_type;
-  op_info.total_ops = 0;
-  op_info.completed_ops = 0;
-  active_ops_[app_id] = op_info;
+    op_info.app_id = app_id;
+    op_info.op_type = op_type;
+    op_info.total_ops = 0;
+    op_info.completed_ops = 0;
+    active_ops_[app_id] = op_info;
 
-  spdlog::debug("[FlatpakPlugin] Operation {} Tracker started for {}",op_type,app_id);
+    spdlog::debug("[FlatpakPlugin] Operation {} Tracker started for {}",
+                  op_type, app_id);
   });
 }
 
 void OperationTracker::TrackOperationProgress(const std::string& app_id,
                                               const std::string& ref,
                                               int progress) {
-asio::post(io_context_, [this, app_id, ref, progress]() {
-  auto it = active_ops_.find(app_id);
-   if (it == active_ops_.end()) {
-     return;
-   }
-  OperationInfo& op_info = it->second;
+  asio::post(io_context_, [this, app_id, ref, progress]() {
+    auto it = active_ops_.find(app_id);
+    if (it == active_ops_.end()) {
+      return;
+    }
+    OperationInfo& op_info = it->second;
 
-  int overall_progress = 0;
-  if (op_info.total_ops > 0) {
-    overall_progress = ((op_info.completed_ops * 100) + progress) / op_info.total_ops;
-  } else {
-    overall_progress = progress;
-  }
+    int overall_progress = 0;
+    if (op_info.total_ops > 0) {
+      overall_progress =
+          ((op_info.completed_ops * 100) + progress) / op_info.total_ops;
+    } else {
+      overall_progress = progress;
+    }
 
-  overall_progress = std::max(0, std::min(100,overall_progress));
-  flutter::EncodableMap progress_event;
-  progress_event[flutter::EncodableValue("type")] = flutter::EncodableValue("aggregated_progress");
-  progress_event[flutter::EncodableValue("app_id")] = flutter::EncodableValue(app_id);
-  progress_event[flutter::EncodableValue("progress")] = flutter::EncodableValue(overall_progress);
-  progress_event[flutter::EncodableValue("completed_operations")] = flutter::EncodableValue(op_info.completed_ops);
-  progress_event[flutter::EncodableValue("total_operations")] = flutter::EncodableValue(op_info.total_ops);
-  progress_event[flutter::EncodableValue("current_ref")] = flutter::EncodableValue(ref);
-  if (send_event_callback_) {
-    send_event_callback_(progress_event);
-  }
-});
+    overall_progress = std::max(0, std::min(100, overall_progress));
+    flutter::EncodableMap progress_event;
+    progress_event[flutter::EncodableValue("type")] =
+        flutter::EncodableValue("aggregated_progress");
+    progress_event[flutter::EncodableValue("app_id")] =
+        flutter::EncodableValue(app_id);
+    progress_event[flutter::EncodableValue("progress")] =
+        flutter::EncodableValue(overall_progress);
+    progress_event[flutter::EncodableValue("completed_operations")] =
+        flutter::EncodableValue(op_info.completed_ops);
+    progress_event[flutter::EncodableValue("total_operations")] =
+        flutter::EncodableValue(op_info.total_ops);
+    progress_event[flutter::EncodableValue("current_ref")] =
+        flutter::EncodableValue(ref);
+    if (send_event_callback_) {
+      send_event_callback_(progress_event);
+    }
+  });
 }
 
 void OperationTracker::UpdateTotalOperations(const std::string& app_id,
@@ -79,31 +91,35 @@ void OperationTracker::UpdateTotalOperations(const std::string& app_id,
   asio::post(io_context_, [this, app_id, total_ops]() {
     auto it = active_ops_.find(app_id);
     if (it == active_ops_.end()) {
-      spdlog::error("[FlatpakPlugin] can't update total operations for {}",app_id);
+      spdlog::error("[FlatpakPlugin] can't update total operations for {}",
+                    app_id);
       return;
     }
 
     it->second.total_ops = total_ops;
-    spdlog::debug("[FlatpakPlugin] Updated total operations {} for app {}",total_ops,app_id);
+    spdlog::debug("[FlatpakPlugin] Updated total operations {} for app {}",
+                  total_ops, app_id);
   });
 }
 
 void OperationTracker::TrackOperationComplete(const std::string& app_id,
                                               const std::string& ref) {
-  asio::post(io_context_, [this,app_id, ref]() {
+  asio::post(io_context_, [this, app_id, ref]() {
     auto it = active_ops_.find(app_id);
-  if (it == active_ops_.end()) {
-    return;
-  }
+    if (it == active_ops_.end()) {
+      return;
+    }
     OperationInfo& op_info = it->second;
-      op_info.completed_ops++;
-      op_info.completed_ref.insert(ref);
-    spdlog::debug("[FlatpakPlugin] Operation Progress for {}: {}/{}",app_id,op_info.completed_ops,op_info.total_ops);
+    op_info.completed_ops++;
+    op_info.completed_ref.insert(ref);
+    spdlog::debug("[FlatpakPlugin] Operation Progress for {}: {}/{}", app_id,
+                  op_info.completed_ops, op_info.total_ops);
 
     // check if it's the app itself
     if (ref.find(app_id) != std::string::npos) {
       op_info.is_app = true;
-      spdlog::info("[FlatpakPlugin] Application Operations completed: {}",app_id);
+      spdlog::info("[FlatpakPlugin] Application Operations completed: {}",
+                   app_id);
     }
   });
 }
@@ -113,33 +129,42 @@ void OperationTracker::SendOperationFinish(const std::string& app_id,
                                            bool success) {
   asio::post(io_context_, [this, app_id, op_type, success]() {
     auto it = active_ops_.find(app_id);
-  if (it == active_ops_.end()) {
-    return;
-  }
+    if (it == active_ops_.end()) {
+      return;
+    }
     OperationInfo& op_info = it->second;
-    spdlog::info("[FlatpakPlugin] {} operation for {} completed, success:{}, total operations: {}, completed operations:{}",op_type,app_id,success,op_info.total_ops,op_info.completed_ops);
+    spdlog::info(
+        "[FlatpakPlugin] {} operation for {} completed, success:{}, total "
+        "operations: {}, completed operations:{}",
+        op_type, app_id, success, op_info.total_ops, op_info.completed_ops);
     flutter::EncodableMap summary_event;
-    summary_event[flutter::EncodableValue("type")] = flutter::EncodableValue("operation_summary");
-    summary_event[flutter::EncodableValue("app_id")] = flutter::EncodableValue(app_id);
-    summary_event[flutter::EncodableValue("operation_type")] = flutter::EncodableValue(op_type);
-    summary_event[flutter::EncodableValue("success")] = flutter::EncodableValue(success);
-    summary_event[flutter::EncodableValue("operations_completed")] = flutter::EncodableValue(op_info.completed_ops);
-    summary_event[flutter::EncodableValue("total_operations")] = flutter::EncodableValue(op_info.total_ops);
+    summary_event[flutter::EncodableValue("type")] =
+        flutter::EncodableValue("operation_summary");
+    summary_event[flutter::EncodableValue("app_id")] =
+        flutter::EncodableValue(app_id);
+    summary_event[flutter::EncodableValue("operation_type")] =
+        flutter::EncodableValue(op_type);
+    summary_event[flutter::EncodableValue("success")] =
+        flutter::EncodableValue(success);
+    summary_event[flutter::EncodableValue("operations_completed")] =
+        flutter::EncodableValue(op_info.completed_ops);
+    summary_event[flutter::EncodableValue("total_operations")] =
+        flutter::EncodableValue(op_info.total_ops);
 
     if (send_event_callback_) {
-          send_event_callback_(summary_event);
-        }    // remove from the tracker
+      send_event_callback_(summary_event);
+    }  // remove from the tracker
     active_ops_.erase(it);
   });
 }
 
 void OperationTracker::ClearOperation(const std::string& app_id) {
- asio::post(io_context_, [this, app_id]() {
-   auto it = active_ops_.find(app_id);
-   if (it == active_ops_.end()) {
-     active_ops_.erase(it);
-     spdlog::debug("[FlatpakPlugin] clear operation for {}", app_id);
-   }
- });
+  asio::post(io_context_, [this, app_id]() {
+    auto it = active_ops_.find(app_id);
+    if (it == active_ops_.end()) {
+      active_ops_.erase(it);
+      spdlog::debug("[FlatpakPlugin] clear operation for {}", app_id);
+    }
+  });
 }
 }  // namespace flatpak_plugin

--- a/plugins/flatpak/operation_tracker.cc
+++ b/plugins/flatpak/operation_tracker.cc
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020-2026 Toyota Connected North America
+ * Copyright 2026 Ahmed Wafdy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "operation_tracker.h"
+
+#include "asio/post.hpp"
+#include "spdlog/spdlog.h"
+
+namespace flatpak_plugin {
+
+OperationTracker::OperationTracker(asio::io_context& io_context,std::function<void(const flutter::EncodableMap&)> send_event_callback) : io_context_(io_context),send_event_callback_(std::move(send_event_callback)){}
+
+std::map<std::string, OperationTracker::OperationInfo>
+OperationTracker::GetActiveOperations() const {
+  return active_ops_;
+}
+
+void OperationTracker::TrackOperationStart(const std::string& app_id,
+                                           const std::string& op_type) {
+  asio::post(io_context_, [this, app_id, op_type]() {
+    OperationInfo op_info;
+  op_info.app_id = app_id;
+  op_info.op_type = op_type;
+  op_info.total_ops = 0;
+  op_info.completed_ops = 0;
+  active_ops_[app_id] = op_info;
+
+  spdlog::debug("[FlatpakPlugin] Operation {} Tracker started for {}",op_type,app_id);
+  });
+}
+
+void OperationTracker::TrackOperationProgress(const std::string& app_id,
+                                              const std::string& ref,
+                                              int progress) {
+asio::post(io_context_, [this, app_id, ref, progress]() {
+  auto it = active_ops_.find(app_id);
+   if (it == active_ops_.end()) {
+     return;
+   }
+  OperationInfo& op_info = it->second;
+
+  int overall_progress = 0;
+  if (op_info.total_ops > 0) {
+    overall_progress = ((op_info.completed_ops * 100) + progress) / op_info.total_ops;
+  } else {
+    overall_progress = progress;
+  }
+
+  overall_progress = std::max(0, std::min(100,overall_progress));
+  flutter::EncodableMap progress_event;
+  progress_event[flutter::EncodableValue("type")] = flutter::EncodableValue("aggregated_progress");
+  progress_event[flutter::EncodableValue("app_id")] = flutter::EncodableValue(app_id);
+  progress_event[flutter::EncodableValue("progress")] = flutter::EncodableValue(overall_progress);
+  progress_event[flutter::EncodableValue("completed_operations")] = flutter::EncodableValue(op_info.completed_ops);
+  progress_event[flutter::EncodableValue("total_operations")] = flutter::EncodableValue(op_info.total_ops);
+  progress_event[flutter::EncodableValue("current_ref")] = flutter::EncodableValue(ref);
+  if (send_event_callback_) {
+    send_event_callback_(progress_event);
+  }
+});
+}
+
+void OperationTracker::UpdateTotalOperations(const std::string& app_id,
+                                             int total_ops) {
+  asio::post(io_context_, [this, app_id, total_ops]() {
+    auto it = active_ops_.find(app_id);
+    if (it == active_ops_.end()) {
+      spdlog::error("[FlatpakPlugin] can't update total operations for {}",app_id);
+      return;
+    }
+
+    it->second.total_ops = total_ops;
+    spdlog::debug("[FlatpakPlugin] Updated total operations {} for app {}",total_ops,app_id);
+  });
+}
+
+void OperationTracker::TrackOperationComplete(const std::string& app_id,
+                                              const std::string& ref) {
+  asio::post(io_context_, [this,app_id, ref]() {
+    auto it = active_ops_.find(app_id);
+  if (it == active_ops_.end()) {
+    return;
+  }
+    OperationInfo& op_info = it->second;
+      op_info.completed_ops++;
+      op_info.completed_ref.insert(ref);
+    spdlog::debug("[FlatpakPlugin] Operation Progress for {}: {}/{}",app_id,op_info.completed_ops,op_info.total_ops);
+
+    // check if it's the app itself
+    if (ref.find(app_id) != std::string::npos) {
+      op_info.is_app = true;
+      spdlog::info("[FlatpakPlugin] Application Operations completed: {}",app_id);
+    }
+  });
+}
+
+void OperationTracker::SendOperationFinish(const std::string& app_id,
+                                           const std::string& op_type,
+                                           bool success) {
+  asio::post(io_context_, [this, app_id, op_type, success]() {
+    auto it = active_ops_.find(app_id);
+  if (it == active_ops_.end()) {
+    return;
+  }
+    OperationInfo& op_info = it->second;
+    spdlog::info("[FlatpakPlugin] {} operation for {} completed, success:{}, total operations: {}, completed operations:{}",op_type,app_id,success,op_info.total_ops,op_info.completed_ops);
+    flutter::EncodableMap summary_event;
+    summary_event[flutter::EncodableValue("type")] = flutter::EncodableValue("operation_summary");
+    summary_event[flutter::EncodableValue("app_id")] = flutter::EncodableValue(app_id);
+    summary_event[flutter::EncodableValue("operation_type")] = flutter::EncodableValue(op_type);
+    summary_event[flutter::EncodableValue("success")] = flutter::EncodableValue(success);
+    summary_event[flutter::EncodableValue("operations_completed")] = flutter::EncodableValue(op_info.completed_ops);
+    summary_event[flutter::EncodableValue("total_operations")] = flutter::EncodableValue(op_info.total_ops);
+
+    if (send_event_callback_) {
+          send_event_callback_(summary_event);
+        }    // remove from the tracker
+    active_ops_.erase(it);
+  });
+}
+
+void OperationTracker::ClearOperation(const std::string& app_id) {
+ asio::post(io_context_, [this, app_id]() {
+   auto it = active_ops_.find(app_id);
+   if (it == active_ops_.end()) {
+     active_ops_.erase(it);
+     spdlog::debug("[FlatpakPlugin] clear operation for {}", app_id);
+   }
+ });
+}
+}  // namespace flatpak_plugin

--- a/plugins/flatpak/operation_tracker.h
+++ b/plugins/flatpak/operation_tracker.h
@@ -18,9 +18,9 @@
 #ifndef FLUTTER_PLUGIN_FLATPAK_OPERATION_TRACKER_H
 #define FLUTTER_PLUGIN_FLATPAK_OPERATION_TRACKER_H
 
-#include <string>
-#include <set>
 #include <map>
+#include <set>
+#include <string>
 
 #include "asio/io_context.hpp"
 #include "flatpak_shim.h"
@@ -30,7 +30,7 @@ namespace flatpak_plugin {
 struct FlatpakShim;
 
 class OperationTracker {
-public:
+ public:
   struct OperationInfo {
     std::string app_id;
     std::string op_type;
@@ -43,7 +43,6 @@ public:
       asio::io_context& io_context,
       std::function<void(const flutter::EncodableMap&)> send_event_callback);
 
-
   ~OperationTracker() = default;
 
   OperationTracker(const OperationTracker&) = delete;
@@ -51,24 +50,31 @@ public:
   OperationTracker(OperationTracker&&) = delete;
   OperationTracker& operator=(OperationTracker&&) = delete;
 
-  std::map<std::string, OperationInfo> GetActiveOperations() const;
+  [[nodiscard]] std::map<std::string, OperationInfo> GetActiveOperations()
+      const;
 
-  void TrackOperationStart(const std::string& app_id,const std::string& op_type);
+  void TrackOperationStart(const std::string& app_id,
+                           const std::string& op_type);
 
-  void TrackOperationProgress(const std::string& app_id,const std::string& ref,int progress);
+  void TrackOperationProgress(const std::string& app_id,
+                              const std::string& ref,
+                              int progress);
 
-  void UpdateTotalOperations(const std::string& app_id,int total_ops);
+  void UpdateTotalOperations(const std::string& app_id, int total_ops);
 
-  void TrackOperationComplete(const std::string& app_id,const std::string& ref);
+  void TrackOperationComplete(const std::string& app_id,
+                              const std::string& ref);
 
-  void SendOperationFinish(const std::string& app_id,const std::string& op_type,bool success);
+  void SendOperationFinish(const std::string& app_id,
+                           const std::string& op_type,
+                           bool success);
 
   void ClearOperation(const std::string& app_id);
-private:
 
+ private:
   asio::io_context& io_context_;
   std::function<void(const flutter::EncodableMap&)> send_event_callback_;
-  std::map<std::string,OperationInfo> active_ops_;
+  std::map<std::string, OperationInfo> active_ops_;
 };
 }  // namespace flatpak_plugin
 

--- a/plugins/flatpak/operation_tracker.h
+++ b/plugins/flatpak/operation_tracker.h
@@ -27,6 +27,8 @@
 
 namespace flatpak_plugin {
 
+struct FlatpakShim;
+
 class OperationTracker {
 public:
   struct OperationInfo {

--- a/plugins/flatpak/operation_tracker.h
+++ b/plugins/flatpak/operation_tracker.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020-2026 Toyota Connected North America
+ * Copyright 2026 Ahmed Wafdy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FLUTTER_PLUGIN_FLATPAK_OPERATION_TRACKER_H
+#define FLUTTER_PLUGIN_FLATPAK_OPERATION_TRACKER_H
+
+#include <string>
+#include <set>
+#include <map>
+
+#include "asio/io_context.hpp"
+#include "flatpak_shim.h"
+
+namespace flatpak_plugin {
+
+class OperationTracker {
+public:
+  struct OperationInfo {
+    std::string app_id;
+    std::string op_type;
+    bool is_app = false;
+    int total_ops;
+    int completed_ops;
+    std::set<std::string> completed_ref;
+  };
+  explicit OperationTracker(
+      asio::io_context& io_context,
+      std::function<void(const flutter::EncodableMap&)> send_event_callback);
+
+
+  ~OperationTracker() = default;
+
+  OperationTracker(const OperationTracker&) = delete;
+  OperationTracker& operator=(const OperationTracker&) = delete;
+  OperationTracker(OperationTracker&&) = delete;
+  OperationTracker& operator=(OperationTracker&&) = delete;
+
+  std::map<std::string, OperationInfo> GetActiveOperations() const;
+
+  void TrackOperationStart(const std::string& app_id,const std::string& op_type);
+
+  void TrackOperationProgress(const std::string& app_id,const std::string& ref,int progress);
+
+  void UpdateTotalOperations(const std::string& app_id,int total_ops);
+
+  void TrackOperationComplete(const std::string& app_id,const std::string& ref);
+
+  void SendOperationFinish(const std::string& app_id,const std::string& op_type,bool success);
+
+  void ClearOperation(const std::string& app_id);
+private:
+
+  asio::io_context& io_context_;
+  std::function<void(const flutter::EncodableMap&)> send_event_callback_;
+  std::map<std::string,OperationInfo> active_ops_;
+};
+}  // namespace flatpak_plugin
+
+#endif  // FLUTTER_PLUGIN_FLATPAK_OPERATION_TRACKER_H


### PR DESCRIPTION
This PR addresses #208 by adding an asynchronous tracker for all transaction operations, including installation, updating, and uninstallation. In the last operation, the plugin sends a ‘operation_summary’ to the Flutter event channel, which then establishes a handshake with the Flutter app to determine the final status of the installation, update, or uninstallation. Flutter subsequently updates all screens’ UI in a reliable manner to provide a real-time system status for the apps.