### PR TITLE
add appstream updates to background init

### DIFF
--- a/plugins/flatpak/flatpak_plugin.cc
+++ b/plugins/flatpak/flatpak_plugin.cc
@@ -102,6 +102,8 @@ void FlatpakPlugin::Init() {
              std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>>
                  result) { this->HandleMethodCall(call, std::move(result)); });
   spdlog::info("[FlatpakPlugin] Event channel Setup Complete");
+
+  // shim_->update_appstream();
 }
 
 // Get Flatpak Version

--- a/plugins/flatpak/flatpak_plugin.cc
+++ b/plugins/flatpak/flatpak_plugin.cc
@@ -103,7 +103,7 @@ void FlatpakPlugin::Init() {
                  result) { this->HandleMethodCall(call, std::move(result)); });
   spdlog::info("[FlatpakPlugin] Event channel Setup Complete");
 
-  shim_->update_appstream();
+  flatpak_plugin::FlatpakShim::update_appstream();
 }
 
 // Get Flatpak Version

--- a/plugins/flatpak/flatpak_plugin.cc
+++ b/plugins/flatpak/flatpak_plugin.cc
@@ -103,7 +103,7 @@ void FlatpakPlugin::Init() {
                  result) { this->HandleMethodCall(call, std::move(result)); });
   spdlog::info("[FlatpakPlugin] Event channel Setup Complete");
 
-  // shim_->update_appstream();
+  shim_->update_appstream();
 }
 
 // Get Flatpak Version

--- a/plugins/flatpak/flatpak_shim.cc
+++ b/plugins/flatpak/flatpak_shim.cc
@@ -222,6 +222,7 @@ std::time_t FlatpakShim::get_appstream_timestamp(
     return std::time(nullptr);
   }
 }
+
 void FlatpakShim::update_appstream() {
   GError* error = nullptr;
 

--- a/plugins/flatpak/flatpak_shim.cc
+++ b/plugins/flatpak/flatpak_shim.cc
@@ -223,6 +223,46 @@ std::time_t FlatpakShim::get_appstream_timestamp(
   }
 }
 
+void FlatpakShim::update_appstream() {
+
+  GError* error = nullptr;
+  auto installation = flatpak_installation_new_user(nullptr, &error);
+  if (error) {
+    spdlog::error("[FlatpakPlugin] Failed to get user installation: {}",
+                  error->message);
+    g_clear_error(&error);
+    return ;
+  }
+  auto remotes = get_remotes(installation);
+  if (!remotes) {
+    spdlog::error("[FlatpakPlugin] Failed to fetch any remotes");
+    g_clear_error(&error);
+    g_object_unref(installation);
+    return;
+  }
+  for (guint i = 0; i < remotes->len; i++) {
+    const auto remote =
+        static_cast<FlatpakRemoteRef*>(g_ptr_array_index(remotes, i));
+
+    const auto remote_name = flatpak_remote_ref_get_remote_name(remote);
+    const auto arch = flatpak_get_default_arch();
+    gboolean changed{false};
+    flatpak_installation_update_appstream_sync(installation,remote_name,arch,&changed,nullptr,&error);
+    if (error) {
+      spdlog::error("[FlatpakPlugin] Can't update AppStream repo for {}",remote_name);
+      g_clear_error(&error);
+      continue;
+    }
+    if (changed) {
+      spdlog::debug("[FlatpakPlugin] AppStream Updated for {}",remote_name);
+    }
+  }
+  g_ptr_array_unref(remotes);
+  g_object_unref(installation);
+  spdlog::debug("[FlatpakPlugin] Background AppStream sync finished.");
+
+}
+
 void FlatpakShim::format_time_iso8601(const time_t raw_time,
                                       char* buffer,
                                       const size_t buffer_size) {

--- a/plugins/flatpak/flatpak_shim.cc
+++ b/plugins/flatpak/flatpak_shim.cc
@@ -222,45 +222,54 @@ std::time_t FlatpakShim::get_appstream_timestamp(
     return std::time(nullptr);
   }
 }
