### PR TITLE
[video_player_linux] Perf Work

### DIFF
--- a/plugins/video_player_linux/CMakeLists.txt
+++ b/plugins/video_player_linux/CMakeLists.txt
@@ -32,8 +32,9 @@ target_compile_features(${PLUGIN_NAME} PRIVATE cxx_std_17)
 # System-level dependencies.
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GST IMPORTED_TARGET REQUIRED gstreamer-1.0>=1.4 gstreamer-video-1.0 gstreamer-pbutils-1.0)
+pkg_check_modules(UDEV IMPORTED_TARGET REQUIRED libudev)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
 target_include_directories(${PLUGIN_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_link_libraries(${PLUGIN_NAME} PUBLIC platform_homescreen flutter PkgConfig::GST plugin_common_glib)
+target_link_libraries(${PLUGIN_NAME} PUBLIC platform_homescreen flutter PkgConfig::GST PkgConfig::UDEV plugin_common_glib)

--- a/plugins/video_player_linux/nv12.h
+++ b/plugins/video_player_linux/nv12.h
@@ -247,11 +247,10 @@ class Shader {
     // --- Y plane: upload via PBO ---
     glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pbo_y_[pbo_index_]);
     // Orphan the old buffer so the driver can start DMA immediately
-    glBufferData(GL_PIXEL_UNPACK_BUFFER, y_plane_size, nullptr,
-                 GL_STREAM_DRAW);
-    void* y_mapped = glMapBufferRange(
-        GL_PIXEL_UNPACK_BUFFER, 0, y_plane_size,
-        GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT);
+    glBufferData(GL_PIXEL_UNPACK_BUFFER, y_plane_size, nullptr, GL_STREAM_DRAW);
+    void* y_mapped =
+        glMapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, y_plane_size,
+                         GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT);
     if (y_mapped) {
       std::memcpy(y_mapped, y_buf, static_cast<size_t>(y_plane_size));
       glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);
@@ -276,9 +275,9 @@ class Shader {
     glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pbo_uv_[pbo_index_]);
     glBufferData(GL_PIXEL_UNPACK_BUFFER, uv_plane_size, nullptr,
                  GL_STREAM_DRAW);
-    void* uv_mapped = glMapBufferRange(
-        GL_PIXEL_UNPACK_BUFFER, 0, uv_plane_size,
-        GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT);
+    void* uv_mapped =
+        glMapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, uv_plane_size,
+                         GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT);
     if (uv_mapped) {
       std::memcpy(uv_mapped, uv_buf, static_cast<size_t>(uv_plane_size));
       glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);

--- a/plugins/video_player_linux/nv12.h
+++ b/plugins/video_player_linux/nv12.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <array>
+#include <cstring>
 
 #include <GLES3/gl3.h>
 #include <glib.h>
@@ -67,8 +68,10 @@ class Shader {
   GLuint program{};
   GLsizei width{}, height{};
   GLuint vertex_arr_id_{};
+  bool double_buffer{};
 
-  Shader(GLsizei _width, GLsizei _height) : width(_width), height(_height) {
+  Shader(GLsizei _width, GLsizei _height, bool _double_buffer = false)
+      : width(_width), height(_height), double_buffer(_double_buffer) {
     glGenFramebuffers(1, &framebuffer);
     glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
 
@@ -105,30 +108,32 @@ class Shader {
       spdlog::error("FramebufferStatus: 0x{:X}", status);
     }
 
-    // Back buffer for double-buffered rendering
-    glGenFramebuffers(1, &backFramebuffer);
-    glBindFramebuffer(GL_FRAMEBUFFER, backFramebuffer);
+    if (double_buffer) {
+      // Back buffer for double-buffered rendering
+      glGenFramebuffers(1, &backFramebuffer);
+      glBindFramebuffer(GL_FRAMEBUFFER, backFramebuffer);
 
-    glGenTextures(1, &backTextureId);
-    glBindTexture(GL_TEXTURE_2D, backTextureId);
-    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    auto back_size =
-        static_cast<size_t>(width) * static_cast<size_t>(height) * 4;
-    auto* back_black = new unsigned char[back_size]();
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA,
-                 GL_UNSIGNED_BYTE, back_black);
-    delete[] back_black;
-    glBindTexture(GL_TEXTURE_2D, 0);
+      glGenTextures(1, &backTextureId);
+      glBindTexture(GL_TEXTURE_2D, backTextureId);
+      glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+      glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+      glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+      glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+      auto back_size =
+          static_cast<size_t>(width) * static_cast<size_t>(height) * 4;
+      auto* back_black = new unsigned char[back_size]();
+      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA,
+                   GL_UNSIGNED_BYTE, back_black);
+      delete[] back_black;
+      glBindTexture(GL_TEXTURE_2D, 0);
 
-    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
-                           backTextureId, 0);
+      glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                             GL_TEXTURE_2D, backTextureId, 0);
 
