### PR TITLE
feat(flatpak) :add a fresh permissions storage for installations

### DIFF
--- a/plugins/flatpak/CMakeLists.txt
+++ b/plugins/flatpak/CMakeLists.txt
@@ -30,8 +30,8 @@ add_library(plugin_flatpak STATIC
         screenshot.cc
         portals/portal_manager.cc
         portals/portal_proxy.cc
-        portals/access_portal/access_portal.cc
-        portals/access_portal/access_portal.h
+        portals/permissions_portal/permissions_portal.cc
+        portals/permissions_portal/permissions_portal.h
         operation_tracker.cc
         operation_tracker.h
 )

--- a/plugins/flatpak/flatpak_shim.cc
+++ b/plugins/flatpak/flatpak_shim.cc
@@ -1383,6 +1383,7 @@ void FlatpakShim::ApplicationUninstall(
     g_clear_error(&error);
     callback(ErrorOr<bool>(
         FlutterError("UNINSTALL_ERROR", "Failed to get user installation")));
+    return;
   }
 
   auto refs =
@@ -1394,6 +1395,7 @@ void FlatpakShim::ApplicationUninstall(
     g_object_unref(installation);
     callback(ErrorOr<bool>(
         FlutterError("UNINSTALL_ERROR", "Failed to get installed apps")));
+    return;
   }
 
   bool app_found = false;
@@ -1606,29 +1608,38 @@ void FlatpakShim::ApplicationUninstall(
 
     // Post result back to original strand
     asio::post(*strand_ptr, [self, callback, success, err_msg, id]() {
-      if (success) {
-        flutter::EncodableMap complete_event;
-        complete_event[flutter::EncodableValue("type")] =
-            flutter::EncodableValue("uninstall_complete");
-        complete_event[flutter::EncodableValue("message")] =
-            flutter::EncodableValue("Uninstallation completed successfully");
-        self->SendTransactionEvent(id, complete_event);
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
-        callback(ErrorOr<bool>(true));
-      } else {
+      if (!success) {
         flutter::EncodableMap failed_event;
         failed_event[flutter::EncodableValue("type")] =
             flutter::EncodableValue("uninstall_failed");
         failed_event[flutter::EncodableValue("error")] =
             flutter::EncodableValue("Uninstall failed: " + err_msg);
         self->SendTransactionEvent(id, failed_event);
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
+        self->RemoveTransactionEvent(id);
         callback(ErrorOr<bool>(
             FlutterError("UNINSTALL_FAILED", "Uninstall failed: " + err_msg)));
+        return;
       }
-      self->RemoveTransactionEvent(id);
+
+      self->permissions_portal_->RemoveAllAppPermissions(id, [self, callback,
+                                                              id](bool ok) {
+        if (!ok) {
+          // Uninstall succeeded but permissions cleanup failed
+          spdlog::warn(
+              "[FlatpakPlugin] Permissions cleanup failed for {}, "
+              "app was uninstalled successfully",
+              id);
+        }
+
+        flutter::EncodableMap complete_event;
+        complete_event[flutter::EncodableValue("type")] =
+            flutter::EncodableValue("uninstall_complete");
+        complete_event[flutter::EncodableValue("message")] =
+            flutter::EncodableValue("Uninstallation completed successfully");
+        self->SendTransactionEvent(id, complete_event);
+        self->RemoveTransactionEvent(id);
+        callback(ErrorOr<bool>(true));
+      });
     });
   }).detach();
 }
@@ -3871,7 +3882,7 @@ void FlatpakShim::SetupAccessEventChannel(
               return nullptr;
             }));
 
