### PR TITLE
feat/fix: CI specify homescreen/plugins refs for builds

### DIFF
--- a/.github/actions/homescreen-build/action.yml
+++ b/.github/actions/homescreen-build/action.yml
@@ -5,6 +5,14 @@ inputs:
   name:
     description: "The name of the plugin to build"
     required: true
+  homescreen-ref:
+    description: "The git ref of ivi-homescreen to build against (branch, tag, or commit)"
+    required: false
+    default: "v2.0"
+  plugins-ref:
+    description: "The git ref of ivi-homescreen-plugins to build against (branch, tag, or commit). Ignored if building from the ivi-homescreen-plugins repo."
+    required: false
+    default: "v2.0"
   libcamera-enable:
     description: "Whether to enable libcamera support"
     required: false
@@ -30,7 +38,7 @@ runs:
     with:
       repository: toyota-connected/ivi-homescreen
       path: ivi-homescreen
-      ref: v2.0
+      ref: ${{ inputs.homescreen-ref }}
       fetch-depth: 1
       submodules: true
       persist-credentials: false
@@ -40,7 +48,7 @@ runs:
     with:
       repository: toyota-connected/ivi-homescreen-plugins
       path: ivi-homescreen-plugins
-      ref: v2.0
+      ref: ${{ inputs.plugins-ref }}
       fetch-depth: 1
       submodules: true
       persist-credentials: false

--- a/.github/workflows/_plugin_cpp-ci.yaml
+++ b/.github/workflows/_plugin_cpp-ci.yaml
@@ -41,6 +41,7 @@ jobs:
         uses: ./plugins_source/.github/actions/homescreen-build
         with:
           name: ${{ inputs.name }}
+          plugins-ref: ${{ github.sha }}
           clang-version: ${{ inputs.clang-version }}
           libcamera-enable: ${{ inputs.libcamera-enable }}
           libcamera-version: ${{ inputs.libcamera-version }}
@@ -112,6 +113,7 @@ jobs:
         uses: ./plugins_source/.github/actions/homescreen-build
         with:
           name: ${{ inputs.name }}
+          plugins-ref: ${{ github.sha }}
           clang-version: ${{ inputs.clang-version }}
           libcamera-enable: ${{ inputs.libcamera-enable }}
           libcamera-version: ${{ inputs.libcamera-version }}
@@ -172,6 +174,7 @@ jobs:
         uses: ./plugins_source/.github/actions/homescreen-build
         with:
           name: ${{ inputs.name }}
+          plugins-ref: ${{ github.sha }}
           clang-version: ${{ inputs.clang-version }}
           libcamera-enable: ${{ inputs.libcamera-enable }}
           libcamera-version: ${{ inputs.libcamera-version }}
@@ -235,6 +238,7 @@ jobs:
         uses: ./plugins_source/.github/actions/homescreen-build
         with:
           name: ${{ inputs.name }}
+          plugins-ref: ${{ github.sha }}
           clang-version: ${{ inputs.clang-version }}
           libcamera-enable: ${{ inputs.libcamera-enable }}
           libcamera-version: ${{ inputs.libcamera-version }}


### PR DESCRIPTION
✨ Solves two problems:

- The `homescreen-build` action now allows to specify which git ref of `ivi-homescreen` you want to build against (default: `v2.0`)
- ^ similar for `ivi-homescreen-plugin` + now it defaults to "current ref" for build config instead of always building against `v2.0`
  - proper CQ checks 🧹 
  - better caching 📦 