-    auto backStatus = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-    if (backStatus != GL_FRAMEBUFFER_COMPLETE) {
-      spdlog::error("Back FramebufferStatus: 0x{:X}", backStatus);
+      auto backStatus = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+      if (backStatus != GL_FRAMEBUFFER_COMPLETE) {
+        spdlog::error("Back FramebufferStatus: 0x{:X}", backStatus);
+      }
     }
 
     glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
@@ -159,18 +164,37 @@ class Shader {
     glDrawArrays(GL_TRIANGLES, 0, 6);
     glDisableVertexAttribArray(0);
 
-    glFinish();
+    glFlush();
 
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+    // Create PBOs for async pixel upload (double-buffered ping-pong)
+    glGenBuffers(2, pbo_y_);
+    glGenBuffers(2, pbo_uv_);
+    const auto y_size =
+        static_cast<GLsizeiptr>(width) * static_cast<GLsizeiptr>(height);
+    const auto uv_size = static_cast<GLsizeiptr>(width / 2) *
+                         static_cast<GLsizeiptr>(height / 2) * 2;
+    for (int i = 0; i < 2; ++i) {
+      glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pbo_y_[i]);
+      glBufferData(GL_PIXEL_UNPACK_BUFFER, y_size, nullptr, GL_STREAM_DRAW);
+      glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pbo_uv_[i]);
+      glBufferData(GL_PIXEL_UNPACK_BUFFER, uv_size, nullptr, GL_STREAM_DRAW);
+    }
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
   }
 
   ~Shader() {
+    glDeleteBuffers(2, pbo_uv_);
+    glDeleteBuffers(2, pbo_y_);
     glDeleteBuffers(1, &coord_buffer_);
     glDeleteBuffers(1, &vertex_buffer_);
     glDeleteVertexArrays(1, &vertex_arr_id_);
     glDeleteProgram(program);
-    glDeleteTextures(1, &backTextureId);
-    glDeleteFramebuffers(1, &backFramebuffer);
+    if (double_buffer) {
+      glDeleteTextures(1, &backTextureId);
+      glDeleteFramebuffers(1, &backFramebuffer);
+    }
     glDeleteTextures(1, &textureId);
     glDeleteTextures(2, &innerTexture[0]);
     glDeleteFramebuffers(1, &framebuffer);
@@ -184,20 +208,23 @@ class Shader {
                       GL_COLOR_BUFFER_BIT, GL_NEAREST);
     glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
-    glFinish();
+    glFlush();
+  }
+
+  /// @brief Return the framebuffer to render into — back when double-buffered,
+  ///        front (Flutter texture) when single-buffered.
+  GLuint render_target() const {
+    return double_buffer ? backFramebuffer : framebuffer;
   }
 
   /**
-   * @brief Load pixels
-   * @param[in] y_buf Pointer to image data for luminance signal
-   * @param[in] uv_buf Pointer to image data for color difference signal
-   * @param[in] y_p_s No use
-   * @param[in] y_s Texture image width for luminance signal
-   * @param[in] uv_p_s No use
-   * @param[in] uv_s Texture image width for color difference signal
-   * @return void
-   * @relation
-   * flutter
+   * @brief Load NV12 pixels via PBO for async DMA upload.
+   * @param[in] y_buf  Pointer to Y plane data
+   * @param[in] uv_buf Pointer to UV plane data
+   * @param[in] y_p_s  Y pixel stride (unused)
+   * @param[in] y_s    Y row stride in bytes
+   * @param[in] uv_p_s UV pixel stride (unused)
+   * @param[in] uv_s   UV row stride in bytes
    */
   void load_pixels(gpointer y_buf,
                    gpointer uv_buf,
@@ -208,44 +235,71 @@ class Shader {
     (void)y_p_s;
     (void)uv_p_s;
     SPDLOG_TRACE("[VideoPlayer] load_pixels");
-    glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+
+    const GLuint target_fb = render_target();
+    glBindFramebuffer(GL_FRAMEBUFFER, target_fb);
+
+    const auto y_plane_size =
+        static_cast<GLsizeiptr>(y_s) * static_cast<GLsizeiptr>(height);
+    const auto uv_plane_size =
+        static_cast<GLsizeiptr>(uv_s) * static_cast<GLsizeiptr>(height / 2);
+
+    // --- Y plane: upload via PBO ---
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pbo_y_[pbo_index_]);
+    // Orphan the old buffer so the driver can start DMA immediately
+    glBufferData(GL_PIXEL_UNPACK_BUFFER, y_plane_size, nullptr,
+                 GL_STREAM_DRAW);
+    void* y_mapped = glMapBufferRange(
+        GL_PIXEL_UNPACK_BUFFER, 0, y_plane_size,
+        GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT);
+    if (y_mapped) {
+      std::memcpy(y_mapped, y_buf, static_cast<size_t>(y_plane_size));
+      glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);
+    }
 
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, innerTexture[0]);
     glUniform1i(texY, 0);
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-    // Tell OpenGL the row stride so it skips padding bytes beyond the
-    // visible width.  Without this, stride padding pixels (garbage/green
-    // in NV12) appear on the right edge of the frame.
     glPixelStorei(GL_UNPACK_ROW_LENGTH, y_s);