-    access_portal_ = std::make_unique<AccessPortal>(strand.context());
+    permissions_portal_ = std::make_unique<PermissionsPortal>(strand.context());
     spdlog::info("[FlatpakPlugin] Access portal created and initialized");
   } catch (const std::exception& e) {
     spdlog::error("[FlatpakPlugin] Exception setting up event channel: {}",
@@ -4405,7 +4416,7 @@ void FlatpakShim::CheckExistingPermissions(
     return;
   }
 
-  access_portal_->CheckAllPermissions(
+  permissions_portal_->CheckAllPermissions(
       app_id, permissions,
       [callback](const std::map<std::string, flatpak_plugin::PermissionStatus>&
                      statuses) {
@@ -4539,7 +4550,7 @@ void FlatpakShim::HandlePermissionResponse(const std::string& request_id,
   }
 
   if (!app_id.empty()) {
-    access_portal_->SetPermission(
+    permissions_portal_->SetPermission(
         table, permission, app_id, {granted ? "yes" : "no"},
         [weak_self = weak_from_this(), request_id, permission,
          granted](bool success) {
@@ -4564,7 +4575,7 @@ void FlatpakShim::RequestAppLaunchPermission(
     const std::string& app_id,
     FlatpakInstalledRef* installed_ref,
     const std::function<void(const std::map<std::string, bool>&)>& callback) {
-  if (!access_portal_) {
+  if (!permissions_portal_) {
     spdlog::error("[FlatpakPlugin] Access portal not initialized");
     callback({});
     return;

--- a/plugins/flatpak/flatpak_shim.cc
+++ b/plugins/flatpak/flatpak_shim.cc
@@ -218,7 +218,7 @@ std::time_t FlatpakShim::get_appstream_timestamp(
     return std::chrono::system_clock::to_time_t(sctp);
   } catch (const std::exception& e) {
     spdlog::error("[FlatpakPlugin] Failed to get timestamp for {}: {}",
-                 timestamp_filepath.string(), e.what());
+                  timestamp_filepath.string(), e.what());
     return std::time(nullptr);
   }
 }
@@ -801,7 +801,7 @@ ErrorOr<bool> FlatpakShim::RemoteAdd(const Remote& configuration) {
         installation, configuration.name().c_str(), nullptr, nullptr);
     if (existing_remote) {
       spdlog::error("[FlatpakPlugin] Remote '{}' already exists",
-                   configuration.name());
+                    configuration.name());
       g_object_unref(installation);
       g_object_unref(existing_remote);
       return ErrorOr<bool>(

--- a/plugins/flatpak/flatpak_shim.h
+++ b/plugins/flatpak/flatpak_shim.h
@@ -35,7 +35,7 @@
 #include "messages.g.h"
 #include "operation_tracker.h"
 #include "plugins/flatpak/portals/portal_manager.h"
-#include "portals/access_portal/access_portal.h"
+#include "portals/permissions_portal/permissions_portal.h"
 
 namespace flatpak_plugin {
 class FlatpakPlugin;
@@ -59,6 +59,9 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
             this->SendTransactionEvent(
                 "operation_tracker", const_cast<flutter::EncodableMap&>(event));
           });
+
+      permissions_portal_ =
+          std::make_unique<PermissionsPortal>(strand->context());
     }
   }
 
@@ -492,7 +495,7 @@ struct FlatpakShim : std::enable_shared_from_this<FlatpakShim> {
   mutable std::mutex event_sink_mutex_;
 
   // Event channel for streaming permissions access to the flutter widget
-  std::unique_ptr<AccessPortal> access_portal_;
+  std::unique_ptr<PermissionsPortal> permissions_portal_;
   std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>
       access_event_channel_;
   std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> access_sink_;

--- a/plugins/flatpak/portals/permissions_portal/permissions_portal.cc
+++ b/plugins/flatpak/portals/permissions_portal/permissions_portal.cc
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "access_portal.h"
+#include "permissions_portal.h"
 
 #include <iomanip>
 #include "asio/post.hpp"
@@ -24,11 +24,11 @@
 
 namespace flatpak_plugin {
 
-AccessPortal::AccessPortal(asio::io_context& io_context)
+PermissionsPortal::PermissionsPortal(asio::io_context& io_context)
     : io_context_(io_context),
       session_bus_(plugin_common_sdbus::SessionDBus::Instance()) {}
 
-void AccessPortal::CheckAllPermissions(
+void PermissionsPortal::CheckAllPermissions(
     const std::string& app,
     const std::vector<std::string>& permissions,
     const std::function<void(std::map<std::string, PermissionStatus>)>&
@@ -76,7 +76,7 @@ void AccessPortal::CheckAllPermissions(
   }
 }
 
-void AccessPortal::GetPermission(
+void PermissionsPortal::GetPermission(
     const std::string& table,
     const std::string& id,
     const std::string& app,
@@ -148,7 +148,7 @@ void AccessPortal::GetPermission(
   }
 }
 
-void AccessPortal::SetPermission(
+void PermissionsPortal::SetPermission(
     const std::string& table,
     const std::string& id,
     const std::string& app,
@@ -194,7 +194,7 @@ void AccessPortal::SetPermission(
   }
 }
 
-void AccessPortal::DeletePermission(
+void PermissionsPortal::DeletePermission(
     const std::string& table,
     const std::string& id,
     const std::string& app,
@@ -219,11 +219,18 @@ void AccessPortal::DeletePermission(
                  error) {  // NOLINT(performance-unnecessary-value-param)
               asio::post(io_context_, [callback, error]() {
                 if (error) {
+                  const auto& msg = error->getMessage();
+                  if (msg.find("No entry") != std::string::npos ||
+                      msg.find("not found") != std::string::npos) {
+                    spdlog::debug(
+                        "[AccessPortal] DeletePermission: no entry, skipping");
+                    callback(true);
+                    return;
+                  }
                   spdlog::error("[AccessPortal] DeletePermission failed: {}",
-                                error->getMessage());
+                                msg);
                   callback(false);
                 } else {
-                  spdlog::debug("DeletePermission successful");
                   callback(true);
                 }
               });
@@ -234,7 +241,7 @@ void AccessPortal::DeletePermission(
   }
 }
 
-void AccessPortal::SetResource(
+void PermissionsPortal::SetResource(
     const std::string& table,
     const std::string& id,
     const std::map<std::string, std::vector<std::string>>& permissions,
@@ -278,7 +285,7 @@ void AccessPortal::SetResource(
   }
 }
 
-void AccessPortal::DeleteResource(
+void PermissionsPortal::DeleteResource(
     const std::string& table,
     const std::string& id,
     const std::function<void(bool ready)>& callback) const {
@@ -315,7 +322,7 @@ void AccessPortal::DeleteResource(
     callback(false);
   }
 }
-void AccessPortal::GetAllResource(
+void PermissionsPortal::GetAllResource(
     const std::string& table,
     const std::function<void(bool success, std::vector<std::string> resources)>&
         callback) const {
@@ -357,7 +364,7 @@ void AccessPortal::GetAllResource(
   }
 }
 
-void AccessPortal::GetAllPermissions(
+void PermissionsPortal::GetAllPermissions(
     const std::string& table,
     const std::string& id,
     const std::string& app,
@@ -422,7 +429,56 @@ void AccessPortal::GetAllPermissions(
   }
 }
 
-void AccessPortal::StoreTimestamp(
+void PermissionsPortal::RemoveAllAppPermissions(
+    const std::string& app,
+    const std::function<void(bool ready)>& callback) {
+  struct TableEntry {
+    std::string table;
+    std::string resource_id;
+  };
+
+  auto fixed_entries =
+      std::make_shared<std::vector<TableEntry>>(std::vector<TableEntry>{
+          {"notifications", "notifications"},
+          {"location", "location"},
+          {"background", app},  // resource_id == app for background
+      });
+
+  GetAllResource("devices", [this, app, fixed_entries, callback](
+                                bool ready,
+                                std::vector<std::string> resources) {
+    auto table_entries =
+        std::make_shared<std::vector<TableEntry>>(*fixed_entries);
+    for (const auto& entry : resources) {
+      table_entries->push_back({"devices", entry});
+    }
+
+    auto total = std::make_shared<int>(table_entries->size());
+    auto counter = std::make_shared<std::atomic<int>>(0);
+    auto any_error = std::make_shared<bool>(false);
+
+    if (table_entries->empty()) {
+      callback(true);
+      return;
+    }
+
+    for (const auto& entry : *table_entries) {
+      DeletePermission(
+          entry.table, entry.resource_id, app,
+          [counter, total, any_error, callback](bool ok) {
+            if (!ok) {
+              *any_error = true;
+            }
+            int current = counter->fetch_add(1, std::memory_order_relaxed) + 1;
+            if (current == *total) {
+              callback(!*any_error);
+            }
+          });
+    }
+  });
+}
+
+void PermissionsPortal::StoreTimestamp(
     const std::string& table,
     const std::string& id,
     const std::string& data,

--- a/plugins/flatpak/portals/permissions_portal/permissions_portal.cc
+++ b/plugins/flatpak/portals/permissions_portal/permissions_portal.cc
@@ -431,7 +431,7 @@ void PermissionsPortal::GetAllPermissions(
 
 void PermissionsPortal::RemoveAllAppPermissions(
     const std::string& app,
-    const std::function<void(bool ready)>& callback) {
+    const std::function<void(bool ready)>& callback) const {
   struct TableEntry {
     std::string table;
     std::string resource_id;
@@ -445,8 +445,8 @@ void PermissionsPortal::RemoveAllAppPermissions(
       });
 
   GetAllResource("devices", [this, app, fixed_entries, callback](
-                                bool ready,
-                                std::vector<std::string> resources) {
+                                bool /*ready*/,
+                                const std::vector<std::string>& resources) {
     auto table_entries =
         std::make_shared<std::vector<TableEntry>>(*fixed_entries);
     for (const auto& entry : resources) {

--- a/plugins/flatpak/portals/permissions_portal/permissions_portal.h
+++ b/plugins/flatpak/portals/permissions_portal/permissions_portal.h
@@ -33,11 +33,11 @@ enum PermissionStatus {
   NOT_SET   // No entry exists
 };
 
-class AccessPortal {
+class PermissionsPortal {
  public:
-  explicit AccessPortal(asio::io_context& io_context);
+  explicit PermissionsPortal(asio::io_context& io_context);
 
-  ~AccessPortal() = default;
+  ~PermissionsPortal() = default;
 
   /**
    * \brief Check all permissions for app to launch.
@@ -142,6 +142,14 @@ class AccessPortal {
       const std::function<void(bool success,
                                std::vector<std::string> resources)>& callback)
       const;
+
+  /**
+   * \brief Removes all app permissions from all tables and resources.
+   * \param app Application that needs to uninstall an removes it's resources.
+   * \param callback Callback function for async operations.
+   */
+  void RemoveAllAppPermissions(const std::string& app,
+                               const std::function<void(bool ready)>& callback);
 
   /**
    * \brief Storing timestamps of when a resource was last accessed.

--- a/plugins/flatpak/portals/permissions_portal/permissions_portal.h
+++ b/plugins/flatpak/portals/permissions_portal/permissions_portal.h
@@ -145,11 +145,12 @@ class PermissionsPortal {
 
   /**
    * \brief Removes all app permissions from all tables and resources.
-   * \param app Application that needs to uninstall an removes it's resources.
+   * \param app Application that needs to uninstall and removes it's resources.
    * \param callback Callback function for async operations.
    */
-  void RemoveAllAppPermissions(const std::string& app,
-                               const std::function<void(bool ready)>& callback);
+  void RemoveAllAppPermissions(
+      const std::string& app,
+      const std::function<void(bool ready)>& callback) const;
 
   /**
    * \brief Storing timestamps of when a resource was last accessed.


### PR DESCRIPTION
This PR addresses issue #222. When the app is uninstalled, it removes all stored permissions, giving the app a fresh start after reinstalling.