### PR TITLE
[video_player_linux] replace FFmpeg probing with GstDiscoverer, let playbin auto-plug decoders

### DIFF
--- a/plugins/video_player_linux/CMakeLists.txt
+++ b/plugins/video_player_linux/CMakeLists.txt
@@ -31,7 +31,7 @@ target_compile_features(${PLUGIN_NAME} PRIVATE cxx_std_17)
 
 # System-level dependencies.
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(GST IMPORTED_TARGET REQUIRED gstreamer-1.0>=1.4 gstreamer-video-1.0 libavformat libavutil)
+pkg_check_modules(GST IMPORTED_TARGET REQUIRED gstreamer-1.0>=1.4 gstreamer-video-1.0 gstreamer-pbutils-1.0)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)

--- a/plugins/video_player_linux/nv12.h
+++ b/plugins/video_player_linux/nv12.h
@@ -64,8 +64,8 @@ class Shader {
   GLuint framebuffer{};
   GLuint backTextureId{};
   GLuint backFramebuffer{};
-  GLuint program;
-  GLsizei width, height;
+  GLuint program{};
+  GLsizei width{}, height{};
   GLuint vertex_arr_id_{};
 
   Shader(GLsizei _width, GLsizei _height) : width(_width), height(_height) {
@@ -132,22 +132,6 @@ class Shader {
     }
 
     glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
-
-    auto size = static_cast<unsigned long>(width) *
-                static_cast<unsigned long>(height) * 3;
-    auto pixels = new unsigned char[size]{0};
-    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, static_cast<GLsizei>(width),
-                 static_cast<GLsizei>(height), 0, GL_RGB, GL_UNSIGNED_BYTE,
-                 pixels);
-    delete[] pixels;
-
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
-                    GL_LINEAR_MIPMAP_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glGenerateMipmap(GL_TEXTURE_2D);
 
     glGenBuffers(1, &vertex_buffer_);
     glBindBuffer(GL_ARRAY_BUFFER, vertex_buffer_);

--- a/plugins/video_player_linux/video_player.cc
+++ b/plugins/video_player_linux/video_player.cc
@@ -22,10 +22,6 @@
 #include <flutter/plugin_registrar_homescreen.h>
 #include <flutter/standard_method_codec.h>
 
-extern "C" {
-#include <libavutil/avutil.h>
-}
-
 #include <backend/backend.h>
 #include <plugins/common/common.h>
 #include <utility>
@@ -49,16 +45,13 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrarDesktop* registrar,
                          std::map<std::string, std::string> http_headers,
                          const GLsizei width,
                          const GLsizei height,
-                         const gint64 duration,
-                         GstElementFactory* decoder_factory)
+                         const gint64 duration)
     : m_registrar(registrar),
       uri_(std::move(uri)),
       http_headers_(std::move(http_headers)),
       width_(width),
       height_(height),
       duration_(duration),