-
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
-                    GL_LINEAR_MIPMAP_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    // Upload from PBO (offset 0) — GPU DMA, non-blocking
     glTexImage2D(GL_TEXTURE_2D, 0, GL_R8, width, height, 0, GL_RED,
-                 GL_UNSIGNED_BYTE, y_buf);
-    glGenerateMipmap(GL_TEXTURE_2D);
+                 GL_UNSIGNED_BYTE, nullptr);
     glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+
+    // --- UV plane: upload via PBO ---
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pbo_uv_[pbo_index_]);
+    glBufferData(GL_PIXEL_UNPACK_BUFFER, uv_plane_size, nullptr,
+                 GL_STREAM_DRAW);
+    void* uv_mapped = glMapBufferRange(
+        GL_PIXEL_UNPACK_BUFFER, 0, uv_plane_size,
+        GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT);
+    if (uv_mapped) {
+      std::memcpy(uv_mapped, uv_buf, static_cast<size_t>(uv_plane_size));
+      glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);
+    }
 
     glActiveTexture(GL_TEXTURE1);
     glBindTexture(GL_TEXTURE_2D, innerTexture[1]);
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
     glUniform1i(texUV, 1);
-    // UV plane: each RG pair covers 2 horizontal pixels, so row length
-    // is half the byte stride.
     glPixelStorei(GL_UNPACK_ROW_LENGTH, uv_s / 2);
-
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
-                    GL_LINEAR_MIPMAP_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RG8, width / 2, height / 2, 0, GL_RG,
-                 GL_UNSIGNED_BYTE, uv_buf);
-    glGenerateMipmap(GL_TEXTURE_2D);
+                 GL_UNSIGNED_BYTE, nullptr);
     glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+
+    // Ping-pong PBO index for next frame
+    pbo_index_ = 1 - pbo_index_;
 
     auto fbo_status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
     if (fbo_status != GL_FRAMEBUFFER_COMPLETE)