-
 void FlatpakShim::update_appstream() {
-
   GError* error = nullptr;
+
   auto installation = flatpak_installation_new_user(nullptr, &error);
-  if (error) {
+  if (!installation) {
     spdlog::error("[FlatpakPlugin] Failed to get user installation: {}",
                   error->message);
     g_clear_error(&error);
-    return ;
+    return;
   }
+
   auto remotes = get_remotes(installation);
   if (!remotes) {
     spdlog::error("[FlatpakPlugin] Failed to fetch any remotes");
-    g_clear_error(&error);
     g_object_unref(installation);
     return;
   }
+
+  const auto arch = flatpak_get_default_arch();
+
   for (guint i = 0; i < remotes->len; i++) {
     const auto remote =
-        static_cast<FlatpakRemoteRef*>(g_ptr_array_index(remotes, i));
+        static_cast<FlatpakRemote*>(g_ptr_array_index(remotes, i));
 
-    const auto remote_name = flatpak_remote_ref_get_remote_name(remote);
-    const auto arch = flatpak_get_default_arch();
-    gboolean changed{false};
-    flatpak_installation_update_appstream_sync(installation,remote_name,arch,&changed,nullptr,&error);
+    if (flatpak_remote_get_disabled(remote))
+      continue;
+
+    const auto remote_name = flatpak_remote_get_name(remote);
+    gboolean changed = FALSE;
+
+    flatpak_installation_update_appstream_sync(installation, remote_name, arch,
+                                               &changed, nullptr, &error);
+
     if (error) {
-      spdlog::error("[FlatpakPlugin] Can't update AppStream repo for {}",remote_name);
+      spdlog::error("[FlatpakPlugin] Can't update AppStream for {}",
+                    remote_name);
       g_clear_error(&error);
       continue;
     }
+
     if (changed) {
-      spdlog::debug("[FlatpakPlugin] AppStream Updated for {}",remote_name);
+      spdlog::debug("[FlatpakPlugin] AppStream updated for {}", remote_name);
     }
   }
+
   g_ptr_array_unref(remotes);
   g_object_unref(installation);
   spdlog::debug("[FlatpakPlugin] Background AppStream sync finished.");
-
 }
 
 void FlatpakShim::format_time_iso8601(const time_t raw_time,

--- a/plugins/flatpak/flatpak_shim.h
+++ b/plugins/flatpak/flatpak_shim.h
@@ -114,6 +114,11 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
       const std::filesystem::path& timestamp_filepath);
 
   /**
+   * \brief Updates the AppStream repo for all remotes.
+   */
+  void update_appstream();
+
+  /**
    * \brief Formats a time value into an ISO 8601 string.
    * \param raw_time The raw time value to format.
    * \param buffer The buffer to store the formatted string.

--- a/plugins/flatpak/flatpak_shim.h
+++ b/plugins/flatpak/flatpak_shim.h
@@ -116,7 +116,7 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
   /**
    * \brief Updates the AppStream repo for all remotes.
    */
-  void update_appstream();
+  static void update_appstream();
 
   /**
    * \brief Formats a time value into an ISO 8601 string.

--- a/plugins/flatpak/test/test_flatpak.cc
+++ b/plugins/flatpak/test/test_flatpak.cc
@@ -749,37 +749,3 @@ TEST_F(FlatpakPluginTest, ApplicationUpdateTest) {
     io_thread.join();
   }
 }
-
-TEST_F(FlatpakPluginTest,UpdateAppStreamTest) {
-  auto io_context = std::make_shared<asio::io_context>();
-  auto work_guard = asio::make_work_guard(*io_context);
-  auto strand = std::make_shared<asio::io_context::strand>(*io_context);
-
-  std::thread io_thread([io_context]() { io_context->run(); });
-
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
-  struct PromiseGuard {
-    std::shared_ptr<std::promise<ErrorOr<bool>>> promise;
-    std::once_flag flag;
-
-    void set_value(ErrorOr<bool> value) {
-      std::call_once(flag, [this, value = std::move(value)]() mutable {
-        try {
-          promise->set_value(std::move(value));
-        } catch (...) {
-        }
-      });
-    }
-  };
-
-  auto guard = std::make_shared<PromiseGuard>();
-  guard->promise = std::make_shared<std::promise<ErrorOr<bool>>>();
-  auto future = guard->promise->get_future();
-
-  auto messenger = GetTestMessenger();
-
-  auto shim = std::make_shared<FlatpakShim>(nullptr, messenger, strand.get());
-
-  shim->update_appstream();
-}

--- a/plugins/flatpak/test/test_flatpak.cc
+++ b/plugins/flatpak/test/test_flatpak.cc
@@ -749,3 +749,37 @@ TEST_F(FlatpakPluginTest, ApplicationUpdateTest) {
     io_thread.join();
   }
 }
+
+TEST_F(FlatpakPluginTest,UpdateAppStreamTest) {
+  auto io_context = std::make_shared<asio::io_context>();
+  auto work_guard = asio::make_work_guard(*io_context);
+  auto strand = std::make_shared<asio::io_context::strand>(*io_context);
+
+  std::thread io_thread([io_context]() { io_context->run(); });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  struct PromiseGuard {
+    std::shared_ptr<std::promise<ErrorOr<bool>>> promise;
+    std::once_flag flag;
+
+    void set_value(ErrorOr<bool> value) {
+      std::call_once(flag, [this, value = std::move(value)]() mutable {
+        try {
+          promise->set_value(std::move(value));
+        } catch (...) {
+        }
+      });
+    }
+  };
+
+  auto guard = std::make_shared<PromiseGuard>();
+  guard->promise = std::make_shared<std::promise<ErrorOr<bool>>>();
+  auto future = guard->promise->get_future();
+
+  auto messenger = GetTestMessenger();
+
+  auto shim = std::make_shared<FlatpakShim>(nullptr, messenger, strand.get());
+
+  shim->update_appstream();
+}


### PR DESCRIPTION
This PR addresses issue #219 by adding background appstream updates while starting the flatpak plugin, which updates all available remotes. 