### PR TITLE
video_player_linux: Fix compiler error

### DIFF
--- a/plugins/video_player_linux/video_player.cc
+++ b/plugins/video_player_linux/video_player.cc
@@ -1432,7 +1432,7 @@ GstElement* VideoPlayer::BuildAudioSinkBin() {
   gst_object_unref(pad);
 
   SPDLOG_DEBUG("[VideoPlayer] Built audio sink bin (sink={}, channels={})",
-               sink_name, output_channels_);
+               picked, output_channels_);
   return bin;
 }
 


### PR DESCRIPTION
An incorrect old variable name was used in a debug log. Changed to the picked audio sink name.