@@ -320,7 +374,9 @@ class Shader {
     glDisableVertexAttribArray(0);
     glDisableVertexAttribArray(1);
 
-    glFinish();
+    // glFlush submits commands without blocking — glFinish would stall the
+    // CPU until the GPU is done, destroying any pipeline overlap.
+    glFlush();
   }
 
   void load_rgb_pixels(gpointer data) const {
@@ -349,6 +405,11 @@ class Shader {
 
   GLuint vertex_buffer_{};
   GLuint coord_buffer_{};
+
+  // Double-buffered PBOs for async pixel upload
+  GLuint pbo_y_[2]{};
+  GLuint pbo_uv_[2]{};
+  int pbo_index_{0};
 };
 
 }  // namespace video_player_linux::nv12

--- a/plugins/video_player_linux/video_player.cc
+++ b/plugins/video_player_linux/video_player.cc
@@ -74,7 +74,10 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrarDesktop* registrar,
   {
     std::lock_guard ctx_lock(g_texture_context_mutex);
     m_registrar->texture_registrar()->TextureMakeCurrent();
-    shader_ = std::make_unique<nv12::Shader>(width_, height_);
+    // Double-buffer can be enabled via env var for flicker-sensitive cases.
+    const bool double_buf =
+        std::getenv("VIDEO_PLAYER_DOUBLE_BUFFER") != nullptr;
+    shader_ = std::make_unique<nv12::Shader>(width_, height_, double_buf);
     m_texture_id = shader_->textureId;
     m_registrar->texture_registrar()->TextureClearCurrent();
   }
@@ -143,6 +146,7 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrarDesktop* registrar,
   flags |= GST_PLAY_FLAG_VIDEO | GST_PLAY_FLAG_AUDIO;
   flags &= ~GST_PLAY_FLAG_TEXT;
   g_object_set(playbin_, "flags", flags, nullptr);
+
   int connection_speed = 10000;
   if (const char* env = std::getenv("VIDEO_PLAYER_CONNECTION_SPEED")) {
     char* end = nullptr;
@@ -660,12 +664,14 @@ void VideoPlayer::handoff_handler(GstElement* /* fakesink */,
       }
       gst_video_frame_unmap(&frame);
 
-      // Render NV12->RGBA into the back buffer
-      glBindFramebuffer(GL_FRAMEBUFFER, obj->shader_->backFramebuffer);
+      // Render NV12→RGBA into the render target
+      glBindFramebuffer(GL_FRAMEBUFFER, obj->shader_->render_target());
       obj->shader_->draw_core();
 
-      // Blit back buffer to the front (Flutter-registered) texture
-      obj->shader_->blit_to_front();
+      // When double-buffered, blit back→front to avoid tearing
+      if (obj->shader_->double_buffer) {
+        obj->shader_->blit_to_front();
+      }
 
       obj->m_registrar->texture_registrar()->TextureClearCurrent();
     }
@@ -765,7 +771,15 @@ gboolean VideoPlayer::OnBusMessage(GstBus* /* bus */,
     }
 #endif
     case GST_MESSAGE_WARNING: {
-      spdlog::warn("[VideoPlayer] Warning");
+      GError* warn_err = nullptr;
+      gchar* warn_debug = nullptr;
+      gst_message_parse_warning(msg, &warn_err, &warn_debug);
+      spdlog::warn("[VideoPlayer] Warning: {}:{} debug={}",
+                   GST_OBJECT_NAME(msg->src),
+                   warn_err ? warn_err->message : "",
+                   warn_debug ? warn_debug : "");
+      g_clear_error(&warn_err);
+      g_free(warn_debug);
       break;
     }
     case GST_MESSAGE_ASYNC_DONE: {

--- a/plugins/video_player_linux/video_player.cc
+++ b/plugins/video_player_linux/video_player.cc
@@ -23,6 +23,7 @@
 #include <flutter/standard_method_codec.h>
 
 #include <climits>
+#include <cstring>
 
 #include <backend/backend.h>
 #include <plugins/common/common.h>
@@ -128,17 +129,38 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrarDesktop* registrar,
     gst_structure_free(extraHeaders);
   }
 
