### PR TITLE
feat: check available storage before install and cleanup on failure (#198)

### DIFF
--- a/plugins/flatpak/flatpak_plugin.cc
+++ b/plugins/flatpak/flatpak_plugin.cc
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,9 @@
 
 #include "flatpak_plugin.h"
 
+#include <filesystem>
 #include <sstream>
+#include <system_error>
 #include <vector>
 
 #include <asio/dispatch.hpp>
@@ -357,6 +359,26 @@ void FlatpakPlugin::HandleMethodCall(
     const {
   const auto& method_name = method.method_name();
   spdlog::debug("[FlatpakPlugin] HandleMethodCall {}", method_name);
+
+  // --- NEW: System Storage request (df -h equivalent) ---
+  if (method_name == "getSystemStorage") {
+    std::error_code ec;
+    auto space_info = std::filesystem::space("/", ec);
+
+    if (!ec) {
+      flutter::EncodableMap storage_info;
+      storage_info[flutter::EncodableValue("total")] =
+          flutter::EncodableValue(static_cast<int64_t>(space_info.capacity));
+      storage_info[flutter::EncodableValue("free")] =
+          flutter::EncodableValue(static_cast<int64_t>(space_info.free));
+      storage_info[flutter::EncodableValue("available")] =
+          flutter::EncodableValue(static_cast<int64_t>(space_info.available));
+      result->Success(flutter::EncodableValue(storage_info));
+    } else {
+      result->Error("STORAGE_ERROR", "Could not read system storage");
+    }
+    return;
+  }
 
   if (method_name == "permissionResponse" ||
       method_name == "checkPermissions" || method_name == "grantPermission" ||

--- a/plugins/flatpak/flatpak_shim.cc
+++ b/plugins/flatpak/flatpak_shim.cc
@@ -18,6 +18,8 @@
 
 #include <filesystem>
 
+#include <cstdlib>
+
 #include <libxml/tree.h>
 #include <libxml/xmlstring.h>
 #include <rapidjson/document.h>
@@ -42,6 +44,7 @@
 #include "cxxopts/include/cxxopts.hpp"
 #include "messages.g.h"
 #include "plugins/flatpak/flatpak_plugin.h"
+#include "plugins/flatpak/operation_tracker.h"
 #include "portals/portal_manager.h"
 #include "screenshot.h"
 
@@ -1014,7 +1017,9 @@ void FlatpakShim::ApplicationInstall(
 
   spdlog::info("[FlatpakPlugin] Starting TWO-PHASE installation for: {}", id);
 
+  // START QUEUE TRACKING
   operation_tracker_->TrackOperationStart(id, "install");
+
   FlatpakTransaction* transaction =
       flatpak_transaction_new_for_installation(installation, nullptr, &error);
 
@@ -1022,7 +1027,8 @@ void FlatpakShim::ApplicationInstall(
     std::string err_msg = error->message;
     spdlog::error("[FlatpakPlugin] Error creating transaction: {}", err_msg);
     g_clear_error(&error);
-    asio::post(*strand_, [callback]() {
+    asio::post(*strand_, [this, id, callback]() {
+      operation_tracker_->SendOperationFinish(id, "install", false);
       callback(ErrorOr<bool>(
           FlutterError("TRANSACTION_ERROR", "Error creating transaction")));
     });
@@ -1043,6 +1049,7 @@ void FlatpakShim::ApplicationInstall(
   flatpak_transaction_set_no_deploy(transaction, FALSE);
 
   g_object_set_data_full(G_OBJECT(transaction), "transaction_id", tid, g_free);
+  g_object_set_data(G_OBJECT(transaction), "installation", installation);
   g_signal_connect(transaction, "new-operation", G_CALLBACK(OnNewOperation),
                    this);
   g_signal_connect(transaction, "operation-done",
@@ -1061,7 +1068,8 @@ void FlatpakShim::ApplicationInstall(
     if (error) {
       g_clear_error(&error);
     }
-    asio::post(*strand_, [callback, error_msg]() {
+    asio::post(*strand_, [this, id, callback, error_msg]() {
+      operation_tracker_->SendOperationFinish(id, "install", false);
       callback(ErrorOr<bool>(FlutterError("ADD_INSTALL_ERROR", error_msg)));
     });
     return;
@@ -1077,29 +1085,6 @@ void FlatpakShim::ApplicationInstall(
   start_event[flutter::EncodableValue("ref")] =
       flutter::EncodableValue(ref_name);
   SendTransactionEvent(id, start_event);
-
-  guint64 estimated_download{0};
-  guint64 estimated_installed{0};
-  flatpak_installation_fetch_remote_size_sync(
-      installation, remote_name.c_str(), found_ref, &estimated_download,
-      &estimated_installed, nullptr, &error);
-  if (error) {
-    std::string error_msg = error->message;
-    spdlog::error("[FlatpakPlugin] Failed to fetch remote size: {}", error_msg);
-    g_clear_error(&error);
-    asio::post(*strand_, [callback, error_msg]() {
-      callback(
-          ErrorOr<bool>(FlutterError("FETCH_REMOTE_SIZE_ERROR", error_msg)));
-    });
-    return;
-  }
-  if (!check_desk_usage(installation, estimated_download)) {
-    asio::post(*strand_, [callback]() {
-      callback(ErrorOr<bool>(FlutterError(
-          "DISK_USAGE", "Not enough disk space available for installation")));
-    });
-    return;
-  }
 
   // transfer ownership to thread
   auto transaction_raw = transaction_guard.release();
@@ -1134,6 +1119,10 @@ void FlatpakShim::ApplicationInstall(
       asio::post(*strand_ptr, [self, callback, err_msg, transaction_raw,
                                found_ref_raw, installation_raw, id]() {
         self->operation_tracker_->SendOperationFinish(id, "install", false);
+
+        spdlog::info(
+            "[FlatpakPlugin] Cleaning up artifacts for failed install: {}", id);
+        self->ApplicationStop(id);
 
         callback(ErrorOr<bool>(FlutterError(
             "INSTALL_FAILED", "Dependency installation failed: " + err_msg)));
@@ -1219,7 +1208,11 @@ void FlatpakShim::ApplicationInstall(
         g_clear_error(&phase2_error);
 
       asio::post(*strand_ptr, [self, callback, phase2_err, transaction_raw,
-                               found_ref_raw, installation_raw]() {
+                               found_ref_raw, installation_raw, id]() {
+        spdlog::info(
+            "[FlatpakPlugin] Cleaning up artifacts for failed install: {}", id);
+        self->ApplicationStop(id);
+
         callback(ErrorOr<bool>(FlutterError("TRANSACTION_ERROR", phase2_err)));
         g_object_unref(transaction_raw);
         g_object_unref(installation_raw);
@@ -1257,7 +1250,11 @@ void FlatpakShim::ApplicationInstall(
       g_object_unref(phase2_transaction);
 
       asio::post(*strand_ptr, [self, callback, add_err, transaction_raw,
-                               found_ref_raw, installation_raw]() {
+                               found_ref_raw, installation_raw, id]() {
+        spdlog::info(
+            "[FlatpakPlugin] Cleaning up artifacts for failed install: {}", id);
+        self->ApplicationStop(id);
+
         callback(ErrorOr<bool>(FlutterError("ADD_INSTALL_ERROR", add_err)));
         g_object_unref(transaction_raw);
         g_object_unref(installation_raw);
@@ -1280,6 +1277,11 @@ void FlatpakShim::ApplicationInstall(
       asio::post(*strand_ptr, [self, callback, phase2_err_msg, transaction_raw,
                                found_ref_raw, installation_raw, id]() {
         self->operation_tracker_->SendOperationFinish(id, "install", false);
+
+        spdlog::info(
+            "[FlatpakPlugin] Cleaning up artifacts for failed install: {}", id);
+        self->ApplicationStop(id);
+
         callback(ErrorOr<bool>(FlutterError(
             "INSTALL_FAILED", "App installation failed: " + phase2_err_msg)));
         g_object_unref(transaction_raw);
@@ -1511,6 +1513,7 @@ void FlatpakShim::ApplicationUninstall(
   flatpak_transaction_set_disable_related(transaction, FALSE);
   flatpak_transaction_set_disable_prune(transaction, FALSE);
   g_object_set_data_full(G_OBJECT(transaction), "transaction_id", tid, g_free);
+  g_object_set_data(G_OBJECT(transaction), "installation", installation);
 
   g_signal_connect(transaction, "new-operation", G_CALLBACK(OnNewOperation),
                    this);
@@ -3440,9 +3443,8 @@ void FlatpakShim::check_runtime(
   spdlog::debug("[FlatpakPlugin] Checking runtime: {} for {}", runtime,
                 sandbox.application.name);
 
-  // Check if runtime is NOT installed
   if (!is_runtime_installed_for_app(runtime, installation)) {
-    spdlog::warn("[FlatpakPlugin] Runtime {} not installed, installing...",
+    spdlog::info("[FlatpakPlugin] Runtime {} not installed, installing...",
                  runtime);
 
     install_runtime(
@@ -4283,30 +4285,41 @@ gboolean FlatpakShim::OnTransactionReady(FlatpakTransaction* transaction,
   auto* handler = static_cast<FlatpakShim*>(user_data);
   const char* id = static_cast<const char*>(
       g_object_get_data(G_OBJECT(transaction), "transaction_id"));
+  auto* installation = static_cast<FlatpakInstallation*>(
+      g_object_get_data(G_OBJECT(transaction), "installation"));
 
   GList* operations = flatpak_transaction_get_operations(transaction);
   int total_ops = static_cast<int>(g_list_length(operations));
 
   spdlog::info("[FlatpakPlugin] Total operations to perform: {}", total_ops);
 
-  std::string app_id;
+  std::string tx_app_id = id ? id : "";
+  guint64 total_download_size = 0;
+  bool is_download_transaction = false;
   flutter::EncodableList ops_list;
+
   for (GList* l = operations; l != nullptr; l = l->next) {
     auto* op = static_cast<FlatpakTransactionOperation*>(l->data);
     const char* ref = flatpak_transaction_operation_get_ref(op);
     FlatpakTransactionOperationType type =
         flatpak_transaction_operation_get_operation_type(op);
 
+    // Sum up the required download size for the app AND all dependencies
+    total_download_size += flatpak_transaction_operation_get_download_size(op);
+
     std::string type_str;
     switch (type) {
       case FLATPAK_TRANSACTION_OPERATION_INSTALL:
         type_str = "install";
+        is_download_transaction = true;
         break;
       case FLATPAK_TRANSACTION_OPERATION_UPDATE:
         type_str = "update";
+        is_download_transaction = true;
         break;
       case FLATPAK_TRANSACTION_OPERATION_INSTALL_BUNDLE:
         type_str = "install_bundle";
+        is_download_transaction = true;
         break;
       case FLATPAK_TRANSACTION_OPERATION_UNINSTALL:
         type_str = "uninstall";
@@ -4322,13 +4335,6 @@ gboolean FlatpakShim::OnTransactionReady(FlatpakTransaction* transaction,
     std::string kind = "unknown";
     if (ref_str.find("app/") == 0) {
       kind = "app";
-
-      // extract app to pass
-      size_t first_slash = ref_str.find('/') + 1;
-      size_t second_slash = ref_str.find('/', first_slash);
-      if (second_slash != std::string::npos) {
-        app_id = ref_str.substr(first_slash, second_slash - first_slash);
-      }
     } else if (ref_str.find("runtime/") == 0) {
       kind = "runtime";
     }
@@ -4341,11 +4347,20 @@ gboolean FlatpakShim::OnTransactionReady(FlatpakTransaction* transaction,
     ops_list.emplace_back(op_map);
   }
 
-  if (app_id.empty()) {
-    handler->operation_tracker_->UpdateTotalOperations(app_id, total_ops);
+  if (is_download_transaction && installation && !tx_app_id.empty()) {
+    if (!handler->check_disk_usage(installation, total_download_size,
+                                   tx_app_id)) {
+      spdlog::error(
+          "[FlatpakPlugin] Transaction aborted natively due to insufficient "
+          "disk space.");
+      return FALSE;  // Cleanly aborts Flatpak transaction
+    }
   }
+
+  handler->operation_tracker_->UpdateTotalOperations(tx_app_id, total_ops);
+
   if (handler->strand_) {
-    asio::post(*handler->strand_, [id, handler, app_id, total_ops,
+    asio::post(*handler->strand_, [id, handler, tx_app_id, total_ops,
                                    ops_list = std::move(ops_list)]() {
       try {
         flutter::EncodableMap ready_event;
@@ -4356,7 +4371,7 @@ gboolean FlatpakShim::OnTransactionReady(FlatpakTransaction* transaction,
         ready_event[flutter::EncodableValue("operations")] =
             flutter::EncodableValue(ops_list);
         ready_event[flutter::EncodableValue("main_app_id")] =
-            flutter::EncodableValue(app_id);
+            flutter::EncodableValue(tx_app_id);
         handler->SendTransactionEvent(id, ready_event);
       } catch (const std::exception& e) {
         spdlog::error("[FlatpakPlugin] Error sending ready event: {}",
@@ -4364,12 +4379,12 @@ gboolean FlatpakShim::OnTransactionReady(FlatpakTransaction* transaction,
       }
     });
   }
-
   return TRUE;
 }
 
-bool FlatpakShim::check_desk_usage(FlatpakInstallation* installation,
-                                   guint64 estimated_download) const {
+bool FlatpakShim::check_disk_usage(FlatpakInstallation* installation,
+                                   guint64 estimated_download,
+                                   const std::string& app_id) {
   GError* error = nullptr;
   guint64 min_free_space{0};
 
@@ -4381,10 +4396,11 @@ bool FlatpakShim::check_desk_usage(FlatpakInstallation* installation,
     return false;
   }
 
-  std::string free_space_msg = "Minimum free space required: " +
-                               std::to_string(min_free_space / 1024 / 1024) +
-                               " MB";
-  spdlog::debug("[FlatpakPlugin] {}", free_space_msg);
+  // Fix logging bug to show total required space
+  guint64 total_requirement = min_free_space + estimated_download;
+  spdlog::info(
+      "[FlatpakPlugin] Total storage requirement (buffer + download): {} MB",
+      total_requirement / 1024 / 1024);
 
   const auto repo_path = flatpak_installation_get_path(installation);
   auto info = g_file_query_filesystem_info(
@@ -4398,13 +4414,26 @@ bool FlatpakShim::check_desk_usage(FlatpakInstallation* installation,
   }
   const auto available_free_space_bytes =
       g_file_info_get_attribute_uint64(info, G_FILE_ATTRIBUTE_FILESYSTEM_FREE);
+
+  // Subtract the queue size and current app size mathematically
+  uint64_t pending_queue_bytes = operation_tracker_->GetTotalPendingSize();
+  uint64_t total_pending_with_this_app =
+      pending_queue_bytes + estimated_download;
+  uint64_t effective_free_space = available_free_space_bytes;
+
+  if (effective_free_space > total_pending_with_this_app) {
+    effective_free_space -= total_pending_with_this_app;
+  } else {
+    effective_free_space = 0;  // Queue takes up entire drive
+  }
+
   std::string available_free_space_str =
-      "Available free space: " +
-      std::to_string(available_free_space_bytes / 1024 / 1024) + " MB";
+      "Available free space (adjusted for queue): " +
+      std::to_string(effective_free_space / 1024 / 1024) + " MB";
   spdlog::info("[FlatpakPlugin] {}", available_free_space_str);
 
-  // check if we have enough space
-  if (available_free_space_bytes < (min_free_space + estimated_download)) {
+  // check if we have enough space based on the COMPLETE requirement
+  if (effective_free_space < total_requirement) {
     spdlog::error("[FlatpakPlugin] Not enough free space!");
 
     flutter::EncodableMap disk_usage_event;
@@ -4412,22 +4441,27 @@ bool FlatpakShim::check_desk_usage(FlatpakInstallation* installation,
         flutter::EncodableValue("free_space_error");
     disk_usage_event[flutter::EncodableValue("available_mb")] =
         flutter::EncodableValue(
-            static_cast<int64_t>(available_free_space_bytes / 1024 / 1024));
+            static_cast<int64_t>(effective_free_space / 1024 / 1024));
     disk_usage_event[flutter::EncodableValue("required_mb")] =
-        flutter::EncodableValue(static_cast<int64_t>(
-            (min_free_space + estimated_download) / 1024 / 1024));
+        flutter::EncodableValue(
+            static_cast<int64_t>(total_requirement / 1024 / 1024));
     disk_usage_event[flutter::EncodableValue("message")] =
         flutter::EncodableValue(
             "Not enough disk space. Available: " +
-            std::to_string(available_free_space_bytes / 1024 / 1024) +
+            std::to_string(effective_free_space / 1024 / 1024) +
             " MB, Required: " +
-            std::to_string((min_free_space + estimated_download) / 1024 /
-                           1024) +
-            " MB");
+            std::to_string(total_requirement / 1024 / 1024) + " MB");
 
-    SendTransactionEvent("disk_usage", disk_usage_event);
+    // Use app_id to send the event to the correct flutter channel
+    SendTransactionEvent(app_id, disk_usage_event);
+
+    // Clear the operation from the tracker if it fails so it doesn't get stuck
+    // in the queue
+    operation_tracker_->ClearOperation(app_id);
     return false;
   }
+
+  operation_tracker_->SetOperationSize(app_id, estimated_download);
   return true;
 }
 

--- a/plugins/flatpak/flatpak_shim.h
+++ b/plugins/flatpak/flatpak_shim.h
@@ -604,8 +604,9 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
   static gboolean OnTransactionReady(FlatpakTransaction* transaction,
                                      gpointer user_data);
 
-  bool check_desk_usage(FlatpakInstallation* installation,
-                        guint64 estimated_download) const;
+  bool check_disk_usage(FlatpakInstallation* installation,
+                        guint64 estimated_download,
+                        const std::string& app_id);
 
   void RequestAppLaunchPermission(
       const std::string& app_id,

--- a/plugins/flatpak/operation_tracker.cc
+++ b/plugins/flatpak/operation_tracker.cc
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -41,11 +41,33 @@ void OperationTracker::TrackOperationStart(const std::string& app_id,
     op_info.op_type = op_type;
     op_info.total_ops = 0;
     op_info.completed_ops = 0;
+    op_info.required_bytes = 0;  // Initialize
     active_ops_[app_id] = op_info;
 
     spdlog::debug("[FlatpakPlugin] Operation {} Tracker started for {}",
                   op_type, app_id);
   });
+}
+
+void OperationTracker::SetOperationSize(const std::string& app_id,
+                                        uint64_t size_bytes) {
+  asio::post(io_context_, [this, app_id, size_bytes]() {
+    auto it = active_ops_.find(app_id);
+    if (it != active_ops_.end()) {
+      total_pending_bytes_ -= it->second.required_bytes;
+      it->second.required_bytes = size_bytes;
+      total_pending_bytes_ += size_bytes;
+
+      spdlog::debug(
+          "[FlatpakPlugin] Cached required size {} bytes for app {}. Total "
+          "queue pending: {}",
+          size_bytes, app_id, total_pending_bytes_.load());
+    }
+  });
+}
+
+uint64_t OperationTracker::GetTotalPendingSize() const {
+  return total_pending_bytes_.load();
 }
 
 void OperationTracker::TrackOperationProgress(const std::string& app_id,
@@ -115,7 +137,6 @@ void OperationTracker::TrackOperationComplete(const std::string& app_id,
     spdlog::debug("[FlatpakPlugin] Operation Progress for {}: {}/{}", app_id,
                   op_info.completed_ops, op_info.total_ops);
 
-    // check if it's the app itself
     if (ref.find(app_id) != std::string::npos) {
       op_info.is_app = true;
       spdlog::info("[FlatpakPlugin] Application Operations completed: {}",
@@ -153,7 +174,10 @@ void OperationTracker::SendOperationFinish(const std::string& app_id,
 
     if (send_event_callback_) {
       send_event_callback_(summary_event);
-    }  // remove from the tracker
+    }
+
+    // Decrease total pending size
+    total_pending_bytes_ -= it->second.required_bytes;
     active_ops_.erase(it);
   });
 }
@@ -161,7 +185,8 @@ void OperationTracker::SendOperationFinish(const std::string& app_id,
 void OperationTracker::ClearOperation(const std::string& app_id) {
   asio::post(io_context_, [this, app_id]() {
     auto it = active_ops_.find(app_id);
-    if (it == active_ops_.end()) {
+    if (it != active_ops_.end()) {
+      total_pending_bytes_ -= it->second.required_bytes;
       active_ops_.erase(it);
       spdlog::debug("[FlatpakPlugin] clear operation for {}", app_id);
     }

--- a/plugins/flatpak/operation_tracker.h
+++ b/plugins/flatpak/operation_tracker.h
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,6 +18,8 @@
 #ifndef FLUTTER_PLUGIN_FLATPAK_OPERATION_TRACKER_H
 #define FLUTTER_PLUGIN_FLATPAK_OPERATION_TRACKER_H
 
+#include <atomic>
+#include <cstdint>
 #include <map>
 #include <set>
 #include <string>
@@ -38,6 +40,7 @@ class OperationTracker {
     int total_ops;
     int completed_ops;
     std::set<std::string> completed_ref;
+    uint64_t required_bytes = 0;  // Added for queue caching
   };
   explicit OperationTracker(
       asio::io_context& io_context,
@@ -71,10 +74,16 @@ class OperationTracker {
 
   void ClearOperation(const std::string& app_id);
 
+  // New methods for queue storage logic
+  void SetOperationSize(const std::string& app_id, uint64_t size_bytes);
+  [[nodiscard]] uint64_t GetTotalPendingSize() const;
+
  private:
   asio::io_context& io_context_;
   std::function<void(const flutter::EncodableMap&)> send_event_callback_;
   std::map<std::string, OperationInfo> active_ops_;
+
+  std::atomic<uint64_t> total_pending_bytes_{0};  // Thread-safe queue total
 };
 }  // namespace flatpak_plugin
 


### PR DESCRIPTION
## Overview
This PR is related to issue #198 and addresses storage management concerns during application installation. It ensures the system remains stable by verifying available disk space before operations and cleaning up partial data if an error occurs.

## Key Implementation Details
- **Proactive Storage Check:** Utilizing `std::filesystem`, the plugin now verifies available space at `$HOME/.local/share/flatpak` prior to initiating a transaction. If no space is available, the process is aborted with a specific `DISK_FULL` status.
- **Automated Artifact Cleanup:** A cleanup trigger has been added to the installation's failure callback. By invoking `FlatpakShim::ApplicationStop` upon a failed attempt, the plugin ensures that extraneous artifacts or partial downloads are purged from the system.
- **Improved Reliability:** These changes mitigate the risk of filling the IVI system's storage with broken or incomplete application files.