-      decoder_factory_(decoder_factory),
-      media_state_(GST_STATE_VOID_PENDING),
       event_channel_(nullptr) {
   SPDLOG_DEBUG(
       "[VideoPlayer] uri: {}, http_headers: {}, size: {} x {}, duration: {}",
@@ -148,12 +141,6 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrarDesktop* registrar,
   handoff_handler_id_ = g_signal_connect(
       sink_, "handoff", reinterpret_cast<GCallback>(handoff_handler), this);
 
-  decoder_ = gst_element_factory_create(decoder_factory, "decoder");
-  if (!decoder_) {
-    SPDLOG_ERROR("[VideoPlayer] Failed to create decoder element");
-    return;
-  }
-
   video_convert_ = gst_element_factory_make("videoconvert", nullptr);
   if (!video_convert_) {
     SPDLOG_ERROR("[VideoPlayer] Failed to create videoconvert element");
@@ -175,38 +162,25 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrarDesktop* registrar,
 
   pipeline_ = gst_bin_new(nullptr);
 
-  gst_bin_add_many(reinterpret_cast<GstBin*>(pipeline_), decoder_,
-                   video_convert_, video_scale_, sink_, nullptr);
-  if (!gst_element_link(decoder_, video_convert_)) {
-    SPDLOG_ERROR("[VideoPlayer] Failed to link decoder with videoconvert");
-  }
+  gst_bin_add_many(GST_BIN(pipeline_), video_convert_, video_scale_, sink_,
+                   nullptr);
 
   if (!gst_element_link_filtered(video_convert_, video_scale_, caps)) {
-    SPDLOG_ERROR(
-        "[VideoPlayer] Failed to link videoconvert with videoscale using "
-        "filter");
+    SPDLOG_ERROR("[VideoPlayer] Failed to link videoconvert with videoscale");
   }
-
   gst_caps_unref(caps);
 
-  GstPad* pad = gst_element_get_static_pad(decoder_, "sink");
-  if (gst_pad_is_linked(pad)) {
-    SPDLOG_ERROR("[VideoPlayer] already linked, ignore");
-    gst_object_unref(pad);
-    gst_caps_unref(scale);
-    m_valid = false;
-    return;
+  if (!gst_element_link_filtered(video_scale_, sink_, scale)) {
+    SPDLOG_ERROR("[VideoPlayer] Failed to link videoscale with fakesink");
   }
+  gst_caps_unref(scale);
+
+  // Ghost pad so playbin can link its decoded output into this bin
+  GstPad* pad = gst_element_get_static_pad(video_convert_, "sink");
   GstPad* ghost_pad = gst_ghost_pad_new("sink", pad);
   gst_pad_set_active(ghost_pad, TRUE);
   gst_element_add_pad(pipeline_, ghost_pad);
   gst_object_unref(pad);
-
-  if (!gst_element_link_filtered(video_scale_, sink_, scale)) {
-    SPDLOG_ERROR(
-        "[VideoPlayer] Failed to link videoscale with fakesink using filter");
-  }
-  gst_caps_unref(scale);
 
   g_object_set(playbin_, "video-sink", pipeline_, nullptr);
 
@@ -223,6 +197,291 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrarDesktop* registrar,
   g_source_unref(bus_source);
   on_bus_msg_id_ = g_signal_connect(
       bus_, "message", reinterpret_cast<GCallback>(OnBusMessage), this);
+}
+
+VideoPlayer::~VideoPlayer() {
+  if (m_valid) {
+    Dispose();
+  }
+}
+
+void VideoPlayer::Dispose() {
+  SPDLOG_DEBUG("[VideoPlayer] Dispose");
+  m_valid = false;
+  is_initialized_ = false;
+
+  std::lock_guard buffer_lock(buffer_mutex_);
+
+  g_signal_handler_disconnect(G_OBJECT(bus_), on_bus_msg_id_);
+  g_signal_handler_disconnect(G_OBJECT(sink_), handoff_handler_id_);
+
+  gst_element_set_state(playbin_, GST_STATE_NULL);
+
+  {
+    // Ensure no in-flight handoff callback is using the shader
+    std::lock_guard gst_lock(gst_mutex_);
+    std::lock_guard ctx_lock(g_texture_context_mutex);
+    m_registrar->texture_registrar()->TextureMakeCurrent();
+    shader_.reset();
+    m_registrar->texture_registrar()->TextureClearCurrent();
+  }
+
+  SPDLOG_DEBUG("[VideoPlayer] Unregistering texture_id={}", m_texture_id);
+  m_registrar->texture_registrar()->UnregisterTexture(m_texture_id);
+
+  m_texture_id = 0;
+  {
+    std::lock_guard event_lock(event_mutex_);
+    event_sink_ = nullptr;
+  }
+  event_channel_ = nullptr;
+}
+
+void VideoPlayer::SetLooping(const bool isLooping) {
+  SPDLOG_DEBUG("[VideoPlayer] SetLooping: {}", is_looping_.load());
+  is_looping_ = isLooping;
+}
+
+void VideoPlayer::SetVolume(const double volume) {
+  SPDLOG_DEBUG("[VideoPlayer] SetVolume: {}", volume);
+  volume_ = volume;
+  g_object_set(playbin_, "volume", volume, nullptr);
+}
+
+void VideoPlayer::SetPlaybackSpeed(const double playbackSpeed) {
+  // Store the desired rate so it can be applied when the pipeline is ready
+  pending_rate_ = playbackSpeed;
+
+  // Seek events require the pipeline to be in PAUSED or PLAYING state
+  GstState state;
+  gst_element_get_state(playbin_, &state, nullptr, 0);
+  if (state < GST_STATE_PAUSED) {
+    SPDLOG_DEBUG(
+        "[VideoPlayer] Deferring playback speed {} until pipeline is ready",
+        playbackSpeed);
+    return;
+  }
+
+  ApplyPlaybackSpeed();
+}
+
+void VideoPlayer::Play() {
+  target_state_ = GST_STATE_PLAYING;
+  const GstStateChangeReturn ret =
+      gst_element_set_state(playbin_, GST_STATE_PLAYING);
+  if (ret == GST_STATE_CHANGE_FAILURE) {
+    spdlog::error("[VideoPlayer] Failed to set state GST_STATE_PLAYING.");
+  } else if (ret == GST_STATE_CHANGE_NO_PREROLL) {
+    is_live_ = TRUE;
+    SPDLOG_DEBUG("[VideoPlayer] Pipeline is live");
+  }
+}
+
+void VideoPlayer::Pause() {
+  GstState state;
+  gst_element_get_state(playbin_, &state, nullptr, GST_SECOND);
+  if (state != GST_STATE_NULL) {
+    target_state_ = GST_STATE_PAUSED;
+    const GstStateChangeReturn ret =
+        gst_element_set_state(playbin_, GST_STATE_PAUSED);
+    if (ret == GST_STATE_CHANGE_FAILURE) {
+      std::lock_guard event_lock(event_mutex_);
+      if (event_sink_) {
+        event_sink_->Error("[VideoPlayer] Unable to Pause Transport.");
+      }
+      return;
+    }
+    SPDLOG_DEBUG("[VideoPlayer] Transport Paused.");
+  }
+}
+
+int64_t VideoPlayer::GetPosition() {
+  gint64 pos;
+  if (gst_element_query_position(playbin_, GST_FORMAT_TIME, &pos)) {
+    position_ = pos;
+    SPDLOG_TRACE("[VideoPlayer] Position: {}", pos);
+  }
+  const gint64 current = position_.load();
+  return current >= 0 ? current / GST_MSECOND : 0;
+}
+
+void VideoPlayer::SendBufferingUpdate() {
+  std::lock_guard event_lock(event_mutex_);
+  if (!event_sink_) {
+    return;
+  }
+  auto values = flutter::EncodableList();
+
+  GstQuery* query = gst_query_new_buffering(GST_FORMAT_TIME);
+  if (gst_element_query(playbin_, query)) {
+    const guint n_ranges = gst_query_get_n_buffering_ranges(query);
+    for (guint i = 0; i < n_ranges; i++) {
+      gint64 start, stop;
+      if (gst_query_parse_nth_buffering_range(query, i, &start, &stop)) {
+        values.emplace_back(
+            std::in_place_type<flutter::EncodableList>,
+            flutter::EncodableList{
+                flutter::EncodableValue(std::in_place_type<int64_t>,
+                                        start / GST_MSECOND),
+                flutter::EncodableValue(std::in_place_type<int64_t>,
+                                        stop / GST_MSECOND)});
+      }
+    }
+  }
+  gst_query_unref(query);
+
+  auto res = flutter::EncodableMap(
+      {{flutter::EncodableValue("event"),
+        flutter::EncodableValue("bufferingUpdate")},
+       {flutter::EncodableValue("values"),
+        flutter::EncodableValue(std::in_place_type<flutter::EncodableList>,
+                                std::move(values))}});
+  event_sink_->Success(flutter::EncodableValue(
+      std::in_place_type<flutter::EncodableMap>, std::move(res)));
+}
+
+void VideoPlayer::SeekTo(const int64_t seek) {
+  const gint64 position = seek * GST_MSECOND;
+  SPDLOG_DEBUG("[VideoPlayer] SeekTo: {} -> {}", seek, position);
+
+  if (!gst_element_seek_simple(
+          playbin_, GST_FORMAT_TIME,
+          static_cast<GstSeekFlags>(GST_SEEK_FLAG_FLUSH |
+                                    GST_SEEK_FLAG_KEY_UNIT),
+          position)) {
+    SPDLOG_ERROR("[VideoPlayer] Seek Failed");
+  }
+  gint64 pos;
+  gst_element_query_position(playbin_, GST_FORMAT_TIME, &pos);
+  position_ = pos;
+  SPDLOG_DEBUG("[VideoPlayer] SeekTo: {} -> {}", seek, pos);
+}
+
+bool VideoPlayer::IsValid() {
+  return m_valid;
+}
+
+void VideoPlayer::Init(flutter::BinaryMessenger* messenger) {
+  if (is_initialized_) {
+    return;
+  }
+
+  SPDLOG_DEBUG("[VideoPlayer] Init");
+  event_channel_ = std::make_unique<flutter::EventChannel<>>(
+      messenger,
+      std::string("flutter.io/videoPlayer/videoEvents") +
+          std::to_string(m_texture_id),
+      &flutter::StandardMethodCodec::GetInstance());
+
+  event_channel_->SetStreamHandler(
+      std::make_unique<flutter::StreamHandlerFunctions<>>(
+          [this](const flutter::EncodableValue* /* arguments */,
+                 std::unique_ptr<flutter::EventSink<>>&& events)
+              -> std::unique_ptr<flutter::StreamHandlerError<>> {
+            std::lock_guard event_lock(event_mutex_);
+            event_sink_ = std::move(events);
+            return nullptr;
+          },
+          [this](const flutter::EncodableValue* /* arguments */)
+              -> std::unique_ptr<flutter::StreamHandlerError<>> {
+            std::lock_guard event_lock(event_mutex_);
+            event_sink_ = nullptr;
+            return nullptr;
+          }));
+}
+
+void VideoPlayer::SetBuffering(const bool buffering) {
+  std::lock_guard event_lock(event_mutex_);
+  if (event_sink_) {
+    SPDLOG_DEBUG("[VideoPlayer] SetBuffering: {}", buffering);
+    auto res = flutter::EncodableMap(
+        {{flutter::EncodableValue("event"),
+          flutter::EncodableValue(buffering ? "bufferingStart"
+                                            : "bufferingEnd")}});
+    event_sink_->Success(flutter::EncodableValue(
+        std::in_place_type<flutter::EncodableMap>, std::move(res)));
+  }
+}
+
+void VideoPlayer::ApplyPlaybackSpeed() {
+  if (pending_rate_ == rate_) {
+    return;
+  }
+
+  const auto playbackSpeed = pending_rate_;
+  const gint64 pos = position_.load();
+  GstEvent* seek_event;
+  if (playbackSpeed > 0) {
+    // Forward playback: from current position to end
+    seek_event = gst_event_new_seek(
+        playbackSpeed, GST_FORMAT_TIME,
+        static_cast<GstSeekFlags>(GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE),
+        GST_SEEK_TYPE_SET, pos, GST_SEEK_TYPE_END, 0);
+  } else {
+    // Reverse playback: from beginning to current position
+    seek_event = gst_event_new_seek(
+        playbackSpeed, GST_FORMAT_TIME,
+        static_cast<GstSeekFlags>(GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE),
+        GST_SEEK_TYPE_SET, 0, GST_SEEK_TYPE_SET, pos);
+  }
+
+  // Send seek to playbin_ so the segment event propagates to all elements
+  // (including audio). Sending to sink_ alone causes "data flow before segment
+  // event" warnings on the audio path.
+  if (!gst_element_send_event(playbin_, seek_event)) {
+    SPDLOG_ERROR("[VideoPlayer] Failed to set playback speed: {}",
+                 playbackSpeed);
+    return;
+  }
+  rate_ = playbackSpeed;
+
+  SPDLOG_DEBUG("[VideoPlayer] Playback speed: {}", rate_);
+}
+
+void VideoPlayer::OnPlaybackEnded() {
+  if (is_looping_) {
+    SPDLOG_DEBUG("[VideoPlayer] Looping: seeking to start");
+    if (!gst_element_seek_simple(
+            playbin_, GST_FORMAT_TIME,
+            static_cast<GstSeekFlags>(GST_SEEK_FLAG_FLUSH |
+                                      GST_SEEK_FLAG_SEGMENT),
+            0)) {
+      SPDLOG_ERROR("[VideoPlayer] Loop seek failed");
+    }
+    return;
+  }
+  std::lock_guard event_lock(event_mutex_);
+  if (event_sink_) {
+    SPDLOG_DEBUG("[VideoPlayer] OnPlaybackEnded");
+    auto res = flutter::EncodableMap({{flutter::EncodableValue("event"),
+                                       flutter::EncodableValue("completed")}});
+    event_sink_->Success(flutter::EncodableValue(
+        std::in_place_type<flutter::EncodableMap>, std::move(res)));
+  }
+}
+
+void VideoPlayer::OnMediaInitialized() {}
+
+void VideoPlayer::OnMediaStateChange(const GstState state) {
+  if (state == GST_STATE_NULL) {
+    SetBuffering(true);
+    SendBufferingUpdate();
+  } else {
+    if (!is_initialized_) {
+      is_initialized_ = true;
+    }
+    SetBuffering(false);
+
+    if (state == GST_STATE_PLAYING) {
+      SPDLOG_DEBUG("[VideoPlayer] message state changed, start playing {}",
+                   m_texture_id);
+      prepare(this);
+      ApplyPlaybackSpeed();
+    } else if (state == GST_STATE_READY) {
+      SPDLOG_DEBUG("[VideoPlayer] message state changed, ready {}",
+                   m_texture_id);
+    }
+  }
 }
 
 void VideoPlayer::OnMediaError(GstMessage* msg) {
@@ -250,6 +509,115 @@ void VideoPlayer::OnMediaDurationChange() {
     gst_query_parse_duration(query, nullptr, &duration_);
   }
   gst_query_unref(query);
+}
+
+void VideoPlayer::SendInitialized() {
+  std::lock_guard event_lock(event_mutex_);
+  if (!event_sink_) {
+    return;
+  }
+  auto event = flutter::EncodableMap(
+      {{flutter::EncodableValue("event"),
+        flutter::EncodableValue("initialized")},
+       {flutter::EncodableValue("duration"),
+        flutter::EncodableValue(
+            std::in_place_type<int64_t>,
+            static_cast<int64_t>(duration_ / GST_MSECOND))}});
+
+  event.insert({flutter::EncodableValue("width"),
+                flutter::EncodableValue(std::in_place_type<int32_t>,
+                                        static_cast<int32_t>(width_))});
+  event.insert({flutter::EncodableValue("height"),
+                flutter::EncodableValue(std::in_place_type<int32_t>,
+                                        static_cast<int32_t>(height_))});
+
+  event_sink_->Success(flutter::EncodableValue(
+      std::in_place_type<flutter::EncodableMap>, std::move(event)));
+}
+
+void VideoPlayer::OnTag(const GstTagList* list,
+                        const gchar* tag,
+                        gpointer /* user_data */) {
+  const std::string tag_str = tag;
+  if (const auto type = gst_tag_get_type(tag);
+      tag_str == "audio-codec" && type == 64) {
+    gchar* value;
+    gst_tag_list_get_string(list, tag, &value);
+    spdlog::debug("[VideoPlayer] audio-codec: {}", value);
+  } else if (tag_str == "video-codec" && type == 64) {
+    gchar* value;
+    gst_tag_list_get_string(list, tag, &value);
+    spdlog::debug("[VideoPlayer] video-codec: {}", value);
+  } else if (tag_str == "maximum-bitrate" && type == 28) {
+    guint value;
+    gst_tag_list_get_uint(list, tag, &value);
+    spdlog::debug("[VideoPlayer] maximum-bitrate: {}", value);
+  } else if (tag_str == "minimum-bitrate" && type == 28) {
+    guint value;
+    gst_tag_list_get_uint(list, tag, &value);
+    spdlog::debug("[VideoPlayer] minimum-bitrate: {}", value);
+  } else if (tag_str == "bitrate" && type == 28) {
+    guint value;
+    gst_tag_list_get_uint(list, tag, &value);
+    spdlog::debug("[VideoPlayer] bitrate: {}", value);
+  }
+}
+
+void VideoPlayer::handoff_handler(GstElement* /* fakesink */,
+                                  GstBuffer* buffer,
+                                  GstPad* /* pad */,
+                                  void* user_data) {
+  const auto obj = static_cast<VideoPlayer*>(user_data);
+  if (!obj->m_valid || !obj->is_initialized_ || obj->info_.finfo == nullptr) {
+    return;
+  }
+
+  std::lock_guard lock(obj->gst_mutex_);
+  GstVideoFrame frame;
+  if (gst_video_frame_map(&frame, &obj->info_, buffer, GST_MAP_READ)) {
+    {
+      std::lock_guard ctx_lock(g_texture_context_mutex);
+      obj->m_registrar->texture_registrar()->TextureMakeCurrent();
+      glBindVertexArray(obj->shader_->vertex_arr_id_);
+
+      if (const guint n_planes = GST_VIDEO_INFO_N_PLANES(&obj->info_);
+          n_planes == 2) {
+        // Assume NV12
+        obj->shader_->load_pixels(GST_VIDEO_FRAME_PLANE_DATA(&frame, 0),
+                                  GST_VIDEO_FRAME_PLANE_DATA(&frame, 1),
+                                  GST_VIDEO_FRAME_COMP_PSTRIDE(&frame, 0),
+                                  GST_VIDEO_FRAME_PLANE_STRIDE(&frame, 0),
+                                  GST_VIDEO_FRAME_COMP_PSTRIDE(&frame, 1),
+                                  GST_VIDEO_FRAME_PLANE_STRIDE(&frame, 1));
+      } else {
+        // Assume RGB
+        obj->shader_->load_rgb_pixels(GST_VIDEO_FRAME_PLANE_DATA(&frame, 0));
+      }
+      gst_video_frame_unmap(&frame);
+
+      // Render NV12->RGBA into the back buffer
+      glBindFramebuffer(GL_FRAMEBUFFER, obj->shader_->backFramebuffer);
+      obj->shader_->draw_core();
+
+      // Blit back buffer to the front (Flutter-registered) texture
+      obj->shader_->blit_to_front();
+
+      obj->m_registrar->texture_registrar()->TextureClearCurrent();
+    }
+
+    // Send initialized event after first frame so the Dart Texture widget
+    // doesn't display stale GL content before real video arrives.
+    if (!obj->sent_initialized_) {
+      obj->sent_initialized_ = true;
+      obj->SendInitialized();
+    }
+
+    obj->m_registrar->texture_registrar()->MarkTextureFrameAvailable(
+        obj->m_texture_id);
+    SPDLOG_TRACE("[VideoPlayer] frame");
+  } else {
+    SPDLOG_ERROR("[VideoPlayer] Cannot read video frame out from buffer");
+  }
 }
 
 gboolean VideoPlayer::OnBusMessage(GstBus* bus,
@@ -426,397 +794,6 @@ gboolean VideoPlayer::OnBusMessage(GstBus* bus,
 #endif
   }
   return TRUE;
-}
-
-void VideoPlayer::OnTag(const GstTagList* list,
-                        const gchar* tag,
-                        gpointer /* user_data */) {
-  const std::string tag_str = tag;
-  if (const auto type = gst_tag_get_type(tag);
-      tag_str == "audio-codec" && type == 64) {
-    gchar* value;
-    gst_tag_list_get_string(list, tag, &value);
-    spdlog::debug("[VideoPlayer] audio-codec: {}", value);
-  } else if (tag_str == "video-codec" && type == 64) {
-    gchar* value;
-    gst_tag_list_get_string(list, tag, &value);
-    spdlog::debug("[VideoPlayer] video-codec: {}", value);
-  } else if (tag_str == "maximum-bitrate" && type == 28) {
-    guint value;
-    gst_tag_list_get_uint(list, tag, &value);
-    spdlog::debug("[VideoPlayer] maximum-bitrate: {}", value);
-  } else if (tag_str == "minimum-bitrate" && type == 28) {
-    guint value;
-    gst_tag_list_get_uint(list, tag, &value);
-    spdlog::debug("[VideoPlayer] minimum-bitrate: {}", value);
-  } else if (tag_str == "bitrate" && type == 28) {
-    guint value;
-    gst_tag_list_get_uint(list, tag, &value);
-    spdlog::debug("[VideoPlayer] bitrate: {}", value);
-  }
-}
-
-void VideoPlayer::handoff_handler(GstElement* /* fakesink */,
-                                  GstBuffer* buffer,
-                                  GstPad* /* pad */,
-                                  void* user_data) {
-  const auto obj = static_cast<VideoPlayer*>(user_data);
-  if (!obj->m_valid || !obj->is_initialized_ || obj->info_.finfo == nullptr) {
-    return;
-  }
-
-  std::lock_guard lock(obj->gst_mutex_);
-  GstVideoFrame frame;
-  if (gst_video_frame_map(&frame, &obj->info_, buffer, GST_MAP_READ)) {
-    {
-      std::lock_guard ctx_lock(g_texture_context_mutex);
-      obj->m_registrar->texture_registrar()->TextureMakeCurrent();
-      glBindVertexArray(obj->shader_->vertex_arr_id_);
-
-      if (const guint n_planes = GST_VIDEO_INFO_N_PLANES(&obj->info_);
-          n_planes == 2) {
-        // Assume NV12
-        obj->shader_->load_pixels(GST_VIDEO_FRAME_PLANE_DATA(&frame, 0),
-                                  GST_VIDEO_FRAME_PLANE_DATA(&frame, 1),
-                                  GST_VIDEO_FRAME_COMP_PSTRIDE(&frame, 0),
-                                  GST_VIDEO_FRAME_PLANE_STRIDE(&frame, 0),
-                                  GST_VIDEO_FRAME_COMP_PSTRIDE(&frame, 1),
-                                  GST_VIDEO_FRAME_PLANE_STRIDE(&frame, 1));
-      } else {
-        // Assume RGB
-        obj->shader_->load_rgb_pixels(GST_VIDEO_FRAME_PLANE_DATA(&frame, 0));
-      }
-      gst_video_frame_unmap(&frame);
-
-      // Render NV12->RGBA into the back buffer
-      glBindFramebuffer(GL_FRAMEBUFFER, obj->shader_->backFramebuffer);
-      obj->shader_->draw_core();
-
-      // Blit back buffer to the front (Flutter-registered) texture
-      obj->shader_->blit_to_front();
-
-      obj->m_registrar->texture_registrar()->TextureClearCurrent();
-    }
-
-    // Send initialized event after first frame so the Dart Texture widget
-    // doesn't display stale GL content before real video arrives.
-    if (!obj->sent_initialized_) {
-      obj->sent_initialized_ = true;
-      obj->SendInitialized();
-    }
-
-    obj->m_registrar->texture_registrar()->MarkTextureFrameAvailable(
-        obj->m_texture_id);
-    SPDLOG_TRACE("[VideoPlayer] frame");
-  } else {
-    SPDLOG_ERROR("[VideoPlayer] Cannot read video frame out from buffer");
-  }
-}
-
-void VideoPlayer::Init(flutter::BinaryMessenger* messenger) {
-  if (is_initialized_) {
-    return;
-  }
-
-  SPDLOG_DEBUG("[VideoPlayer] Init");
-  event_channel_ = std::make_unique<flutter::EventChannel<>>(
-      messenger,
-      std::string("flutter.io/videoPlayer/videoEvents") +
-          std::to_string(m_texture_id),
-      &flutter::StandardMethodCodec::GetInstance());
-
-  event_channel_->SetStreamHandler(
-      std::make_unique<flutter::StreamHandlerFunctions<>>(
-          [this](const flutter::EncodableValue* /* arguments */,
-                 std::unique_ptr<flutter::EventSink<>>&& events)
-              -> std::unique_ptr<flutter::StreamHandlerError<>> {
-            std::lock_guard event_lock(event_mutex_);
-            event_sink_ = std::move(events);
-            return nullptr;
-          },
-          [this](const flutter::EncodableValue* /* arguments */)
-              -> std::unique_ptr<flutter::StreamHandlerError<>> {
-            std::lock_guard event_lock(event_mutex_);
-            event_sink_ = nullptr;
-            return nullptr;
-          }));
-}
-
-VideoPlayer::~VideoPlayer() {
-  if (m_valid) {
-    Dispose();
-  }
-}
-
-bool VideoPlayer::IsValid() {
-  return m_valid;
-}
-
-void VideoPlayer::SendInitialized() {
-  std::lock_guard event_lock(event_mutex_);
-  if (!event_sink_) {
-    return;
-  }
-  auto event = flutter::EncodableMap(
-      {{flutter::EncodableValue("event"),
-        flutter::EncodableValue("initialized")},
-       {flutter::EncodableValue("duration"),
-        flutter::EncodableValue(std::in_place_type<int64_t>,
-                                static_cast<int64_t>(duration_))}});
-
-  event.insert({flutter::EncodableValue("width"),
-                flutter::EncodableValue(std::in_place_type<int32_t>,
-                                        static_cast<int32_t>(width_))});
-  event.insert({flutter::EncodableValue("height"),
-                flutter::EncodableValue(std::in_place_type<int32_t>,
-                                        static_cast<int32_t>(height_))});
-
-  event_sink_->Success(flutter::EncodableValue(
-      std::in_place_type<flutter::EncodableMap>, std::move(event)));
-}
-
-void VideoPlayer::OnPlaybackEnded() {
-  if (is_looping_) {
-    SPDLOG_DEBUG("[VideoPlayer] Looping: seeking to start");
-    if (!gst_element_seek_simple(
-            playbin_, GST_FORMAT_TIME,
-            static_cast<GstSeekFlags>(GST_SEEK_FLAG_FLUSH |
-                                      GST_SEEK_FLAG_SEGMENT),
-            0)) {
-      SPDLOG_ERROR("[VideoPlayer] Loop seek failed");
-    }
-    return;
-  }
-  std::lock_guard event_lock(event_mutex_);
-  if (event_sink_) {
-    SPDLOG_DEBUG("[VideoPlayer] OnPlaybackEnded");
-    auto res = flutter::EncodableMap({{flutter::EncodableValue("event"),
-                                       flutter::EncodableValue("completed")}});
-    event_sink_->Success(flutter::EncodableValue(
-        std::in_place_type<flutter::EncodableMap>, std::move(res)));
-  }
-}
-
-void VideoPlayer::OnMediaStateChange(const GstState state) {
-  if (state == GST_STATE_NULL) {
-    SetBuffering(true);
-    SendBufferingUpdate();
-  } else {
-    if (!is_initialized_) {
-      is_initialized_ = true;
-    }
-    SetBuffering(false);
-
-    if (state == GST_STATE_PLAYING) {
-      SPDLOG_DEBUG("[VideoPlayer] message state changed, start playing {}",
-                   m_texture_id);
-      prepare(this);
-      ApplyPlaybackSpeed();
-    } else if (state == GST_STATE_READY) {
-      SPDLOG_DEBUG("[VideoPlayer] message state changed, ready {}",
-                   m_texture_id);
-    }
-  }
-}
-
-void VideoPlayer::SetBuffering(const bool buffering) {
-  std::lock_guard event_lock(event_mutex_);
-  if (event_sink_) {
-    SPDLOG_DEBUG("[VideoPlayer] SetBuffering: {}", buffering);
-    auto res = flutter::EncodableMap(
-        {{flutter::EncodableValue("event"),
-          flutter::EncodableValue(buffering ? "bufferingStart"
-                                            : "bufferingEnd")}});
-    event_sink_->Success(flutter::EncodableValue(
-        std::in_place_type<flutter::EncodableMap>, std::move(res)));
-  }
-}
-
-void VideoPlayer::Dispose() {
-  SPDLOG_DEBUG("[VideoPlayer] Dispose");
-  m_valid = false;
-  is_initialized_ = false;
-
-  std::lock_guard buffer_lock(buffer_mutex_);
-
-  g_signal_handler_disconnect(G_OBJECT(bus_), on_bus_msg_id_);
-  g_signal_handler_disconnect(G_OBJECT(sink_), handoff_handler_id_);
-
-  gst_element_set_state(playbin_, GST_STATE_NULL);
-
-  {
-    // Ensure no in-flight handoff callback is using the shader
-    std::lock_guard gst_lock(gst_mutex_);
-    std::lock_guard ctx_lock(g_texture_context_mutex);
-    m_registrar->texture_registrar()->TextureMakeCurrent();
-    shader_.reset();
-    m_registrar->texture_registrar()->TextureClearCurrent();
-  }
-
-  SPDLOG_DEBUG("[VideoPlayer] Unregistering texture_id={}", m_texture_id);
-  m_registrar->texture_registrar()->UnregisterTexture(m_texture_id);
-
-  m_texture_id = 0;
-  {
-    std::lock_guard event_lock(event_mutex_);
-    event_sink_ = nullptr;
-  }
-  event_channel_ = nullptr;
-}
-
-void VideoPlayer::SetLooping(const bool isLooping) {
-  SPDLOG_DEBUG("[VideoPlayer] SetLooping: {}", is_looping_.load());
-  is_looping_ = isLooping;
-}
-
-void VideoPlayer::SetVolume(const double volume) {
-  SPDLOG_DEBUG("[VideoPlayer] SetVolume: {}", volume);
-  volume_ = volume;
-  g_object_set(playbin_, "volume", volume, nullptr);
-}
-
-void VideoPlayer::SetPlaybackSpeed(const double playbackSpeed) {
-  // Store the desired rate so it can be applied when the pipeline is ready
-  pending_rate_ = playbackSpeed;
-
-  // Seek events require the pipeline to be in PAUSED or PLAYING state
-  GstState state;
-  gst_element_get_state(playbin_, &state, nullptr, 0);
-  if (state < GST_STATE_PAUSED) {
-    SPDLOG_DEBUG(
-        "[VideoPlayer] Deferring playback speed {} until pipeline is ready",
-        playbackSpeed);
-    return;
-  }
-
-  ApplyPlaybackSpeed();
-}
-
-void VideoPlayer::ApplyPlaybackSpeed() {
-  if (pending_rate_ == rate_) {
-    return;
-  }
-
-  const auto playbackSpeed = pending_rate_;
-  const gint64 pos = position_.load();
-  GstEvent* seek_event;
-  if (playbackSpeed > 0) {
-    // Forward playback: from current position to end
-    seek_event = gst_event_new_seek(
-        playbackSpeed, GST_FORMAT_TIME,
-        static_cast<GstSeekFlags>(GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE),
-        GST_SEEK_TYPE_SET, pos, GST_SEEK_TYPE_END, 0);
-  } else {
-    // Reverse playback: from beginning to current position
-    seek_event = gst_event_new_seek(
-        playbackSpeed, GST_FORMAT_TIME,
-        static_cast<GstSeekFlags>(GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE),
-        GST_SEEK_TYPE_SET, 0, GST_SEEK_TYPE_SET, pos);
-  }
-
-  // Send seek to playbin_ so the segment event propagates to all elements
-  // (including audio). Sending to sink_ alone causes "data flow before segment
-  // event" warnings on the audio path.
-  if (!gst_element_send_event(playbin_, seek_event)) {
-    SPDLOG_ERROR("[VideoPlayer] Failed to set playback speed: {}",
-                 playbackSpeed);
-    return;
-  }
-  rate_ = playbackSpeed;
-
-  SPDLOG_DEBUG("[VideoPlayer] Playback speed: {}", rate_);
-}
-
-void VideoPlayer::Play() {
-  target_state_ = GST_STATE_PLAYING;
-  const GstStateChangeReturn ret =
-      gst_element_set_state(playbin_, GST_STATE_PLAYING);
-  if (ret == GST_STATE_CHANGE_FAILURE) {
-    spdlog::error("[VideoPlayer] Failed to set state GST_STATE_PLAYING.");
-  } else if (ret == GST_STATE_CHANGE_NO_PREROLL) {
-    is_live_ = TRUE;
-    SPDLOG_DEBUG("[VideoPlayer] Pipeline is live");
-  }
-}
-
-void VideoPlayer::Pause() {
-  GstState state;
-  gst_element_get_state(playbin_, &state, nullptr, GST_SECOND);
-  if (state != GST_STATE_NULL) {
-    target_state_ = GST_STATE_PAUSED;
-    const GstStateChangeReturn ret =
-        gst_element_set_state(playbin_, GST_STATE_PAUSED);
-    if (ret == GST_STATE_CHANGE_FAILURE) {
-      std::lock_guard event_lock(event_mutex_);
-      if (event_sink_) {
-        event_sink_->Error("[VideoPlayer] Unable to Pause Transport.");
-      }
-      return;
-    }
-    SPDLOG_DEBUG("[VideoPlayer] Transport Paused.");
-  }
-}
-
-int64_t VideoPlayer::GetPosition() {
-  gint64 pos;
-  if (gst_element_query_position(playbin_, GST_FORMAT_TIME, &pos)) {
-    position_ = pos;
-    SPDLOG_TRACE("[VideoPlayer] Position: {}", pos);
-  }
-  const gint64 current = position_.load();
-  return current >= 0 ? current / AV_TIME_BASE : 0;
-}
-
-void VideoPlayer::SendBufferingUpdate() {
-  std::lock_guard event_lock(event_mutex_);
-  if (!event_sink_) {
-    return;
-  }
-  auto values = flutter::EncodableList();
-
-  GstQuery* query = gst_query_new_buffering(GST_FORMAT_TIME);
-  if (gst_element_query(playbin_, query)) {
-    const guint n_ranges = gst_query_get_n_buffering_ranges(query);
-    for (guint i = 0; i < n_ranges; i++) {
-      gint64 start, stop;
-      if (gst_query_parse_nth_buffering_range(query, i, &start, &stop)) {
-        values.emplace_back(
-            std::in_place_type<flutter::EncodableList>,
-            flutter::EncodableList{
-                flutter::EncodableValue(std::in_place_type<int64_t>,
-                                        start / AV_TIME_BASE),
-                flutter::EncodableValue(std::in_place_type<int64_t>,
-                                        stop / AV_TIME_BASE)});
-      }
-    }
-  }
-  gst_query_unref(query);
-
-  auto res = flutter::EncodableMap(
-      {{flutter::EncodableValue("event"),
-        flutter::EncodableValue("bufferingUpdate")},
-       {flutter::EncodableValue("values"),
-        flutter::EncodableValue(std::in_place_type<flutter::EncodableList>,
-                                std::move(values))}});
-  event_sink_->Success(flutter::EncodableValue(
-      std::in_place_type<flutter::EncodableMap>, std::move(res)));
-}
-
-void VideoPlayer::SeekTo(const int64_t seek) {
-  const gint64 position = seek * AV_TIME_BASE;
-  SPDLOG_DEBUG("[VideoPlayer] SeekTo: {} -> {}", seek, position);
-
-  if (!gst_element_seek_simple(
-          playbin_, GST_FORMAT_TIME,
-          static_cast<GstSeekFlags>(GST_SEEK_FLAG_FLUSH |
-                                    GST_SEEK_FLAG_KEY_UNIT),
-          position)) {
-    SPDLOG_ERROR("[VideoPlayer] Seek Failed");
-  }
-  gint64 pos;
-  gst_element_query_position(playbin_, GST_FORMAT_TIME, &pos);
-  position_ = pos;
-  SPDLOG_DEBUG("[VideoPlayer] SeekTo: {} -> {}", seek, pos);
 }
 
 void VideoPlayer::prepare(VideoPlayer* user_data) {

--- a/plugins/video_player_linux/video_player.cc
+++ b/plugins/video_player_linux/video_player.cc
@@ -22,6 +22,8 @@
 #include <flutter/plugin_registrar_homescreen.h>
 #include <flutter/standard_method_codec.h>
 
+#include <climits>
+
 #include <backend/backend.h>
 #include <plugins/common/common.h>
 #include <utility>
@@ -56,6 +58,14 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrarDesktop* registrar,
   SPDLOG_DEBUG(
       "[VideoPlayer] uri: {}, http_headers: {}, size: {} x {}, duration: {}",
       uri.c_str(), http_headers_.size(), width, height, duration);
+
+  gst_video_info_init(&info_);
+
+  if (width_ <= 0 || height_ <= 0) {
+    SPDLOG_ERROR("[VideoPlayer] Invalid dimensions: {}x{}", width_, height_);
+    m_valid = false;
+    return;
+  }
 
   std::lock_guard buffer_lock(buffer_mutex_);
 
@@ -99,6 +109,7 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrarDesktop* registrar,
   playbin_ = gst_element_factory_make("playbin", nullptr);
   if (!playbin_) {
     SPDLOG_ERROR("[VideoPlayer] Failed to create playbin element");
+    m_valid = false;
     return;
   }
   g_object_set(playbin_, "uri", uri_.c_str(), nullptr);
@@ -123,7 +134,7 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrarDesktop* registrar,
   if (const char* env = std::getenv("VIDEO_PLAYER_CONNECTION_SPEED")) {
     char* end = nullptr;
     const long val = std::strtol(env, &end, 10);
-    if (end != env && val > 0) {
+    if (end != env && val > 0 && val <= INT_MAX) {
       connection_speed = static_cast<int>(val);
     }
   }
@@ -133,6 +144,7 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrarDesktop* registrar,
   sink_ = gst_element_factory_make("fakesink", nullptr);
   if (!sink_) {
     SPDLOG_ERROR("[VideoPlayer] Failed to create fakesink element");
+    m_valid = false;
     return;
   }
   g_object_set(sink_, "sync", TRUE, nullptr);
@@ -144,6 +156,7 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrarDesktop* registrar,
   video_convert_ = gst_element_factory_make("videoconvert", nullptr);
   if (!video_convert_) {
     SPDLOG_ERROR("[VideoPlayer] Failed to create videoconvert element");
+    m_valid = false;
     return;
   }
 
@@ -153,6 +166,7 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrarDesktop* registrar,
   video_scale_ = gst_element_factory_make("videoscale", nullptr);
   if (!video_scale_) {
     SPDLOG_ERROR("[VideoPlayer] Failed to create videoscale element");
+    m_valid = false;
     return;
   }
 
@@ -212,24 +226,39 @@ void VideoPlayer::Dispose() {
 
   std::lock_guard buffer_lock(buffer_mutex_);
 
-  g_signal_handler_disconnect(G_OBJECT(bus_), on_bus_msg_id_);
-  g_signal_handler_disconnect(G_OBJECT(sink_), handoff_handler_id_);
+  if (bus_) {
+    g_signal_handler_disconnect(G_OBJECT(bus_), on_bus_msg_id_);
+  }
+  if (sink_) {
+    g_signal_handler_disconnect(G_OBJECT(sink_), handoff_handler_id_);
+  }
 
-  gst_element_set_state(playbin_, GST_STATE_NULL);
+  if (playbin_) {
+    gst_element_set_state(playbin_, GST_STATE_NULL);
+  }
 
   {
     // Ensure no in-flight handoff callback is using the shader
     std::lock_guard gst_lock(gst_mutex_);
-    std::lock_guard ctx_lock(g_texture_context_mutex);
-    m_registrar->texture_registrar()->TextureMakeCurrent();
-    shader_.reset();
-    m_registrar->texture_registrar()->TextureClearCurrent();
+    if (shader_) {
+      std::lock_guard ctx_lock(g_texture_context_mutex);
+      m_registrar->texture_registrar()->TextureMakeCurrent();
+      shader_.reset();
+      m_registrar->texture_registrar()->TextureClearCurrent();
+    }
   }
 
-  SPDLOG_DEBUG("[VideoPlayer] Unregistering texture_id={}", m_texture_id);
-  m_registrar->texture_registrar()->UnregisterTexture(m_texture_id);
+  if (m_texture_id != 0) {
+    SPDLOG_DEBUG("[VideoPlayer] Unregistering texture_id={}", m_texture_id);
+    m_registrar->texture_registrar()->UnregisterTexture(m_texture_id);
+    m_texture_id = 0;
+  }
 
-  m_texture_id = 0;
+  if (bus_) {
+    gst_object_unref(bus_);
+    bus_ = nullptr;
+  }
+
   {
     std::lock_guard event_lock(event_mutex_);
     event_sink_ = nullptr;
@@ -296,7 +325,7 @@ void VideoPlayer::Pause() {
 }
 
 int64_t VideoPlayer::GetPosition() {
-  gint64 pos;
+  gint64 pos = 0;
   if (gst_element_query_position(playbin_, GST_FORMAT_TIME, &pos)) {
     position_ = pos;
     SPDLOG_TRACE("[VideoPlayer] Position: {}", pos);
@@ -316,7 +345,7 @@ void VideoPlayer::SendBufferingUpdate() {
   if (gst_element_query(playbin_, query)) {
     const guint n_ranges = gst_query_get_n_buffering_ranges(query);
     for (guint i = 0; i < n_ranges; i++) {
-      gint64 start, stop;
+      gint64 start = 0, stop = 0;
       if (gst_query_parse_nth_buffering_range(query, i, &start, &stop)) {
         values.emplace_back(
             std::in_place_type<flutter::EncodableList>,
@@ -467,15 +496,13 @@ void VideoPlayer::OnMediaStateChange(const GstState state) {
     SetBuffering(true);
     SendBufferingUpdate();
   } else {
-    if (!is_initialized_) {
-      is_initialized_ = true;
-    }
     SetBuffering(false);
 
     if (state == GST_STATE_PLAYING) {
       SPDLOG_DEBUG("[VideoPlayer] message state changed, start playing {}",
                    m_texture_id);
       prepare(this);
+      is_initialized_ = true;
       ApplyPlaybackSpeed();
     } else if (state == GST_STATE_READY) {
       SPDLOG_DEBUG("[VideoPlayer] message state changed, ready {}",
@@ -541,25 +568,32 @@ void VideoPlayer::OnTag(const GstTagList* list,
   const std::string tag_str = tag;
   if (const auto type = gst_tag_get_type(tag);
       tag_str == "audio-codec" && type == 64) {
-    gchar* value;
-    gst_tag_list_get_string(list, tag, &value);
-    spdlog::debug("[VideoPlayer] audio-codec: {}", value);
+    gchar* value = nullptr;
+    if (gst_tag_list_get_string(list, tag, &value) && value) {
+      spdlog::debug("[VideoPlayer] audio-codec: {}", value);
+      g_free(value);
+    }
   } else if (tag_str == "video-codec" && type == 64) {
-    gchar* value;
-    gst_tag_list_get_string(list, tag, &value);
-    spdlog::debug("[VideoPlayer] video-codec: {}", value);
+    gchar* value = nullptr;
+    if (gst_tag_list_get_string(list, tag, &value) && value) {
+      spdlog::debug("[VideoPlayer] video-codec: {}", value);
+      g_free(value);
+    }
   } else if (tag_str == "maximum-bitrate" && type == 28) {
-    guint value;
-    gst_tag_list_get_uint(list, tag, &value);
-    spdlog::debug("[VideoPlayer] maximum-bitrate: {}", value);
+    guint value = 0;
+    if (gst_tag_list_get_uint(list, tag, &value)) {
+      spdlog::debug("[VideoPlayer] maximum-bitrate: {}", value);
+    }
   } else if (tag_str == "minimum-bitrate" && type == 28) {
-    guint value;
-    gst_tag_list_get_uint(list, tag, &value);
-    spdlog::debug("[VideoPlayer] minimum-bitrate: {}", value);
+    guint value = 0;
+    if (gst_tag_list_get_uint(list, tag, &value)) {
+      spdlog::debug("[VideoPlayer] minimum-bitrate: {}", value);
+    }
   } else if (tag_str == "bitrate" && type == 28) {
-    guint value;
-    gst_tag_list_get_uint(list, tag, &value);
-    spdlog::debug("[VideoPlayer] bitrate: {}", value);
+    guint value = 0;
+    if (gst_tag_list_get_uint(list, tag, &value)) {
+      spdlog::debug("[VideoPlayer] bitrate: {}", value);
+    }
   }
 }
 
@@ -568,11 +602,14 @@ void VideoPlayer::handoff_handler(GstElement* /* fakesink */,
                                   GstPad* /* pad */,
                                   void* user_data) {
   const auto obj = static_cast<VideoPlayer*>(user_data);
-  if (!obj->m_valid || !obj->is_initialized_ || obj->info_.finfo == nullptr) {
+  if (!obj->m_valid || !obj->is_initialized_) {
     return;
   }
 
   std::lock_guard lock(obj->gst_mutex_);
+  if (obj->info_.finfo == nullptr || !obj->shader_) {
+    return;
+  }
   GstVideoFrame frame;
   if (gst_video_frame_map(&frame, &obj->info_, buffer, GST_MAP_READ)) {
     {
@@ -620,14 +657,13 @@ void VideoPlayer::handoff_handler(GstElement* /* fakesink */,
   }
 }
 
-gboolean VideoPlayer::OnBusMessage(GstBus* bus,
+gboolean VideoPlayer::OnBusMessage(GstBus* /* bus */,
                                    GstMessage* msg,
                                    void* user_data) {
   auto obj = static_cast<VideoPlayer*>(user_data);
   switch (GST_MESSAGE_TYPE(msg)) {
     case GST_MESSAGE_ERROR:
       obj->OnMediaError(msg);
-      gst_object_unref(bus);
       return FALSE;
     case GST_MESSAGE_EOS: {
       SPDLOG_DEBUG("[VideoPlayer] EOS: texture_id: {}", obj->m_texture_id);
@@ -811,7 +847,7 @@ void VideoPlayer::prepare(VideoPlayer* user_data) {
     // TODO g_main_loop_quit(obj->main_loop_);
     return;
   }
-  const GstCaps* caps = gst_pad_get_current_caps(pad);
+  GstCaps* caps = gst_pad_get_current_caps(pad);
   if (!caps) {
     SPDLOG_ERROR("[VideoPlayer] Failed to get caps from video pad");
     gst_object_unref(pad);
@@ -820,9 +856,8 @@ void VideoPlayer::prepare(VideoPlayer* user_data) {
   std::lock_guard lock(user_data->gst_mutex_);
   if (!gst_video_info_from_caps(&user_data->info_, caps)) {
     SPDLOG_ERROR("[VideoPlayer] Fail to get video info from the cap");
-    // TODO g_main_loop_quit(data->main_loop);
-    // return;
   }
+  gst_caps_unref(caps);
   SPDLOG_DEBUG("[VideoPlayer] original video width: {}, height: {}",
                user_data->info_.width, user_data->info_.height);
   // set to the target
@@ -831,7 +866,6 @@ void VideoPlayer::prepare(VideoPlayer* user_data) {
                                  static_cast<guint>(user_data->height_))) {
     SPDLOG_ERROR("[VideoPlayer] Failed to set the video info to target NV12");
   }
-  user_data->is_initialized_ = true;
 }
 
 }  // namespace video_player_linux

--- a/plugins/video_player_linux/video_player.h
+++ b/plugins/video_player_linux/video_player.h
@@ -21,14 +21,11 @@
 #include <map>
 #include <memory>
 #include <mutex>
-#include <sstream>
 #include <string>
 
 #include <flutter/event_channel.h>
-#include <flutter/event_stream_handler.h>
 #include <flutter/event_stream_handler_functions.h>
 #include <flutter/plugin_registrar_homescreen.h>
-#include <flutter/standard_method_codec.h>
 
 #include "nv12.h"
 
@@ -50,8 +47,7 @@ class VideoPlayer {
               std::map<std::string, std::string> http_headers,
               GLsizei width,
               GLsizei height,
-              gint64 duration,
-              GstElementFactory* decoder_factory);
+              gint64 duration);
   ~VideoPlayer();
 
   void Dispose();
@@ -76,20 +72,17 @@ class VideoPlayer {
   GLsizei width_{};
   GLsizei height_{};
   gint64 duration_{};
-  GstElementFactory* decoder_factory_;
 
   GLuint m_texture_id{};
   std::atomic<bool> m_valid = true;
   std::unique_ptr<flutter::GpuSurfaceTexture> gpu_surface_texture_;
 
   GMainContext* context_;
-  GstState media_state_;
 
   // Gst members
   GstElement* playbin_{};
   GstElement* pipeline_{};
   GstElement* sink_{};
-  GstElement* decoder_{};
   GstElement* video_convert_{};
   GstElement* video_scale_{};
   GstVideoInfo info_{};
@@ -120,7 +113,7 @@ class VideoPlayer {
 
   void ApplyPlaybackSpeed();
   void OnPlaybackEnded();
-  void OnMediaInitialized();
+  static void OnMediaInitialized();
   void OnMediaStateChange(GstState state);
   void OnMediaError(GstMessage* msg);
   void OnMediaDurationChange();
@@ -149,7 +142,7 @@ class VideoPlayer {
    * @param[in] fakesink No use
    * @param[in] buffer Pointer to New frame data
    * @param[in] pad No use
-   * @param[in,out] _data Pointer to User data
+   * @param[in,out] user_data Pointer to User data
    * @return void
    * @relation
    * flutter
@@ -163,7 +156,7 @@ class VideoPlayer {
 
   /**
    * @brief Prepare
-   * @param[in,out] data Pointer to User data
+   * @param[in,out] user_data Pointer to User data
    * @return void
    * @relation
    * flutter

--- a/plugins/video_player_linux/video_player_plugin.cc
+++ b/plugins/video_player_linux/video_player_plugin.cc
@@ -18,7 +18,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cstring>
 #include <filesystem>
 #include <map>
 #include <memory>
@@ -134,6 +133,9 @@ ErrorOr<int64_t> VideoPlayerPlugin::Create(
     if (!discover_video_info(asset_to_load.c_str(), width, height, duration)) {
       return FlutterError("video_info_failed",
                           "Failed to discover video information");
+    }
+    if (width <= 0 || height <= 0 || width > 16384 || height > 16384) {
+      return FlutterError("video_info_failed", "Invalid video dimensions");
     }
 
     player = std::make_unique<VideoPlayer>(registrar_, asset_to_load.c_str(),
@@ -285,11 +287,14 @@ bool VideoPlayerPlugin::discover_video_info(const char* url,
 
   duration = static_cast<gint64>(gst_discoverer_info_get_duration(info));
 
-  GList* video_streams = gst_discoverer_info_get_video_streams(info);
-  if (video_streams) {
-    auto* vinfo = static_cast<GstDiscovererVideoInfo*>(video_streams->data);
-    width = static_cast<int>(gst_discoverer_video_info_get_width(vinfo));
-    height = static_cast<int>(gst_discoverer_video_info_get_height(vinfo));
+  if (GList* video_streams = gst_discoverer_info_get_video_streams(info)) {
+    auto* stream_info =
+        static_cast<GstDiscovererStreamInfo*>(video_streams->data);
+    if (GST_IS_DISCOVERER_VIDEO_INFO(stream_info)) {
+      auto* vinfo = GST_DISCOVERER_VIDEO_INFO(stream_info);
+      width = static_cast<int>(gst_discoverer_video_info_get_width(vinfo));
+      height = static_cast<int>(gst_discoverer_video_info_get_height(vinfo));
+    }
     gst_discoverer_stream_info_list_free(video_streams);
   } else {
     spdlog::error("[VideoPlayer] No video stream found in {}", url);

--- a/plugins/video_player_linux/video_player_plugin.cc
+++ b/plugins/video_player_linux/video_player_plugin.cc
@@ -23,12 +23,8 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <vector>
 
-extern "C" {
-#include <libavutil/avutil.h>
-#include <libavutil/dict.h>
-}
+#include <gst/pbutils/pbutils.h>
 
 #include "messages.g.h"
 #include "plugins/common/glib/main_loop.h"
@@ -54,10 +50,6 @@ VideoPlayerPlugin::VideoPlayerPlugin(flutter::PluginRegistrarDesktop* registrar)
 
   // start the main loop if not already running
   plugin_common_glib::MainLoop::GetInstance();
-
-  // supress libavformat logging
-  av_log_set_callback([](void* /* avcl */, int /* level */,
-                         const char* /* fmt */, va_list /* vl */) {});
 }
 
 std::optional<FlutterError> VideoPlayerPlugin::Initialize() {
@@ -137,24 +129,16 @@ ErrorOr<int64_t> VideoPlayerPlugin::Create(
   SPDLOG_DEBUG("[VideoPlayer] asset: {}", asset_to_load);
 
   try {
-    // Get stream information
-    int width, height;
-    gint64 duration;
-    AVCodecID codec_id;
-    if (!get_video_info(asset_to_load.c_str(), width, height, duration,
-                        codec_id)) {
-      spdlog::error("Failed to get video info");
-    }
-
-    const auto decoder_factory = find_decoder_factory(codec_id);
-    if (decoder_factory == nullptr) {
-      return FlutterError("codec_load_failed",
-                          "No suitable decoder found for this codec");
+    int width = 0, height = 0;
+    gint64 duration = 0;
+    if (!discover_video_info(asset_to_load.c_str(), width, height, duration)) {
+      return FlutterError("video_info_failed",
+                          "Failed to discover video information");
     }
 
     player = std::make_unique<VideoPlayer>(registrar_, asset_to_load.c_str(),
                                            std::move(http_headers_), width,
-                                           height, duration, decoder_factory);
+                                           height, duration);
 
   } catch (std::exception& e) {
     return FlutterError("uri_load_failed", e.what());
@@ -275,508 +259,51 @@ std::optional<FlutterError> VideoPlayerPlugin::Pause(const int64_t texture_id) {
   return std::nullopt;
 }
 
-bool VideoPlayerPlugin::get_video_info(const char* url,
-                                       int& width,
-                                       int& height,
-                                       gint64& duration,
-                                       AVCodecID& codec_id) {
-  AVFormatContext* fmt_ctx = avformat_alloc_context();
-
-  AVDictionary* opts = nullptr;
-  av_dict_set(&opts, "protocol_whitelist",
-              "file,http,https,tcp,tls,rtsp,rtp,udp", 0);
-  av_dict_set(&opts, "timeout", "10000000", 0);  // 10 seconds in microseconds
-
-  if (avformat_open_input(&fmt_ctx, url, nullptr, &opts) < 0) {
-    spdlog::error("[VideoPlayer] Unable to open: {}", url);
-    av_dict_free(&opts);
-    avformat_free_context(fmt_ctx);
-    return false;
-  }
-  av_dict_free(&opts);
-
-  if (avformat_find_stream_info(fmt_ctx, nullptr) < 0) {
-    spdlog::error("[VideoPlayer] Cannot find stream information: {}", url);
-    avformat_free_context(fmt_ctx);
+bool VideoPlayerPlugin::discover_video_info(const char* url,
+                                            int& width,
+                                            int& height,
+                                            gint64& duration) {
+  GError* err = nullptr;
+  GstDiscoverer* discoverer = gst_discoverer_new(10 * GST_SECOND, &err);
+  if (!discoverer) {
+    spdlog::error("[VideoPlayer] Failed to create discoverer: {}",
+                  err ? err->message : "unknown");
+    g_clear_error(&err);
     return false;
   }
 
-  const int ret =
-      av_find_best_stream(fmt_ctx, AVMEDIA_TYPE_VIDEO, -1, -1, nullptr, 0);
-  if (ret < 0) {
-    spdlog::error("[VideoPlayer] Cannot find a video stream in the input file");
-    avformat_free_context(fmt_ctx);
+  GstDiscovererInfo* info = gst_discoverer_discover_uri(discoverer, url, &err);
+  if (!info || gst_discoverer_info_get_result(info) != GST_DISCOVERER_OK) {
+    spdlog::error("[VideoPlayer] Discovery failed for {}: {}", url,
+                  err ? err->message : "unknown");
+    g_clear_error(&err);
+    if (info)
+      gst_discoverer_info_unref(info);
+    g_object_unref(discoverer);
     return false;
   }
-  const int video_stream_index = ret;
-  const AVStream* stream = fmt_ctx->streams[video_stream_index];
-  const AVCodecParameters* par = stream->codecpar;
 
-  codec_id = par->codec_id;
-  width = par->width;
-  height = par->height;
-  duration = fmt_ctx->duration;
+  duration = static_cast<gint64>(gst_discoverer_info_get_duration(info));
 
-#if GSTREAMER_DEBUG
-  av_dump_format(fmt_ctx, 0, url, 0);
-#endif
+  GList* video_streams = gst_discoverer_info_get_video_streams(info);
+  if (video_streams) {
+    auto* vinfo = static_cast<GstDiscovererVideoInfo*>(video_streams->data);
+    width = static_cast<int>(gst_discoverer_video_info_get_width(vinfo));
+    height = static_cast<int>(gst_discoverer_video_info_get_height(vinfo));
+    gst_discoverer_stream_info_list_free(video_streams);
+  } else {
+    spdlog::error("[VideoPlayer] No video stream found in {}", url);
+    gst_discoverer_info_unref(info);
+    g_object_unref(discoverer);
+    return false;
+  }
 
-  avformat_free_context(fmt_ctx);
+  SPDLOG_DEBUG("[VideoPlayer] Discovered: {}x{}, duration={}ns", width, height,
+               duration);
+
+  gst_discoverer_info_unref(info);
+  g_object_unref(discoverer);
   return true;
-}
-
-GstElementFactory* VideoPlayerPlugin::find_decoder_factory(
-    const AVCodecID codec_id) {
-  // Hardware decoder candidates per codec, tried in priority order.
-  // vaapidecodebin works across Intel/AMD, v4l2 for embedded SoCs, nv for
-  // NVIDIA.
-  struct HwDecoder {
-    const char* name;
-  };
-
-  // clang-format off
-  static const std::map<AVCodecID, std::vector<HwDecoder>> kHwDecoders = {
-      {AV_CODEC_ID_H264,  {{"vaapidecodebin"}, {"v4l2h264dec"},  {"nvh264dec"}, {"openh264dec"}}},
-      {AV_CODEC_ID_H265,  {{"vaapidecodebin"}, {"v4l2h265dec"},  {"nvh265dec"}}},
-      {AV_CODEC_ID_VP8,   {{"vaapidecodebin"}, {"v4l2vp8dec"},   {"nvvp8dec"}}},
-      {AV_CODEC_ID_VP9,   {{"vaapidecodebin"}, {"v4l2vp9dec"},   {"nvvp9dec"}}},
-      {AV_CODEC_ID_MPEG2VIDEO, {{"vaapidecodebin"}, {"v4l2mpeg2dec"}}},
-      {AV_CODEC_ID_MPEG4, {{"vaapidecodebin"}, {"v4l2mpeg4dec"}}},
-  };
-  // clang-format on
-
-  // Try hardware decoders first
-  if (const auto it = kHwDecoders.find(codec_id); it != kHwDecoders.end()) {
-    for (const auto& [name] : it->second) {
-      GstElementFactory* factory = gst_element_factory_find(name);
-      if (factory) {
-        SPDLOG_DEBUG("[VideoPlayer] Using hardware decoder: {}", name);
-        return factory;
-      }
-    }
-  }
-
-  // Fall back to software decoder
-  const auto sw_name = map_ffmpeg_plugin(codec_id);
-  if (sw_name[0]) {
-    GstElementFactory* factory = gst_element_factory_find(sw_name);
-    if (factory) {
-      SPDLOG_DEBUG("[VideoPlayer] Using software decoder: {}", sw_name);
-      return factory;
-    }
-    spdlog::error(
-        "[VideoPlayer] Failed to find decoder: {}. May be a missing runtime "
-        "package",
-        sw_name);
-  }
-
-  return nullptr;
-}
-
-const char* VideoPlayerPlugin::map_ffmpeg_plugin(const AVCodecID codec_id) {
-  switch (codec_id) {
-    case AV_CODEC_ID_NONE:
-      return "none";
-    case AV_CODEC_ID_4XM:
-      return "avdec_4xm";
-    case AV_CODEC_ID_8BPS:
-      return "avdec_8bps";
-    case AV_CODEC_ID_8SVX_EXP:
-      return "avdec_8svx_exp";
-    case AV_CODEC_ID_8SVX_FIB:
-      return "avdec_8svx_fib";
-    case AV_CODEC_ID_AASC:
-      return "avdec_aasc";
-    case AV_CODEC_ID_AIC:
-      return "avdec_aic";
-    case AV_CODEC_ID_AMV:
-      return "avdec_amv";
-    case AV_CODEC_ID_ASV1:
-      return "avdec_asv1";
-    case AV_CODEC_ID_ASV2:
-      return "avdec_asv2";
-    case AV_CODEC_ID_AVS:
-      return "avdec_avs";
-    case AV_CODEC_ID_BMV_VIDEO:
-      return "avdec_bmv_video";
-    case AV_CODEC_ID_CAVS:
-      return "avdec_cavs";
-    case AV_CODEC_ID_CFHD:
-      return "avdec_cfhd";
-    case AV_CODEC_ID_CINEPAK:
-      return "avdec_cinepak";
-    case AV_CODEC_ID_CLEARVIDEO:
-      return "avdec_clearvideo";
-    case AV_CODEC_ID_CLJR:
-      return "avdec_cljr";
-    case AV_CODEC_ID_CYUV:
-      return "avdec_cyuv";
-    case AV_CODEC_ID_DDS:
-      return "avdec_dds";
-    case AV_CODEC_ID_DFA:
-      return "avdec_dfa";
-    case AV_CODEC_ID_DIRAC:
-      return "avdec_dirac";
-    case AV_CODEC_ID_DNXHD:
-      return "avdec_dnxhd";
-    case AV_CODEC_ID_DPX:
-      return "avdec_dpx";
-    case AV_CODEC_ID_DSICINVIDEO:
-      return "avdec_dsicinvideo";
-    case AV_CODEC_ID_DVVIDEO:
-      return "avdec_dvvideo";
-    case AV_CODEC_ID_DXA:
-      return "avdec_dxa";
-    case AV_CODEC_ID_DXTORY:
-      return "avdec_dxtory";
-    case AV_CODEC_ID_DXV:
-      return "avdec_dxv";
-    case AV_CODEC_ID_CMV:
-      return "avdec_eacmv";
-    case AV_CODEC_ID_MAD:
-      return "avdec_eamad";
-    case AV_CODEC_ID_TGQ:
-      return "avdec_eatgq";
-    case AV_CODEC_ID_TGV:
-      return "avdec_eatgv";
-    case AV_CODEC_ID_TQI:
-      return "avdec_eatqi";
-    case AV_CODEC_ID_ESCAPE124:
-      return "avdec_escape124";
-    case AV_CODEC_ID_ESCAPE130:
-      return "avdec_escape130";
-    case AV_CODEC_ID_EXR:
-      return "avdec_exr";
-    case AV_CODEC_ID_FFV1:
-      return "avdec_ffv1";
-    case AV_CODEC_ID_FFVHUFF:
-      return "avdec_ffvhuff";
-    case AV_CODEC_ID_FIC:
-      return "avdec_fic";
-    case AV_CODEC_ID_FITS:
-      return "avdec_fits";
-    case AV_CODEC_ID_FLASHSV:
-      return "avdec_flashsv";
-    case AV_CODEC_ID_FLASHSV2:
-      return "avdec_flashsv2";
-    case AV_CODEC_ID_FLIC:
-      return "avdec_flic";
-    case AV_CODEC_ID_FLV1:
-      return "avdec_flv";
-    case AV_CODEC_ID_FMVC:
-      return "avdec_fmvc";
-    case AV_CODEC_ID_FRAPS:
-      return "avdec_fraps";
-    case AV_CODEC_ID_FRWU:
-      return "avdec_frwu";
-    case AV_CODEC_ID_G2M:
-      return "avdec_g2m";
-    case AV_CODEC_ID_GDV:
-      return "advec_gdv";
-    case AV_CODEC_ID_H261:
-      return "avdec_h261";
-    case AV_CODEC_ID_H263:
-      return "avdec_h263";
-    case AV_CODEC_ID_H263I:
-      return "avdec_h263i";
-    case AV_CODEC_ID_H263P:
-      return "avdec_h263p";
-    case AV_CODEC_ID_H264:
-      return "avdec_h264";
-    case AV_CODEC_ID_H265:
-      return "avdec_h265";
-    case AV_CODEC_ID_HAP:
-      return "avdec_hap";
-    case AV_CODEC_ID_HNM4_VIDEO:
-      return "avdec_hmn4video";
-    case AV_CODEC_ID_HQ_HQA:
-      return "avdec_hq_hqa";
-    case AV_CODEC_ID_HQX:
-      return "avdec_hqx";
-    case AV_CODEC_ID_HUFFYUV:
-      return "avdec_huffyuv";
-    case AV_CODEC_ID_HYMT:
-      return "avdec_hymt";
-      // case AV_CODEC_ID_IDCINVIDEO:
-      //   return "avdec_idcinvideo";
-    case AV_CODEC_ID_IDF:
-      return "avdec_idf";
-      // case AV_CODEC_ID_IFF:
-      //   return "avdec_iff";
-    case AV_CODEC_ID_IMM4:
-      return "avdec_imm4";
-    case AV_CODEC_ID_INDEO2:
-      return "avdec_indeo2";
-    case AV_CODEC_ID_INDEO3:
-      return "avdec_indeo3";
-    case AV_CODEC_ID_INDEO4:
-      return "avdec_indeo4";
-    case AV_CODEC_ID_INDEO5:
-      return "avdec_indeo5";
-    case AV_CODEC_ID_INTERPLAY_VIDEO:
-      return "avdec_interplayvideo";
-    case AV_CODEC_ID_JPEG2000:
-      return "avdec_jpeg2000";
-    case AV_CODEC_ID_JPEGLS:
-      return "avdec_jpegls";
-    case AV_CODEC_ID_JV:
-      return "avdec_jv";
-    case AV_CODEC_ID_KGV1:
-      return "avdec_kgv1";
-    case AV_CODEC_ID_KMVC:
-      return "avdec_kmvc";
-    case AV_CODEC_ID_LAGARITH:
-      return "avdec_lagarith";
-    case AV_CODEC_ID_LOCO:
-      return "avdec_loco";
-    case AV_CODEC_ID_LSCR:
-      return "avdec_lscr";
-    case AV_CODEC_ID_M101:
-      return "avdec_m101";
-    case AV_CODEC_ID_MAGICYUV:
-      return "avdec_magicyuv";
-    case AV_CODEC_ID_MDEC:
-      return "avdec_mdec";
-    case AV_CODEC_ID_MIMIC:
-      return "avdec_mimic";
-    case AV_CODEC_ID_MJPEG:
-      return "avdec_mjpeg";
-    case AV_CODEC_ID_MJPEGB:
-      return "avdec_mjpegb";
-    case AV_CODEC_ID_MMVIDEO:
-      return "avdec_mmvideo";
-    case AV_CODEC_ID_MOTIONPIXELS:
-      return "avdec_motionpixels";
-    case AV_CODEC_ID_MPEG2VIDEO:
-      return "avdec_mpeg2video";
-    case AV_CODEC_ID_MPEG4:
-      return "avdec_mpeg4";
-    case AV_CODEC_ID_MPEG1VIDEO:
-      return "avdec_mpegvideo";
-    case AV_CODEC_ID_MSA1:
-      return "avdec_msa1";
-    case AV_CODEC_ID_MSCC:
-      return "avdec_mscc";
-    case AV_CODEC_ID_MSMPEG4V3:
-      return "avdec_msmpeg4";
-    case AV_CODEC_ID_MSMPEG4V1:
-      return "avdec_msmpeg4v1";
-    case AV_CODEC_ID_MSMPEG4V2:
-      return "avdec_msmpeg4v2";
-    case AV_CODEC_ID_MSRLE:
-      return "avdec_msrle";
-    case AV_CODEC_ID_MSS1:
-      return "avdec_mss1";
-    case AV_CODEC_ID_MSS2:
-      return "avdec_mss2";
-    case AV_CODEC_ID_MSVIDEO1:
-      return "avdec_msvideo1";
-    case AV_CODEC_ID_MSZH:
-      return "avdec_mszh";
-    case AV_CODEC_ID_MTS2:
-      return "avdec_mts2";
-    case AV_CODEC_ID_MVC1:
-      return "avdec_mvc1";
-    case AV_CODEC_ID_MVC2:
-      return "avdec_mvc2";
-    case AV_CODEC_ID_MWSC:
-      return "avdec_mwsc";
-    case AV_CODEC_ID_MXPEG:
-      return "avdec_mxpeg";
-    case AV_CODEC_ID_NUV:
-      return "avdec_NUV";
-    case AV_CODEC_ID_PAF_VIDEO:
-      return "avdec_paf_video";
-    case AV_CODEC_ID_PAM:
-      return "avdec_pam";
-    case AV_CODEC_ID_PBM:
-      return "avdec_pbm";
-    case AV_CODEC_ID_PCX:
-      return "avdec_pcx";
-    case AV_CODEC_ID_PGM:
-      return "avdec_pgm";
-    case AV_CODEC_ID_PGMYUV:
-      return "avdec_pgmyuv";
-    case AV_CODEC_ID_PICTOR:
-      return "avdec_pictor";
-    case AV_CODEC_ID_PIXLET:
-      return "avdec_pixlet";
-    case AV_CODEC_ID_PNG:
-      return "avdec_png";
-    case AV_CODEC_ID_PPM:
-      return "avdec_ppm";
-    case AV_CODEC_ID_PRORES:
-      return "avdec_prores";
-    case AV_CODEC_ID_PROSUMER:
-      return "avdec_prosumer";
-    case AV_CODEC_ID_PSD:
-      return "avdec_psd";
-    case AV_CODEC_ID_PTX:
-      return "avdec_ptx";
-    case AV_CODEC_ID_QDRAW:
-      return "avdec_qdraw";
-    case AV_CODEC_ID_QPEG:
-      return "avdec_qpeg";
-    case AV_CODEC_ID_QTRLE:
-      return "avdec_qtrle";
-    case AV_CODEC_ID_R10K:
-      return "avdec_r10k";
-    case AV_CODEC_ID_RASC:
-      return "avdec_rasc";
-    case AV_CODEC_ID_RL2:
-      return "avdec_rl2";
-    case AV_CODEC_ID_ROQ:
-      return "avdec_roqvideo";
-    case AV_CODEC_ID_RPZA:
-      return "avdec_rpza";
-    case AV_CODEC_ID_RSCC:
-      return "avdec_rscc";
-    case AV_CODEC_ID_RV10:
-      return "avdec_rv10";
-    case AV_CODEC_ID_RV20:
-      return "avdec_rv20";
-    case AV_CODEC_ID_RV30:
-      return "avdec_rv30";
-    case AV_CODEC_ID_RV40:
-      return "avdec_rv40";
-    case AV_CODEC_ID_SANM:
-      return "avdec_sanm";
-    case AV_CODEC_ID_SCPR:
-      return "avdec_scpr";
-    case AV_CODEC_ID_SCREENPRESSO:
-      return "avdec_screenpresso";
-    case AV_CODEC_ID_SGI:
-      return "avdec_sgi";
-    case AV_CODEC_ID_SGIRLE:
-      return "avdec_sgirle";
-    case AV_CODEC_ID_SHEERVIDEO:
-      return "avdec_sheervideo";
-    case AV_CODEC_ID_SMACKVIDEO:
-      return "avdec_smackvid";
-    case AV_CODEC_ID_SMC:
-      return "avdec_smc";
-    case AV_CODEC_ID_SMVJPEG:
-      return "avdec_smvjpeg";
-    case AV_CODEC_ID_SNOW:
-      return "avdec_snow";
-    case AV_CODEC_ID_SP5X:
-      return "avdec_sp5x";
-    case AV_CODEC_ID_SPEEDHQ:
-      return "avdec_speedhq";
-    case AV_CODEC_ID_SRGC:
-      return "avdec_srgc";
-    case AV_CODEC_ID_SUNRAST:
-      return "avdec_sunrast";
-    case AV_CODEC_ID_SVQ1:
-      return "avdec_svq1";
-    case AV_CODEC_ID_SVQ3:
-      return "avdec_svq3";
-    case AV_CODEC_ID_TARGA:
-      return "avdec_targa";
-    case AV_CODEC_ID_TARGA_Y216:
-      return "avdec_targa_y216";
-    case AV_CODEC_ID_TDSC:
-      return "avdec_tdsc";
-    case AV_CODEC_ID_THP:
-      return "avdec_thp";
-    case AV_CODEC_ID_TIERTEXSEQVIDEO:
-      return "avdec_tiertexseqvideo";
-    case AV_CODEC_ID_TIFF:
-      return "avdec_tiff";
-    case AV_CODEC_ID_TMV:
-      return "avdec_tmv";
-    case AV_CODEC_ID_TRUEHD:
-      return "avdec_truehd";
-    case AV_CODEC_ID_TRUEMOTION1:
-      return "avdec_truemotion1";
-    case AV_CODEC_ID_TRUEMOTION2:
-      return "avdec_truemotion2";
-    case AV_CODEC_ID_TRUEMOTION2RT:
-      return "avdec_truemotion2rt";
-    case AV_CODEC_ID_TSCC2:
-      return "avdec_tscc2";
-    case AV_CODEC_ID_TXD:
-      return "avdec_txd";
-      // case AV_CODEC_ID_ULTIMOTION:
-      //   return "avdec_ultimotion";
-    case AV_CODEC_ID_UTVIDEO:
-      return "avdec_utvideo";
-    case AV_CODEC_ID_VB:
-      return "avdec_vb";
-    case AV_CODEC_ID_VBLE:
-      return "avdec_vble";
-    case AV_CODEC_ID_VC1:
-      return "avdec_vc1";
-    case AV_CODEC_ID_VC1IMAGE:
-      return "avdec_vc1image";
-    case AV_CODEC_ID_VCR1:
-      return "avdec_vcr1";
-    case AV_CODEC_ID_VMDVIDEO:
-      return "avdec_vmdvideo";
-    case AV_CODEC_ID_VMNC:
-      return "avdec_vmnc";
-    case AV_CODEC_ID_VP3:
-      return "avdec_vp3";
-    case AV_CODEC_ID_VP4:
-      return "avdec_vp4";
-    case AV_CODEC_ID_VP5:
-      return "avdec_vp5";
-    case AV_CODEC_ID_VP6:
-      return "avdec_vp6";
-    case AV_CODEC_ID_VP6A:
-      return "avdec_vp6a";
-    case AV_CODEC_ID_VP6F:
-      return "avdec_vp6f";
-    case AV_CODEC_ID_VP7:
-      return "avdec_vp7";
-    case AV_CODEC_ID_VP8:
-      return "avdec_vp8";
-    case AV_CODEC_ID_VP9:
-      return "avdec_vp9";
-    case AV_CODEC_ID_WS_VQA:
-      return "avdec_vqavideo";
-    case AV_CODEC_ID_WCMV:
-      return "avdec_wcmv";
-    case AV_CODEC_ID_WEBP:
-      return "avdec_webp";
-    case AV_CODEC_ID_WMV1:
-      return "avdec_wmv1";
-    case AV_CODEC_ID_WMV2:
-      return "avdec_wmv2";
-    case AV_CODEC_ID_WMV3:
-      return "avdec_wmv3";
-    case AV_CODEC_ID_WMV3IMAGE:
-      return "avdec_wmv3image";
-    case AV_CODEC_ID_WNV1:
-      return "avdec_wnv1";
-    case AV_CODEC_ID_XAN_WC3:
-      return "avdec_xan_wc3";
-    case AV_CODEC_ID_XAN_WC4:
-      return "avdec_xan_wc4";
-    case AV_CODEC_ID_XBIN:
-      return "avdec_xbin";
-    case AV_CODEC_ID_XBM:
-      return "avdec_xbm";
-    case AV_CODEC_ID_XFACE:
-      return "avdec_xface";
-      // case AV_CODEC_ID_XL:
-      //   return "avdec_xl";
-    case AV_CODEC_ID_XPM:
-      return "avdec_xpm";
-    case AV_CODEC_ID_XWD:
-      return "avdec_xwd";
-    case AV_CODEC_ID_YLC:
-      return "avdec_ylc";
-    case AV_CODEC_ID_YOP:
-      return "avdec_yop";
-    case AV_CODEC_ID_ZEROCODEC:
-      return "avdec_zerocodec";
-    case AV_CODEC_ID_ZMBV:
-      return "avdec_zmbv";
-    default:
-      SPDLOG_ERROR("not supported");
-      return "";
-  }
 }
 
 }  // namespace video_player_linux

--- a/plugins/video_player_linux/video_player_plugin.h
+++ b/plugins/video_player_linux/video_player_plugin.h
@@ -20,10 +20,6 @@
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar_homescreen.h>
 
-extern "C" {
-#include <libavformat/avformat.h>
-}
-
 #include "flutter_desktop_plugin_registrar.h"
 #include "messages.g.h"
 #include "video_player.h"
@@ -68,43 +64,10 @@ class VideoPlayerPlugin final : public flutter::Plugin, public VideoPlayerApi {
 
   flutter::PluginRegistrarDesktop* registrar_{};
 
-  /**
-   * @brief Get video info
-   * @param[in] url URL of the stream
-   * @param[out] width Buffer to store width info
-   * @param[out] height Buffer to store height info
-   * @param[out] duration Buffer to store duration info
-   * @param[out] codec_id Buffer to store codec info
-   * @return bool
-   * @retval true Normal end
-   * @retval false Abnormal end
-   * @relation
-   * flutter
-   */
-  static bool get_video_info(const char* url,
-                             int& width,
-                             int& height,
-                             gint64& duration,
-                             AVCodecID& codec_id);
-
-  /**
-   * @brief Return GStreamer plugin for codec ID
-   * @param[in] codec_id Codec ID
-   * @return char*
-   * @retval GStreamer plugin
-   * @relation
-   * flutter
-   */
-  static const char* map_ffmpeg_plugin(AVCodecID codec_id);
-
-  /**
-   * @brief Find the best available decoder factory for a codec
-   * @param[in] codec_id FFmpeg codec ID
-   * @return GstElementFactory* or nullptr if none found
-   * @relation
-   * flutter
-   */
-  static GstElementFactory* find_decoder_factory(AVCodecID codec_id);
+  static bool discover_video_info(const char* url,
+                                  int& width,
+                                  int& height,
+                                  gint64& duration);
 };
 
 }  // namespace video_player_linux


### PR DESCRIPTION
Remove the manual decoder selection pipeline that used FFmpeg (libavformat) to probe streams, mapped ~400 codec IDs to GStreamer element names, an manually created decoder elements. Replace with GStreamer's native GstDiscoverer API for metadata extraction and let playbin's built-in decodebin handle decoder selection automatically.

This eliminates the FFmpeg runtime dependency (libavformat, libavutil), adds gstreamer-pbutils-1.0, and reduces the plugin by ~540 lines.

Changes:
- Replace get_video_info() FFmpeg probing with discover_video_info() using GstDiscoverer
- Delete map_ffmpeg_plugin() (~400-line codec switch) and find_decoder_factory() (manual HW decoder table)
- Simplify video-sink pipeline from decoder!videoconvert!videoscale!fakesink to videoconvert!videoscale!fakesink with ghost pad on videoconvert
- Remove decoder_ member, decoder_factory constructor paramete
- Replace AV_TIME_BASE with GST_MSECOND for time unit conversions
- Fix duration unit in SendInitialized (now correctly converts nanoseconds to milliseconds)
- Update CMakeLists.txt: remove libavformat/libavutil, add gstreamer-pbutils-1.0

fix reliability issues from security audit
- Fix race condition: move is_initialized_ = true after prepare() so
  handoff rejects frames before video info is set, preventing
  gst_video_frame_map format mismatch assertion failures
- Fix race condition: move info_.finfo and shader_ null checks inside
  gst_mutex_ lock in handoff_handler
- Guard Dispose against null members from partial construction failures,
  set m_valid = false on element creation failures
- Fix GstBus reference leak: add gst_object_unref(bus_) in Dispose
- Fix GstCaps reference leak: add gst_caps_unref(caps) in prepare()
- Fix OnTag memory leaks: check gst_tag_list_get_string return value,
  g_free allocated strings
- Remove erroneous gst_object_unref(bus) in OnBusMessage error handler
- Initialize GstVideoInfo with gst_video_info_init() in constructor
- Validate video dimensions (positive, <= 16384) in Create and constructor
- Add connection speed upper bound check (INT_MAX)
- Initialize all local variables (pos, start, stop, tag values)
- Add GstDiscoverer type check with GST_IS_DISCOVERER_VIDEO_INFO
- Remove dead GL code block (glTexImage2D with no texture bound)
- Value-initialize Shader member variables