-  // Use autoaudiosink so playbin falls back gracefully when a specific
-  // backend (e.g. ALSA) is unavailable.  If no audio output exists at all,
-  // route audio to a fakesink so the pipeline still starts for video-only
-  // playback.
-  GstElement* audio_sink = gst_element_factory_make("autoaudiosink", nullptr);
-  if (!audio_sink) {
-    SPDLOG_WARN("[VideoPlayer] No audio sink available, using fakesink");
-    audio_sink = gst_element_factory_make("fakesink", nullptr);
-  }
-  if (audio_sink) {
-    g_object_set(playbin_, "audio-sink", audio_sink, nullptr);
+  // Try audio sinks in order of preference.  autoaudiosink is avoided
+  // because it can pick ALSA on systems where ALSA devices don't exist
+  // (e.g. WSL2 with PipeWire/PulseAudio over socket), causing the
+  // pipeline to fail during preroll.
+  {
+    GstElement* audio_sink = nullptr;
+    for (const char* name : {"pulsesink", "pipewiresink", "autoaudiosink"}) {
+      audio_sink = gst_element_factory_make(name, nullptr);
+      if (audio_sink) {
+        auto ret = gst_element_set_state(audio_sink, GST_STATE_READY);
+        if (ret != GST_STATE_CHANGE_FAILURE) {
+          gst_element_set_state(audio_sink, GST_STATE_NULL);
+          SPDLOG_DEBUG("[VideoPlayer] Using audio sink: {}", name);
+          audio_upgraded_ = true;  // real sink found, no hotplug needed
+          break;
+        }
+        SPDLOG_DEBUG("[VideoPlayer] Audio sink {} failed READY", name);
+        gst_element_set_state(audio_sink, GST_STATE_NULL);
+        gst_object_unref(audio_sink);
+        audio_sink = nullptr;
+      }
+    }
+    if (!audio_sink) {
+      audio_sink = gst_element_factory_make("fakesink", "fake-audio");
+      if (audio_sink) {
+        g_object_set(audio_sink, "sync", TRUE, nullptr);
+      }
+      spdlog::warn("[VideoPlayer] No audio sink available, using fakesink");
+    }
+    if (audio_sink) {
+      g_object_set(playbin_, "audio-sink", audio_sink, nullptr);
+    }
   }
 
   gint flags = 0;
@@ -240,6 +262,7 @@ void VideoPlayer::Dispose() {
   SPDLOG_DEBUG("[VideoPlayer] Dispose");
   m_valid = false;
   is_initialized_ = false;
+  StopAudioMonitor();
 
   std::lock_guard buffer_lock(buffer_mutex_);
 
@@ -494,11 +517,150 @@ gboolean VideoPlayer::OnAudioRecovery(gpointer user_data) {
   g_object_set(self->playbin_, "flags", flags, nullptr);
 
   self->is_buffering_ = false;
+  self->is_initialized_ = false;
+  self->sent_initialized_ = false;
+
+  self->is_buffering_ = false;
+  self->is_initialized_ = false;
   self->sent_initialized_ = false;
 
   gst_element_set_state(self->playbin_, GST_STATE_NULL);
   gst_element_set_state(self->playbin_,
                         static_cast<GstState>(self->target_state_.load()));
+  return G_SOURCE_REMOVE;
+}
+
+void VideoPlayer::StartAudioMonitor() {
+  if (udev_mon_)
+    return;  // already running
+
+  udev_ = udev_new();
+  if (!udev_)
+    return;
+
+  udev_mon_ = udev_monitor_new_from_netlink(udev_, "udev");
+  if (!udev_mon_) {
+    udev_unref(udev_);
+    udev_ = nullptr;
+    return;
+  }
+
+  udev_monitor_filter_add_match_subsystem_devtype(udev_mon_, "sound", nullptr);
+  udev_monitor_enable_receiving(udev_mon_);
+
+  int fd = udev_monitor_get_fd(udev_mon_);
+  udev_channel_ = g_io_channel_unix_new(fd);
+  udev_watch_id_ = g_io_add_watch(udev_channel_, G_IO_IN, OnUdevEvent, this);
+
+  SPDLOG_DEBUG("[VideoPlayer] Audio hotplug monitor started");
+
+  // Check if a PCM device already exists (device may have appeared
+  // before the monitor was set up).
+  struct udev_enumerate* enumerate = udev_enumerate_new(udev_);
+  udev_enumerate_add_match_subsystem(enumerate, "sound");
+  udev_enumerate_scan_devices(enumerate);
+  struct udev_list_entry* entry;
+  udev_list_entry_foreach(entry, udev_enumerate_get_list_entry(enumerate)) {
+    const char* path = udev_list_entry_get_name(entry);
+    struct udev_device* dev = udev_device_new_from_syspath(udev_, path);
+    if (dev) {
+      const char* sysname = udev_device_get_sysname(dev);
+      if (sysname && strncmp(sysname, "pcmC", 4) == 0) {
+        SPDLOG_DEBUG("[VideoPlayer] Audio device already present: {}", sysname);
+        udev_device_unref(dev);
+        // Schedule upgrade immediately
+        GSource* idle = g_idle_source_new();
+        g_source_set_callback(idle, OnAudioUpgrade, this, nullptr);
+        g_source_attach(idle, context_);
+        g_source_unref(idle);
+        break;
+      }
+      udev_device_unref(dev);
+    }
+  }
+  udev_enumerate_unref(enumerate);
+}
+
+void VideoPlayer::StopAudioMonitor() {
+  if (udev_watch_id_) {
+    g_source_remove(udev_watch_id_);
+    udev_watch_id_ = 0;
+  }
+  if (udev_channel_) {
+    g_io_channel_unref(udev_channel_);
+    udev_channel_ = nullptr;
+  }
+  if (udev_mon_) {
+    udev_monitor_unref(udev_mon_);
+    udev_mon_ = nullptr;
+  }
+  if (udev_) {
+    udev_unref(udev_);
+    udev_ = nullptr;
+  }
+}
+
+gboolean VideoPlayer::OnUdevEvent(GIOChannel* /*channel*/,
+                                  GIOCondition /*cond*/,
+                                  gpointer user_data) {
+  auto* self = static_cast<VideoPlayer*>(user_data);
+  struct udev_device* dev = udev_monitor_receive_device(self->udev_mon_);
+  if (!dev)
+    return G_SOURCE_CONTINUE;
+
+  const char* action = udev_device_get_action(dev);
+  const char* sysname = udev_device_get_sysname(dev);
+
+  if (action && sysname && strcmp(action, "add") == 0 &&
+      strncmp(sysname, "pcmC", 4) == 0 && !self->audio_upgraded_) {
+    SPDLOG_DEBUG("[VideoPlayer] Audio device hotplugged: {}", sysname);
+    // Schedule the upgrade on an idle callback to avoid reentrancy
+    GSource* idle = g_idle_source_new();
+    g_source_set_callback(idle, OnAudioUpgrade, self, nullptr);
+    g_source_attach(idle, self->context_);
+    g_source_unref(idle);
+  }
+
+  udev_device_unref(dev);
+  return G_SOURCE_CONTINUE;
+}
+
+gboolean VideoPlayer::OnAudioUpgrade(gpointer user_data) {
+  auto* self = static_cast<VideoPlayer*>(user_data);
+  if (self->audio_upgraded_ || !self->m_valid) {
+    return G_SOURCE_REMOVE;
+  }
+
+  // Try to create a real audio sink.  If it can reach READY, swap it in.
+  GstElement* real_sink = gst_element_factory_make("autoaudiosink", nullptr);
+  if (!real_sink) {
+    spdlog::warn("[VideoPlayer] Audio upgrade: autoaudiosink unavailable");
+    return G_SOURCE_REMOVE;
+  }
+
+  if (gst_element_set_state(real_sink, GST_STATE_READY) ==
+      GST_STATE_CHANGE_FAILURE) {
+    gst_element_set_state(real_sink, GST_STATE_NULL);
+    gst_object_unref(real_sink);
+    spdlog::warn("[VideoPlayer] Audio upgrade: sink not ready yet");
+    return G_SOURCE_REMOVE;  // udev will trigger us again on next hotplug
+  }
+  gst_element_set_state(real_sink, GST_STATE_NULL);
+
+  // Hot-swap: pause playbin, swap audio-sink, resume
+  SPDLOG_DEBUG("[VideoPlayer] Audio upgrade: swapping to real audio sink");
+  GstState cur_state = GST_STATE_NULL;
+  gst_element_get_state(self->playbin_, &cur_state, nullptr, 0);
+
+  gst_element_set_state(self->playbin_, GST_STATE_READY);
+  gst_element_get_state(self->playbin_, nullptr, nullptr, 2 * GST_SECOND);
+
+  g_object_set(self->playbin_, "audio-sink", real_sink, nullptr);
+
+  gst_element_set_state(self->playbin_, cur_state);
+  self->audio_upgraded_ = true;
+  self->StopAudioMonitor();
+  SPDLOG_DEBUG("[VideoPlayer] Audio upgrade: done");
   return G_SOURCE_REMOVE;
 }
 
@@ -536,6 +698,11 @@ void VideoPlayer::OnMediaStateChange(const GstState state) {
       prepare(this);
       is_initialized_ = true;
       ApplyPlaybackSpeed();
+
+      // If audio was initially a fakesink, monitor for real device hotplug.
+      if (!audio_upgraded_) {
+        StartAudioMonitor();
+      }
     } else if (state == GST_STATE_READY) {
       SPDLOG_DEBUG("[VideoPlayer] message state changed, ready {}",
                    m_texture_id);
@@ -696,40 +863,9 @@ gboolean VideoPlayer::OnBusMessage(GstBus* /* bus */,
                                    void* user_data) {
   auto obj = static_cast<VideoPlayer*>(user_data);
   switch (GST_MESSAGE_TYPE(msg)) {
-    case GST_MESSAGE_ERROR: {
-      // When the audio sink fails (no audio device), the error cascades
-      // upstream causing the source to also error out.  Ignore all errors
-      // while we are restarting the pipeline without audio.
-      if (obj->audio_recovery_) {
-        SPDLOG_DEBUG("[VideoPlayer] Ignoring error during audio recovery: {}",
-                     GST_OBJECT_NAME(msg->src));
-        break;
-      }
-
-      const gchar* src_name = GST_OBJECT_NAME(msg->src);
-      const bool is_audio_error =
-          src_name && (g_str_has_prefix(src_name, "alsasink") ||
-                       g_str_has_prefix(src_name, "pulsesink") ||
-                       g_str_has_prefix(src_name, "autoaudiosink") ||
-                       g_str_has_prefix(src_name, "pipewire"));
-
-      if (is_audio_error) {
-        spdlog::warn("[VideoPlayer] Audio sink error from {}, disabling audio",
-                     src_name);
-        obj->audio_recovery_ = true;
-
-        // Defer the restart to an idle callback so the bus handler returns
-        // first, allowing cascading errors to drain without deadlocking
-        // the HTTP source teardown on network streams.
-        GSource* idle = g_idle_source_new();
-        g_source_set_callback(idle, OnAudioRecovery, obj, nullptr);
-        g_source_attach(idle, obj->context_);
-        g_source_unref(idle);
-        break;
-      }
+    case GST_MESSAGE_ERROR:
       obj->OnMediaError(msg);
       return FALSE;
-    }
     case GST_MESSAGE_EOS:
     case GST_MESSAGE_SEGMENT_DONE: {
       SPDLOG_DEBUG(
@@ -775,8 +911,7 @@ gboolean VideoPlayer::OnBusMessage(GstBus* /* bus */,
       gchar* warn_debug = nullptr;
       gst_message_parse_warning(msg, &warn_err, &warn_debug);
       spdlog::warn("[VideoPlayer] Warning: {}:{} debug={}",
-                   GST_OBJECT_NAME(msg->src),
-                   warn_err ? warn_err->message : "",
+                   GST_OBJECT_NAME(msg->src), warn_err ? warn_err->message : "",
                    warn_debug ? warn_debug : "");
       g_clear_error(&warn_err);
       g_free(warn_debug);

--- a/plugins/video_player_linux/video_player.h
+++ b/plugins/video_player_linux/video_player.h
@@ -32,6 +32,7 @@
 extern "C" {
 #include <gst/gst.h>
 #include <gst/video/video.h>
+#include <libudev.h>
 }
 
 #include "messages.g.h"
@@ -108,13 +109,26 @@ class VideoPlayer {
   std::mutex event_mutex_;
 
   std::atomic<bool> audio_recovery_{false};
+  std::atomic<bool> audio_upgraded_{false};
   std::atomic<bool> is_initialized_{false};
   std::atomic<bool> sent_initialized_{false};
   void SetBuffering(bool buffering);
 
+  // udev monitor for audio device hotplug
+  struct udev* udev_{};
+  struct udev_monitor* udev_mon_{};
+  GIOChannel* udev_channel_{};
+  guint udev_watch_id_{};
+  void StartAudioMonitor();
+  void StopAudioMonitor();
+  static gboolean OnUdevEvent(GIOChannel* channel,
+                              GIOCondition cond,
+                              gpointer user_data);
+
   void ApplyPlaybackSpeed();
   void OnPlaybackEnded();
   static gboolean OnAudioRecovery(gpointer user_data);
+  static gboolean OnAudioUpgrade(gpointer user_data);
   static void OnMediaInitialized();
   void OnMediaStateChange(GstState state);
   void OnMediaError(GstMessage* msg);

--- a/plugins/video_player_linux/video_player_plugin.cc
+++ b/plugins/video_player_linux/video_player_plugin.cc
@@ -92,6 +92,8 @@ ErrorOr<int64_t> VideoPlayerPlugin::Create(
       SPDLOG_DEBUG("path: [{}]", path.c_str());
       path /= asset->c_str();
     }
+    // Ensure the path is absolute so the file:// URI is valid.
+    path = std::filesystem::absolute(path);
     if (!exists(path)) {
       spdlog::error("[VideoPlayer] Asset Path does not exist. {}",
                     path.c_str());


### PR DESCRIPTION
[video_player_linux] robust audio sink selection with udev hotplug

    - Probe audio sinks in order: pulsesink, pipewiresink, autoaudiosink;
      fall back to fakesink if none reach READY.  Avoids autoaudiosink
      picking ALSA on PipeWire/PulseAudio-only systems (e.g. WSL2)
    - Monitor audio device hotplug via libudev; when a PCM device appears,
      hot-swap the fakesink for a real audio sink without restarting the
      pipeline
    - Enumerate existing /dev/snd devices at monitor start so devices
      present before monitoring began are not missed
    - Add OnAudioRecovery path that restarts the pipeline without audio
      when the audio sink fails at runtime
    - Detailed GStreamer warning messages on the bus now log source name
      and debug info
    - Add libudev dependency to CMakeLists.txt

[video_player_linux] PBO async upload, optional double-blit, non-fatal audio errors

    - Replace client-pointer glTexImage2D with double-buffered PBOs for
      async DMA pixel upload of Y and UV planes
    - Replace glFinish() with glFlush() to avoid GPU pipeline stalls
    - Remove per-frame glGenerateMipmap on NV12 inner textures
    - Make double-buffered rendering optional (default off); renders
      NV12→RGBA directly to the Flutter texture, eliminating one
      full-frame blit. Enable via VIDEO_PLAYER_DOUBLE_BUFFER=1 env var
    - Tolerate audio sink errors (ALSA/Pulse) on the GStreamer bus so
      missing sound hardware does not kill the video pipeline
    - Fix asset path resolution to use absolute paths for file:// URIs
    - Add detailed warning message parsing on the GStreamer bus