### PR TITLE
migrate to ICompositorSurface

### DIFF
--- a/plugins/layer_playground_view/CMakeLists.txt
+++ b/plugins/layer_playground_view/CMakeLists.txt
@@ -1,16 +1,12 @@
 include_guard()
 
-pkg_check_modules(WAYLAND_EGL REQUIRED IMPORTED_TARGET wayland-egl)
+# The plugin renders into an FBO using the engine's GL context — no
+# per-plugin EGL context, no Wayland subsurface. The compositor composites
+# the resulting texture onto the scene at the layer rect.
 
 add_library(plugin_layer_playground_view STATIC
         layer_playground_view_plugin.cc
         layer_playground_view_plugin_c_api.cc
-)
-
-target_compile_definitions(plugin_layer_playground_view PUBLIC
-        MESA_EGL_NO_X11_HEADERS
-        WL_EGL_PLATFORM
-        EGL_NO_X11
 )
 
 target_include_directories(plugin_layer_playground_view PUBLIC
@@ -21,7 +17,5 @@ target_include_directories(plugin_layer_playground_view PUBLIC
 target_link_libraries(plugin_layer_playground_view PUBLIC
         flutter
         platform_homescreen
-        PkgConfig::WAYLAND_EGL
         GLESv2
-        EGL
 )

--- a/plugins/layer_playground_view/include/layer_playground_view/layer_playground_view_plugin_c_api.h
+++ b/plugins/layer_playground_view/include/layer_playground_view/layer_playground_view_plugin_c_api.h
@@ -44,7 +44,7 @@ FLUTTER_PLUGIN_EXPORT void LayerPlaygroundPluginCApiRegisterWithRegistrar(
     double width,
     double height,
     const std::vector<uint8_t>& params,
-    std::string assetDirectory,
+    const std::string& assetDirectory,
     FlutterDesktopEngineRef engine,
     PlatformViewAddListener add_listener,
     PlatformViewRemoveListener remove_listener,

--- a/plugins/layer_playground_view/layer_playground_view_plugin.cc
+++ b/plugins/layer_playground_view/layer_playground_view_plugin.cc
@@ -36,14 +36,14 @@ void LayerPlaygroundViewPlugin::RegisterWithRegistrar(
     double width,
     double height,
     const std::vector<uint8_t>& params,
-    std::string assetDirectory,
+    const std::string& assetDirectory,
     FlutterDesktopEngineRef engine,
     PlatformViewAddListener addListener,
     PlatformViewRemoveListener removeListener,
     void* platform_view_context) {
   auto plugin = std::make_unique<LayerPlaygroundViewPlugin>(
       id, std::move(viewType), direction, top, left, width, height, params,
-      std::move(assetDirectory), engine, addListener, removeListener,
+      assetDirectory, engine, addListener, removeListener,
       platform_view_context);
   registrar->AddPlugin(std::move(plugin));
 }
@@ -57,7 +57,7 @@ LayerPlaygroundViewPlugin::LayerPlaygroundViewPlugin(
     double width,
     double height,
     const std::vector<uint8_t>& /* params */,
-    std::string /* assetDirectory */,
+    const std::string& /* assetDirectory */,
     FlutterDesktopEngineState* state,
     PlatformViewAddListener addListener,
     PlatformViewRemoveListener removeListener,
@@ -83,12 +83,18 @@ LayerPlaygroundViewPlugin::LayerPlaygroundViewPlugin(
   // fires — the engine's context isn't current here on the platform thread.
   if (state && state->view_controller && state->view_controller->view) {
     state->view_controller->view->RegisterCompositorSurface(
-        id_,
-        std::shared_ptr<ICompositorSurface>(this, [](ICompositorSurface*) {
+        id_, std::shared_ptr<ICompositorSurface>(this, [](ICompositorSurface*) {
           // Aliasing deleter: the plugin's lifetime is owned by the
           // PluginRegistrar, not by this shared_ptr. The compositor's
           // copy is dropped on UnregisterCompositorSurface.
         }));
+    SPDLOG_TRACE("[pv-trace] LayerPlaygroundView registered: id={} size={}x{}",
+                 id_, pending_width_.load(), pending_height_.load());
+  } else {
+    SPDLOG_TRACE(
+        "[pv-trace] LayerPlaygroundView could NOT register (state/view null): "
+        "id={}",
+        id_);
   }
 #else
   (void)state;
@@ -142,7 +148,8 @@ void LayerPlaygroundViewPlugin::on_touch(int32_t /* action */,
                                          const double* /* point_data */,
                                          void* /* data */) {}
 
-void LayerPlaygroundViewPlugin::on_dispose(bool /* hybrid */, void* /* data */) {
+void LayerPlaygroundViewPlugin::on_dispose(bool /* hybrid */,
+                                           void* /* data */) {
   // Compositor-owned shared_ptr drops via PlatformViewsHandler's
   // safety-net UnregisterCompositorSurface call. GL state is leaked
   // intentionally — destroying GL handles requires the engine's context
@@ -189,13 +196,42 @@ GLuint LoadShader(const GLchar* src, GLenum type) {
   return shader;
 }
 
+// Mirrors the simple_box_plugin Cairo pattern: a diagonal 3-stop gradient
+// (deep purple → warm coral → peach), a thin orange border, and a faint
+// 20-pixel white grid. Label text from the GTK variant is omitted — GLES2
+// font rendering would require a glyph atlas we don't want to pull in.
 constexpr GLchar kVertSrc[] =
-    "attribute vec4 vPosition;\n"
-    "void main() { gl_Position = vPosition; }\n";
+    "attribute vec2 aPosition;\n"
+    "varying vec2 vUv;\n"
+    "void main() {\n"
+    "  vUv = aPosition * 0.5 + 0.5;\n"
+    "  gl_Position = vec4(aPosition, 0.0, 1.0);\n"
+    "}\n";
 
 constexpr GLchar kFragSrc[] =
     "precision mediump float;\n"
-    "void main() { gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0); }\n";
+    "uniform vec2 uResolution;\n"
+    "varying vec2 vUv;\n"
+    "vec3 gradient(float t) {\n"
+    "  vec3 c0 = vec3(0.227, 0.110, 0.443);\n"  // #3A1C71
+    "  vec3 c1 = vec3(0.843, 0.427, 0.467);\n"  // #D76D77
+    "  vec3 c2 = vec3(1.000, 0.686, 0.482);\n"  // #FFAF7B
+    "  return t < 0.5 ? mix(c0, c1, t * 2.0) : mix(c1, c2, (t - 0.5) * 2.0);\n"
+    "}\n"
+    "void main() {\n"
+    "  vec2 px = vUv * uResolution;\n"
+    "  float t = clamp((vUv.x + vUv.y) * 0.5, 0.0, 1.0);\n"
+    "  vec3 color = gradient(t);\n"
+    "  vec2 d = min(px, uResolution - px);\n"
+    "  float edge = min(d.x, d.y);\n"
+    "  if (edge < 2.0) {\n"
+    "    color = mix(color, vec3(1.0, 0.65, 0.0), 0.9);\n"
+    "  }\n"
+    "  vec2 g = fract(px / 20.0) * 20.0;\n"
+    "  float grid = step(g.x, 1.0) + step(g.y, 1.0);\n"
+    "  color = mix(color, vec3(1.0), 0.12 * clamp(grid, 0.0, 1.0));\n"
+    "  gl_FragColor = vec4(color, 1.0);\n"
+    "}\n";
 
 }  // namespace
 
@@ -232,8 +268,7 @@ void LayerPlaygroundViewPlugin::EnsureGlState(int32_t w, int32_t h) {
   glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
                          color_texture_, 0);
   if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
-    spdlog::error(
-        "LayerPlaygroundViewPlugin: FBO incomplete at {}x{}", w, h);
+    spdlog::error("LayerPlaygroundViewPlugin: FBO incomplete at {}x{}", w, h);
   }
   glBindFramebuffer(GL_FRAMEBUFFER, 0);
   glBindTexture(GL_TEXTURE_2D, 0);
@@ -244,7 +279,7 @@ void LayerPlaygroundViewPlugin::EnsureGlState(int32_t w, int32_t h) {
     program_ = glCreateProgram();
     glAttachShader(program_, vs);
     glAttachShader(program_, fs);
-    glBindAttribLocation(program_, 0, "vPosition");
+    glBindAttribLocation(program_, 0, "aPosition");
     glLinkProgram(program_);
     glDeleteShader(vs);
     glDeleteShader(fs);
@@ -260,10 +295,26 @@ void LayerPlaygroundViewPlugin::EnsureGlState(int32_t w, int32_t h) {
       spdlog::error("LayerPlaygroundViewPlugin: program link failed: {}", log);
       glDeleteProgram(program_);
       program_ = 0;
+    } else {
+      u_resolution_loc_ = glGetUniformLocation(program_, "uResolution");
+      a_position_loc_ = glGetAttribLocation(program_, "aPosition");
     }
   }
 
-  gl_initialized_ = (program_ != 0);
+  // A VBO is required: under GLES3 the engine has a VAO bound, and
+  // client-side vertex arrays are invalid unless the default VAO (0) is
+  // current. A VBO works regardless of which VAO is bound.
+  if (!vbo_ && program_) {
+    static constexpr GLfloat kVerts[] = {
+        -1.0f, -1.0f, 1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f,
+    };
+    glGenBuffers(1, &vbo_);
+    glBindBuffer(GL_ARRAY_BUFFER, vbo_);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(kVerts), kVerts, GL_STATIC_DRAW);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+  }
+
+  gl_initialized_ = (program_ != 0 && vbo_ != 0);
 }
 
 void LayerPlaygroundViewPlugin::DestroyGlState() {
@@ -276,6 +327,10 @@ void LayerPlaygroundViewPlugin::DestroyGlState() {
     glDeleteFramebuffers(1, &framebuffer_);
     framebuffer_ = 0;
   }
+  if (vbo_) {
+    glDeleteBuffers(1, &vbo_);
+    vbo_ = 0;
+  }
   if (program_) {
     glDeleteProgram(program_);
     program_ = 0;
@@ -284,31 +339,73 @@ void LayerPlaygroundViewPlugin::DestroyGlState() {
 }
 
 void LayerPlaygroundViewPlugin::DrawFrame() const {
-  static constexpr GLfloat verts[] = {0.0f,  0.5f, 0.0f, -0.5f, -0.5f,
-                                      0.0f,  0.5f, -0.5f, 0.0f};
-
+  // Flutter's Skia backend leaves assorted GL state on: a bound VAO, depth
+  // test, scissor test, blend, colour/depth masks. Reset everything we care
+  // about so the draw lands in the FBO as expected.
   glBindFramebuffer(GL_FRAMEBUFFER, framebuffer_);
   glViewport(0, 0, tex_width_, tex_height_);
+
+  glDisable(GL_BLEND);
+  glDisable(GL_CULL_FACE);
+  glDisable(GL_DEPTH_TEST);
+  glDisable(GL_SCISSOR_TEST);
+  glDisable(GL_STENCIL_TEST);
+  glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+  glDepthMask(GL_FALSE);
+
   glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
   glClear(GL_COLOR_BUFFER_BIT);
   glUseProgram(program_);
-  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, verts);
-  glEnableVertexAttribArray(0);
-  glDrawArrays(GL_TRIANGLES, 0, 3);
-  glDisableVertexAttribArray(0);
+  if (u_resolution_loc_ >= 0) {
+    glUniform2f(u_resolution_loc_, static_cast<GLfloat>(tex_width_),
+                static_cast<GLfloat>(tex_height_));
+  }
+  glBindBuffer(GL_ARRAY_BUFFER, vbo_);
+  const GLuint loc =
+      a_position_loc_ >= 0 ? static_cast<GLuint>(a_position_loc_) : 0u;
+  glVertexAttribPointer(loc, 2, GL_FLOAT, GL_FALSE, 0, nullptr);
+  glEnableVertexAttribArray(loc);
+  glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+  glDisableVertexAttribArray(loc);
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
   glUseProgram(0);
   glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
 
 bool LayerPlaygroundViewPlugin::OnPresent(const FlutterLayer* layer) {
-  // Apply any pending resize from the platform thread, then render.
-  const int32_t target_w = pending_width_.load();
-  const int32_t target_h = pending_height_.load();
+  // The engine supplies the composed layer size every frame in layer->size;
+  // trust that over on_resize, which the embedder may never deliver while the
+  // widget is laid out (the platform-views `create` message carries 1x1
+  // placeholders). Fall back to pending_*/ atomic if the layer is absent.
+  int32_t target_w = pending_width_.load();
+  int32_t target_h = pending_height_.load();
+  if (layer && layer->size.width > 0 && layer->size.height > 0) {
+    target_w = static_cast<int32_t>(layer->size.width);
+    target_h = static_cast<int32_t>(layer->size.height);
+  }
+  static thread_local int32_t last_w = 0;
+  static thread_local int32_t last_h = 0;
+  static thread_local bool first_fire = true;
+  const bool size_changed = (target_w != last_w) || (target_h != last_h);
+  if (first_fire || size_changed) {
+    SPDLOG_TRACE(
+        "[pv-trace] LayerPlaygroundView::OnPresent id={} target={}x{} "
+        "tex={}x{} gl_init={} (first={}, size_changed={})",
+        id_, target_w, target_h, tex_width_, tex_height_, gl_initialized_,
+        first_fire, size_changed);
+    first_fire = false;
+    last_w = target_w;
+    last_h = target_h;
+  }
   if (target_w <= 0 || target_h <= 0) {
     return true;
   }
   EnsureGlState(target_w, target_h);
   if (!gl_initialized_) {
+    SPDLOG_TRACE(
+        "[pv-trace] LayerPlaygroundView::OnPresent id={} gl NOT initialised "
+        "(program link failed?); returning false",
+        id_);
     return false;
   }
   DrawFrame();

--- a/plugins/layer_playground_view/layer_playground_view_plugin.cc
+++ b/plugins/layer_playground_view/layer_playground_view_plugin.cc
@@ -19,9 +19,9 @@
 #include <flutter/standard_message_codec.h>
 
 #include "plugins/common/common.h"
+#include "view/flutter_view.h"
 
 class FlutterView;
-
 class Display;
 
 namespace plugin_layer_playground_view {
@@ -45,7 +45,6 @@ void LayerPlaygroundViewPlugin::RegisterWithRegistrar(
       id, std::move(viewType), direction, top, left, width, height, params,
       std::move(assetDirectory), engine, addListener, removeListener,
       platform_view_context);
-
   registrar->AddPlugin(std::move(plugin));
 }
 
@@ -58,7 +57,7 @@ LayerPlaygroundViewPlugin::LayerPlaygroundViewPlugin(
     double width,
     double height,
     const std::vector<uint8_t>& /* params */,
-    std::string assetDirectory,
+    std::string /* assetDirectory */,
     FlutterDesktopEngineState* state,
     PlatformViewAddListener addListener,
     PlatformViewRemoveListener removeListener,
@@ -72,36 +71,28 @@ LayerPlaygroundViewPlugin::LayerPlaygroundViewPlugin(
                    height),
       id_(id),
       platformViewsContext_(platform_view_context),
-      removeListener_(removeListener),
-      flutterAssetsPath_(std::move(assetDirectory)),
-      callback_(nullptr) {
+      removeListener_(removeListener) {
   SPDLOG_TRACE("++LayerPlaygroundViewPlugin::LayerPlaygroundViewPlugin");
 
-  /* Setup Wayland subsurface */
-  auto flutter_view = state->view_controller->view;
-  display_ = flutter_view->GetDisplay()->GetDisplay();
-  egl_display_ = eglGetDisplay(display_);
-  assert(egl_display_);
+#if BUILD_COMPOSITOR
+  pending_width_ = static_cast<int32_t>(width);
+  pending_height_ = static_cast<int32_t>(height);
 
-  surface_ =
-      wl_compositor_create_surface(flutter_view->GetDisplay()->GetCompositor());
-  egl_window_ = wl_egl_window_create(surface_, width_, height_);
-  assert(egl_window_);
-
-  InitializeEGL();
-  egl_surface_ =
-      eglCreateWindowSurface(egl_display_, egl_config_, egl_window_, nullptr);
-
-  // Subsurface
-  parent_surface_ = flutter_view->GetWindow()->GetBaseSurface();
-  subsurface_ = wl_subcompositor_get_subsurface(
-      flutter_view->GetDisplay()->GetSubCompositor(), surface_,
-      parent_surface_);
-
-  wl_subsurface_set_desync(subsurface_);
-
-  eglMakeCurrent(egl_display_, egl_surface_, egl_surface_, egl_context_);
-  InitializeScene();
+  // Register so PresentLayers routes layer dispatch to OnPresent. GL state
+  // is allocated lazily on the rasterizer thread the first time OnPresent
+  // fires — the engine's context isn't current here on the platform thread.
+  if (state && state->view_controller && state->view_controller->view) {
+    state->view_controller->view->RegisterCompositorSurface(
+        id_,
+        std::shared_ptr<ICompositorSurface>(this, [](ICompositorSurface*) {
+          // Aliasing deleter: the plugin's lifetime is owned by the
+          // PluginRegistrar, not by this shared_ptr. The compositor's
+          // copy is dropped on UnregisterCompositorSurface.
+        }));
+  }
+#else
+  (void)state;
+#endif
 
   addListener(platformViewsContext_, id, &platform_view_listener_, this);
   SPDLOG_TRACE("--LayerPlaygroundViewPlugin::LayerPlaygroundViewPlugin");
@@ -114,16 +105,20 @@ LayerPlaygroundViewPlugin::~LayerPlaygroundViewPlugin() {
 void LayerPlaygroundViewPlugin::on_resize(double width,
                                           double height,
                                           void* data) {
-  if (const auto plugin = static_cast<LayerPlaygroundViewPlugin*>(data)) {
+  if (auto* plugin = static_cast<LayerPlaygroundViewPlugin*>(data)) {
     plugin->width_ = static_cast<int32_t>(width);
     plugin->height_ = static_cast<int32_t>(height);
+#if BUILD_COMPOSITOR
+    plugin->pending_width_ = static_cast<int32_t>(width);
+    plugin->pending_height_ = static_cast<int32_t>(height);
+#endif
     SPDLOG_TRACE("Resize: {} {}", width, height);
   }
 }
 
 void LayerPlaygroundViewPlugin::on_set_direction(const int32_t direction,
                                                  void* data) {
-  if (const auto plugin = static_cast<LayerPlaygroundViewPlugin*>(data)) {
+  if (auto* plugin = static_cast<LayerPlaygroundViewPlugin*>(data)) {
     plugin->direction_ = direction;
     SPDLOG_TRACE("SetDirection: {}", plugin->direction_);
   }
@@ -132,17 +127,12 @@ void LayerPlaygroundViewPlugin::on_set_direction(const int32_t direction,
 void LayerPlaygroundViewPlugin::on_set_offset(const double left,
                                               const double top,
                                               void* data) {
-  if (const auto plugin = static_cast<LayerPlaygroundViewPlugin*>(data)) {
+  // Offset positioning is handled by the compositor sequencer in
+  // BUILD_COMPOSITOR mode; we just track the values for diagnostics.
+  if (auto* plugin = static_cast<LayerPlaygroundViewPlugin*>(data)) {
     plugin->left_ = static_cast<int32_t>(left);
     plugin->top_ = static_cast<int32_t>(top);
-    if (plugin->subsurface_) {
-      SPDLOG_DEBUG("SetOffset: left: {}, top: {}", plugin->left_, plugin->top_);
-      wl_subsurface_set_position(plugin->subsurface_, plugin->left_,
-                                 plugin->top_);
-      if (!plugin->callback_) {
-        on_frame(plugin, plugin->callback_, 0);
-      }
-    }
+    SPDLOG_TRACE("SetOffset: {} {}", left, top);
   }
 }
 
@@ -152,27 +142,13 @@ void LayerPlaygroundViewPlugin::on_touch(int32_t /* action */,
                                          const double* /* point_data */,
                                          void* /* data */) {}
 
-void LayerPlaygroundViewPlugin::on_dispose(bool /* hybrid */, void* data) {
-  const auto plugin = static_cast<LayerPlaygroundViewPlugin*>(data);
-  if (plugin->callback_) {
-    wl_callback_destroy(plugin->callback_);
-    plugin->callback_ = nullptr;
-  }
-
-  if (plugin->subsurface_) {
-    wl_subsurface_destroy(plugin->subsurface_);
-    plugin->subsurface_ = nullptr;
-  }
-
-  if (plugin->egl_window_) {
-    wl_egl_window_destroy(plugin->egl_window_);
-    plugin->egl_window_ = nullptr;
-  }
-
-  if (plugin->surface_) {
-    wl_surface_destroy(plugin->surface_);
-    plugin->surface_ = nullptr;
-  }
+void LayerPlaygroundViewPlugin::on_dispose(bool /* hybrid */, void* /* data */) {
+  // Compositor-owned shared_ptr drops via PlatformViewsHandler's
+  // safety-net UnregisterCompositorSurface call. GL state is leaked
+  // intentionally — destroying GL handles requires the engine's context
+  // to be current on the rasterizer thread, and we have no way to
+  // marshal that from the platform-thread dispose call. The engine's
+  // context outlives the plugin and reclaims the resources at shutdown.
 }
 
 const platform_view_listener
@@ -186,186 +162,165 @@ const platform_view_listener
         .reject_gesture = nullptr,
 };
 
-void LayerPlaygroundViewPlugin::on_frame(void* data,
-                                         wl_callback* callback,
-                                         const uint32_t time) {
-  const auto obj = static_cast<LayerPlaygroundViewPlugin*>(data);
+#if BUILD_COMPOSITOR
 
-  obj->callback_ = nullptr;
+namespace {
 
-  if (callback) {
-    wl_callback_destroy(callback);
-  }
-
-  obj->DrawFrame(time);
-
-  // Z-Order
-  // wl_subsurface_place_above(obj->subsurface_, obj->parent_surface_);
-  wl_subsurface_place_below(obj->subsurface_, obj->parent_surface_);
-
-  obj->callback_ = wl_surface_frame(obj->surface_);
-  wl_callback_add_listener(obj->callback_,
-                           &LayerPlaygroundViewPlugin::frame_listener, data);
-
-  wl_subsurface_set_position(obj->subsurface_, obj->left_, obj->top_);
-
-  wl_surface_commit(obj->surface_);
-}
-
-const wl_callback_listener LayerPlaygroundViewPlugin::frame_listener = {
-    .done = on_frame};
-
-GLuint LoadShader(const GLchar* shaderSrc, const GLenum type) {
-  // Create the shader object
+GLuint LoadShader(const GLchar* src, GLenum type) {
   const GLuint shader = glCreateShader(type);
-  if (shader == 0)
+  if (!shader) {
     return 0;
-  glShaderSource(shader, 1, &shaderSrc, nullptr);
+  }
+  glShaderSource(shader, 1, &src, nullptr);
   glCompileShader(shader);
-  GLint compiled;
+  GLint compiled = 0;
   glGetShaderiv(shader, GL_COMPILE_STATUS, &compiled);
   if (!compiled) {
-    GLint infoLen = 0;
-    glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &infoLen);
-    if (infoLen > 1) {
-      auto* infoLog = static_cast<GLchar*>(
-          malloc(sizeof(char) * static_cast<unsigned long>(infoLen)));
-      glGetShaderInfoLog(shader, infoLen, nullptr, infoLog);
-      spdlog::error("Error compiling shader:\n{}\n", infoLog);
-      free(infoLog);
+    GLint len = 0;
+    glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &len);
+    std::string log(static_cast<size_t>(len > 0 ? len : 0), '\0');
+    if (len > 0) {
+      glGetShaderInfoLog(shader, len, nullptr, log.data());
     }
+    spdlog::error("LayerPlaygroundViewPlugin: shader compile failed: {}", log);
     glDeleteShader(shader);
     return 0;
   }
   return shader;
 }
 
-void LayerPlaygroundViewPlugin::InitializeEGL() {
-  EGLint major, minor;
-  EGLBoolean ret = eglInitialize(egl_display_, &major, &minor);
-  assert(ret == EGL_TRUE);
-  SPDLOG_DEBUG("EGL {}.{}", major, minor);
+constexpr GLchar kVertSrc[] =
+    "attribute vec4 vPosition;\n"
+    "void main() { gl_Position = vPosition; }\n";
 
-  ret = eglBindAPI(EGL_OPENGL_ES_API);
-  assert(ret == EGL_TRUE);
+constexpr GLchar kFragSrc[] =
+    "precision mediump float;\n"
+    "void main() { gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0); }\n";
 
-  if (std::vector<EGLConfig> configs;
-      !GetConfig(kEglConfigAttribs.data(), configs)) {
-    spdlog::warn(
-        "[LayerPlaygroundViewPlugin] Could not use default EGLConfig trying "
-        "with fallback.");
-    // try with the fallback one
-    if (!GetConfig(kEglConfigAttribsFallBack.data(), configs)) {
-      spdlog::critical(
-          "[LayerPlaygroundViewPlugin] did not find config with buffer size {}",
-          buffer_size_);
-      abort();
-    }
-  }
+}  // namespace
 
-  egl_context_ = eglCreateContext(egl_display_, egl_config_, EGL_NO_CONTEXT,
-                                  kEglContextAttribs.data());
-  assert(egl_context_);
-  SPDLOG_TRACE("Context={}", egl_context_);
-}
-
-bool LayerPlaygroundViewPlugin::GetConfig(const EGLint* attrib_list,
-                                          std::vector<EGLConfig>& configs) {
-  EGLint n = 0;
-  auto ret = eglChooseConfig(egl_display_, attrib_list, nullptr, 0, &n);
-  if (!ret || n < 1) {
-    spdlog::error("Failed to choose EGL config");
-    return false;
-  }
-
-  configs.resize(static_cast<size_t>(n));
-  ret = eglChooseConfig(egl_display_, attrib_list, configs.data(),
-                        static_cast<EGLint>(configs.size()), &n);
-  if (!ret || n < 1) {
-    spdlog::error("Failed to choose EGL config");
-    return false;
-  }
-
-  EGLint size;
-  for (EGLint i = 0; i < n; i++) {
-    eglGetConfigAttrib(egl_display_, configs[static_cast<size_t>(i)],
-                       EGL_BUFFER_SIZE, &size);
-    SPDLOG_DEBUG("Buffer size for config {} is {}", i, size);
-    if (buffer_size_ <= size) {
-      std::copy(&configs[static_cast<size_t>(i)],
-                &configs[static_cast<size_t>(i)] + 1, &egl_config_);
-      return true;
-    }
-  }
-  return false;
-}
-
-void LayerPlaygroundViewPlugin::InitializeScene() {
-  constexpr GLchar vShaderStr[] =
-      "attribute vec4 vPosition; \n"
-      "void main() \n"
-      "{ \n"
-      " gl_Position = vPosition; \n"
-      "} \n";
-  constexpr GLchar fShaderStr[] =
-      "precision mediump float; \n"
-      "void main() \n"
-      "{ \n"
-      " gl_FragColor = vec4(1.5, 0.0, 0.0, 1.0); \n"
-      "} \n";
-
-  const GLuint vertexShader = LoadShader(vShaderStr, GL_VERTEX_SHADER);
-  const GLuint fragmentShader = LoadShader(fShaderStr, GL_FRAGMENT_SHADER);
-
-  const GLuint programObject = glCreateProgram();
-  if (programObject == 0)
-    return;
-
-  glAttachShader(programObject, vertexShader);
-  glAttachShader(programObject, fragmentShader);
-
-  glBindAttribLocation(programObject, 0, "vPosition");
-
-  glLinkProgram(programObject);
-
-  GLint linked;
-  glGetProgramiv(programObject, GL_LINK_STATUS, &linked);
-  if (!linked) {
-    GLint infoLen = 0;
-    glGetProgramiv(programObject, GL_INFO_LOG_LENGTH, &infoLen);
-    if (infoLen > 1) {
-      auto* infoLog = static_cast<GLchar*>(
-          malloc(sizeof(char) * static_cast<unsigned long>(infoLen)));
-      glGetProgramInfoLog(programObject, infoLen, nullptr, infoLog);
-      spdlog::error("Error linking program:\n{}\n", infoLog);
-      free(infoLog);
-    }
-    glDeleteProgram(programObject);
+void LayerPlaygroundViewPlugin::EnsureGlState(int32_t w, int32_t h) {
+  if (gl_initialized_ && w == tex_width_ && h == tex_height_) {
     return;
   }
 
-  programObject_ = programObject;
+  // Re-create the texture / FBO on size change. Program is reused across
+  // resizes.
+  if (color_texture_) {
+    glDeleteTextures(1, &color_texture_);
+    color_texture_ = 0;
+  }
+  if (framebuffer_) {
+    glDeleteFramebuffers(1, &framebuffer_);
+    framebuffer_ = 0;
+  }
+
+  tex_width_ = w;
+  tex_height_ = h;
+
+  glGenTextures(1, &color_texture_);
+  glBindTexture(GL_TEXTURE_2D, color_texture_);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, tex_width_, tex_height_, 0, GL_RGBA,
+               GL_UNSIGNED_BYTE, nullptr);
+
+  glGenFramebuffers(1, &framebuffer_);
+  glBindFramebuffer(GL_FRAMEBUFFER, framebuffer_);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                         color_texture_, 0);
+  if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+    spdlog::error(
+        "LayerPlaygroundViewPlugin: FBO incomplete at {}x{}", w, h);
+  }
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+  glBindTexture(GL_TEXTURE_2D, 0);
+
+  if (!program_) {
+    const GLuint vs = LoadShader(kVertSrc, GL_VERTEX_SHADER);
+    const GLuint fs = LoadShader(kFragSrc, GL_FRAGMENT_SHADER);
+    program_ = glCreateProgram();
+    glAttachShader(program_, vs);
+    glAttachShader(program_, fs);
+    glBindAttribLocation(program_, 0, "vPosition");
+    glLinkProgram(program_);
+    glDeleteShader(vs);
+    glDeleteShader(fs);
+    GLint linked = 0;
+    glGetProgramiv(program_, GL_LINK_STATUS, &linked);
+    if (!linked) {
+      GLint len = 0;
+      glGetProgramiv(program_, GL_INFO_LOG_LENGTH, &len);
+      std::string log(static_cast<size_t>(len > 0 ? len : 0), '\0');
+      if (len > 0) {
+        glGetProgramInfoLog(program_, len, nullptr, log.data());
+      }
+      spdlog::error("LayerPlaygroundViewPlugin: program link failed: {}", log);
+      glDeleteProgram(program_);
+      program_ = 0;
+    }
+  }
+
+  gl_initialized_ = (program_ != 0);
+}
+
+void LayerPlaygroundViewPlugin::DestroyGlState() {
+  // Intentionally not called from the platform thread — see on_dispose.
+  if (color_texture_) {
+    glDeleteTextures(1, &color_texture_);
+    color_texture_ = 0;
+  }
+  if (framebuffer_) {
+    glDeleteFramebuffers(1, &framebuffer_);
+    framebuffer_ = 0;
+  }
+  if (program_) {
+    glDeleteProgram(program_);
+    program_ = 0;
+  }
+  gl_initialized_ = false;
+}
+
+void LayerPlaygroundViewPlugin::DrawFrame() const {
+  static constexpr GLfloat verts[] = {0.0f,  0.5f, 0.0f, -0.5f, -0.5f,
+                                      0.0f,  0.5f, -0.5f, 0.0f};
+
+  glBindFramebuffer(GL_FRAMEBUFFER, framebuffer_);
+  glViewport(0, 0, tex_width_, tex_height_);
   glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-}
-
-void LayerPlaygroundViewPlugin::DrawFrame(uint32_t /* time */) const {
-  static constexpr GLfloat vVertices[] = {0.0f, 0.5f, 0.0f,  -0.5f, -0.5f,
-                                          0.0f, 0.5f, -0.5f, 0.0f};
-
-  if (eglGetCurrentContext() != egl_context_) {
-    eglMakeCurrent(egl_display_, egl_surface_, egl_surface_, egl_context_);
-  }
-
-  glViewport(0, 0, width_, height_);
   glClear(GL_COLOR_BUFFER_BIT);
-  glUseProgram(programObject_);
-
-  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, vVertices);
+  glUseProgram(program_);
+  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, verts);
   glEnableVertexAttribArray(0);
   glDrawArrays(GL_TRIANGLES, 0, 3);
-  eglSwapBuffers(egl_display_, egl_surface_);
-
-  eglMakeCurrent(egl_display_, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+  glDisableVertexAttribArray(0);
+  glUseProgram(0);
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
+
+bool LayerPlaygroundViewPlugin::OnPresent(const FlutterLayer* layer) {
+  // Apply any pending resize from the platform thread, then render.
+  const int32_t target_w = pending_width_.load();
+  const int32_t target_h = pending_height_.load();
+  if (target_w <= 0 || target_h <= 0) {
+    return true;
+  }
+  EnsureGlState(target_w, target_h);
+  if (!gl_initialized_) {
+    return false;
+  }
+  DrawFrame();
+  (void)layer;
+  return true;
+}
+
+void LayerPlaygroundViewPlugin::OnResize(int32_t w, int32_t h) {
+  pending_width_ = w;
+  pending_height_ = h;
+}
+
+#endif  // BUILD_COMPOSITOR
 
 }  // namespace plugin_layer_playground_view

--- a/plugins/layer_playground_view/layer_playground_view_plugin.h
+++ b/plugins/layer_playground_view/layer_playground_view_plugin.h
@@ -39,16 +39,19 @@ namespace plugin_layer_playground_view {
 /**
  * Layer playground demo platform view.
  *
- * Renders a single colored triangle into an FBO-backed @c GL_TEXTURE_2D
- * which the compositor composites into the scene at the layer's
- * @c offset / @c size each frame. No Wayland subsurface, no per-plugin
- * EGL context — all GL state is created lazily in @c OnPresent on the
- * engine's rasterizer thread using the engine's GL context.
+ * Renders a diagonal 3-stop gradient with a thin border and a faint grid
+ * into an FBO-backed @c GL_TEXTURE_2D which the compositor composites into
+ * the scene at the layer's @c offset / @c size each frame. The visual
+ * design mirrors the GTK/Cairo @c simple_box companion plugin in the
+ * layer_playground app (minus the text label). No Wayland subsurface, no
+ * per-plugin EGL context — all GL state is created lazily in @c OnPresent
+ * on the engine's rasterizer thread using the engine's GL context.
  */
 class LayerPlaygroundViewPlugin : public flutter::Plugin,
                                   public PlatformView
 #if BUILD_COMPOSITOR
-    , public ICompositorSurface
+    ,
+                                  public ICompositorSurface
 #endif
 {
  public:
@@ -61,7 +64,7 @@ class LayerPlaygroundViewPlugin : public flutter::Plugin,
                                     double width,
                                     double height,
                                     const std::vector<uint8_t>& params,
-                                    std::string assetDirectory,
+                                    const std::string& assetDirectory,
                                     FlutterDesktopEngineRef engine,
                                     PlatformViewAddListener addListener,
                                     PlatformViewRemoveListener removeListener,
@@ -75,7 +78,7 @@ class LayerPlaygroundViewPlugin : public flutter::Plugin,
                             double width,
                             double height,
                             const std::vector<uint8_t>& params,
-                            std::string assetDirectory,
+                            const std::string& assetDirectory,
                             FlutterDesktopEngineState* state,
                             PlatformViewAddListener addListener,
                             PlatformViewRemoveListener removeListener,
@@ -125,6 +128,9 @@ class LayerPlaygroundViewPlugin : public flutter::Plugin,
   GLuint framebuffer_{0};
   GLuint color_texture_{0};
   GLuint program_{0};
+  GLuint vbo_{0};
+  GLint u_resolution_loc_{-1};
+  GLint a_position_loc_{-1};
   int32_t tex_width_{0};
   int32_t tex_height_{0};
   // Pending size from on_resize / OnResize, applied next OnPresent.

--- a/plugins/layer_playground_view/layer_playground_view_plugin.h
+++ b/plugins/layer_playground_view/layer_playground_view_plugin.h
@@ -17,25 +17,40 @@
 #ifndef FLUTTER_PLUGIN_LAYER_PLAYGROUND_PLUGIN_H_
 #define FLUTTER_PLUGIN_LAYER_PLAYGROUND_PLUGIN_H_
 
+#include <atomic>
 #include <memory>
+#include <string>
+#include <vector>
 
-#include <EGL/egl.h>
-#include <GLES3/gl32.h>
-#include <flutter/event_channel.h>
-#include <flutter/method_channel.h>
+#include <GLES2/gl2.h>
 #include <flutter/plugin_registrar.h>
-#include <wayland-client.h>
-#include <wayland-egl.h>
 
+#include "config/common.h"
 #include "flutter_desktop_engine_state.h"
 #include "flutter_homescreen.h"
 #include "platform_views/platform_view.h"
-#include "view/flutter_view.h"
-#include "wayland/display.h"
+
+#if BUILD_COMPOSITOR
+#include "view/compositor_surface_interface.h"
+#endif
 
 namespace plugin_layer_playground_view {
 
-class LayerPlaygroundViewPlugin : public flutter::Plugin, PlatformView {
+/**
+ * Layer playground demo platform view.
+ *
+ * Renders a single colored triangle into an FBO-backed @c GL_TEXTURE_2D
+ * which the compositor composites into the scene at the layer's
+ * @c offset / @c size each frame. No Wayland subsurface, no per-plugin
+ * EGL context — all GL state is created lazily in @c OnPresent on the
+ * engine's rasterizer thread using the engine's GL context.
+ */
+class LayerPlaygroundViewPlugin : public flutter::Plugin,
+                                  public PlatformView
+#if BUILD_COMPOSITOR
+    , public ICompositorSurface
+#endif
+{
  public:
   static void RegisterWithRegistrar(flutter::PluginRegistrar* registrar,
                                     int32_t id,
@@ -68,39 +83,58 @@ class LayerPlaygroundViewPlugin : public flutter::Plugin, PlatformView {
 
   ~LayerPlaygroundViewPlugin() override;
 
-  // Disallow copy and assign.
   LayerPlaygroundViewPlugin(const LayerPlaygroundViewPlugin&) = delete;
-
   LayerPlaygroundViewPlugin& operator=(const LayerPlaygroundViewPlugin&) =
       delete;
+
+#if BUILD_COMPOSITOR
+  // ICompositorSurface
+  bool OnCreateBackingStore(const FlutterBackingStoreConfig*,
+                            FlutterBackingStore*) override {
+    return false;  // engine provides backing store; we render into our own FBO
+  }
+  bool OnCollectBackingStore(const FlutterBackingStore*) override {
+    return true;
+  }
+  bool OnPresent(const FlutterLayer* layer) override;
+  [[nodiscard]] FlutterPlatformViewIdentifier GetIdentifier() const override {
+    return id_;
+  }
+  void OnResize(int32_t w, int32_t h) override;
+
+  [[nodiscard]] uint32_t GetGlTextureName() const override {
+    return color_texture_;
+  }
+  [[nodiscard]] int32_t GetGlTextureWidth() const override {
+    return tex_width_;
+  }
+  [[nodiscard]] int32_t GetGlTextureHeight() const override {
+    return tex_height_;
+  }
+#endif
 
  private:
   int32_t id_;
   void* platformViewsContext_;
   PlatformViewRemoveListener removeListener_;
-  const std::string flutterAssetsPath_;
 
-  wl_display* display_;
-  wl_surface* surface_;
-  wl_surface* parent_surface_;
-  wl_callback* callback_;
-  wl_subsurface* subsurface_;
+#if BUILD_COMPOSITOR
+  // Owned FBO state, lazily created on the rasterizer thread when
+  // OnPresent first runs (so the engine's GL context is current).
+  bool gl_initialized_{false};
+  GLuint framebuffer_{0};
+  GLuint color_texture_{0};
+  GLuint program_{0};
+  int32_t tex_width_{0};
+  int32_t tex_height_{0};
+  // Pending size from on_resize / OnResize, applied next OnPresent.
+  std::atomic<int32_t> pending_width_{0};
+  std::atomic<int32_t> pending_height_{0};
 
-  static void on_frame(void* data, wl_callback* callback, uint32_t time);
-  static const wl_callback_listener frame_listener;
-
-  EGLDisplay egl_display_;
-  wl_egl_window* egl_window_;
-  int buffer_size_ = 32;
-  EGLContext egl_context_{};
-  EGLConfig egl_config_{};
-  GLuint programObject_{};
-  EGLSurface egl_surface_{};
-
-  void InitializeEGL();
-  bool GetConfig(const EGLint* attrib_list, std::vector<EGLConfig>& configs);
-  void InitializeScene();
-  void DrawFrame(uint32_t time) const;
+  void EnsureGlState(int32_t w, int32_t h);
+  void DestroyGlState();
+  void DrawFrame() const;
+#endif
 
   static void on_resize(double width, double height, void* data);
   static void on_set_direction(int32_t direction, void* data);

--- a/plugins/layer_playground_view/layer_playground_view_plugin_c_api.cc
+++ b/plugins/layer_playground_view/layer_playground_view_plugin_c_api.cc
@@ -30,7 +30,7 @@ void LayerPlaygroundPluginCApiRegisterWithRegistrar(
     const double width,
     const double height,
     const std::vector<uint8_t>& params,
-    std::string assetDirectory,
+    const std::string& assetDirectory,
     FlutterDesktopEngineRef engine,
     const PlatformViewAddListener add_listener,
     const PlatformViewRemoveListener remove_listener,
@@ -40,6 +40,6 @@ void LayerPlaygroundPluginCApiRegisterWithRegistrar(
           flutter::PluginRegistrarManager::GetInstance()
               ->GetRegistrar<flutter::PluginRegistrar>(registrar),
           id, std::move(viewType), direction, top, left, width, height, params,
-          std::move(assetDirectory), engine, add_listener, remove_listener,
+          assetDirectory, engine, add_listener, remove_listener,
           platform_views_context);
 }

--- a/plugins/nav_render_view/CMakeLists.txt
+++ b/plugins/nav_render_view/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Toyota Connected North America
+# Copyright 2021-2026 Toyota Connected North America
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,10 @@
 # limitations under the License.
 #
 
-pkg_check_modules(WAYLAND_EGL REQUIRED IMPORTED_TARGET wayland-egl)
+# The plugin uses libnav_render's TextureRender API to render into an FBO
+# using the engine's GL context — no per-plugin EGL context, no Wayland
+# subsurface. The compositor composites the resulting GL_TEXTURE_2D onto
+# the scene at the layer rect.
 
 add_library(plugin_nav_render_view STATIC
         nav_render_view_plugin_c_api.cc
@@ -28,6 +31,5 @@ target_include_directories(plugin_nav_render_view PRIVATE include ${PROJECT_BINA
 target_link_libraries(plugin_nav_render_view PUBLIC
         flutter
         platform_homescreen
-        PkgConfig::WAYLAND_EGL
-        EGL
+        GLESv2
 )

--- a/plugins/nav_render_view/CMakeLists.txt
+++ b/plugins/nav_render_view/CMakeLists.txt
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+include_guard()
+
 # The plugin uses libnav_render's TextureRender API to render into an FBO
 # using the engine's GL context — no per-plugin EGL context, no Wayland
 # subsurface. The compositor composites the resulting GL_TEXTURE_2D onto
@@ -26,7 +28,10 @@ add_library(plugin_nav_render_view STATIC
         libnav_render.cc
 )
 
-target_include_directories(plugin_nav_render_view PRIVATE include ${PROJECT_BINARY_DIR})
+target_include_directories(plugin_nav_render_view PUBLIC
+        .
+        include
+)
 
 target_link_libraries(plugin_nav_render_view PUBLIC
         flutter

--- a/plugins/nav_render_view/nav_render_error.h
+++ b/plugins/nav_render_view/nav_render_error.h
@@ -52,7 +52,7 @@ class ErrorOr {
     return std::holds_alternative<FlutterError>(v_);
   }
 
-  const T& value() const { return std::get<T>(v_); };
+  [[nodiscard]] const T& value() const { return std::get<T>(v_); };
 
   [[nodiscard]] const FlutterError& error() const {
     return std::get<FlutterError>(v_);

--- a/plugins/nav_render_view/nav_render_surface.cc
+++ b/plugins/nav_render_view/nav_render_surface.cc
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021-2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "nav_render_surface.h"
 
@@ -8,9 +23,12 @@
 
 #include "libnav_render.h"
 
+#if BUILD_COMPOSITOR
+#include "view/flutter_view.h"
+#endif
+
 namespace nav_render_view_plugin {
 
-// static
 void NavRenderSurface::RegisterWithRegistrar(
     flutter::PluginRegistrar* registrar,
     int32_t id,
@@ -54,50 +72,41 @@ NavRenderSurface::NavRenderSurface(int32_t id,
                    width,
                    height),
       id_(id),
-      view_(state->view_controller->view),
-      width_(static_cast<int>(width)),
-      height_(static_cast<int>(height)),
-      callback_(nullptr),
       platformViewsContext_(platform_view_context),
       removeListener_(removeListener),
       flutterAssetsPath_(std::move(assetDirectory)) {
   SPDLOG_TRACE("++NavRenderSurface::NavRenderSurface");
+
   auto& codec = flutter::StandardMessageCodec::GetInstance();
   const auto decoded = codec.DecodeMessage(params.data(), params.size());
   const auto& creationParams =
       std::get_if<flutter::EncodableMap>(decoded.get());
 
   std::string access_token;
-  std::string module;
-  bool map_flutter_assets{};
   std::string asset_path;
   std::string cache_folder;
   std::string misc_folder;
-
-  for (const auto& [fst, snd] : *creationParams) {
-    if (auto key = std::get<std::string>(fst); key == "access_token") {
-      if (std::holds_alternative<std::string>(snd)) {
+  bool map_flutter_assets{};
+  if (creationParams) {
+    for (const auto& [fst, snd] : *creationParams) {
+      const auto key = std::get<std::string>(fst);
+      if (key == "access_token" && std::holds_alternative<std::string>(snd)) {
         access_token = std::get<std::string>(snd);
-      }
-    } else if (key == "map_flutter_assets") {
-      if (std::holds_alternative<bool>(snd)) {
+      } else if (key == "map_flutter_assets" &&
+                 std::holds_alternative<bool>(snd)) {
         map_flutter_assets = std::get<bool>(snd);
-      }
-    } else if (key == "asset_path") {
-      if (std::holds_alternative<std::string>(snd)) {
+      } else if (key == "asset_path" &&
+                 std::holds_alternative<std::string>(snd)) {
         asset_path = std::get<std::string>(snd);
-      }
-    } else if (key == "cache_folder") {
-      if (std::holds_alternative<std::string>(snd)) {
+      } else if (key == "cache_folder" &&
+                 std::holds_alternative<std::string>(snd)) {
         cache_folder = std::get<std::string>(snd);
-      }
-    } else if (key == "misc_folder") {
-      if (std::holds_alternative<std::string>(snd)) {
+      } else if (key == "misc_folder" &&
+                 std::holds_alternative<std::string>(snd)) {
         misc_folder = std::get<std::string>(snd);
       }
     }
   }
-
   if (map_flutter_assets) {
     asset_path = flutterAssetsPath_;
   }
@@ -106,188 +115,90 @@ NavRenderSurface::NavRenderSurface(int32_t id,
     spdlog::error("[NavRenderViewPlugin] libnav_render.so missing");
     return;
   }
-  if (LibNavRender::kExpectedSurfaceApiVersion !=
-      LibNavRender->SurfaceGetInterfaceVersion()) {
-    spdlog::error("[NavRenderViewPlugin] unexpected interface version: {}",
-                  LibNavRender->SurfaceGetInterfaceVersion());
+
+#if BUILD_COMPOSITOR
+  if (LibNavRender::kExpectedTextureApiVersion !=
+      LibNavRender->TextureGetInterfaceVersion()) {
+    spdlog::error(
+        "[NavRenderViewPlugin] unexpected texture API version: {} (need {})",
+        LibNavRender->TextureGetInterfaceVersion(),
+        LibNavRender::kExpectedTextureApiVersion);
     return;
   }
 
-  /// Setup Native Window pointers
-  display_ = view_->GetDisplay()->GetDisplay();
-  auto compositor = view_->GetDisplay()->GetCompositor();
-  surface_ = wl_compositor_create_surface(compositor);
+  access_token_ = std::move(access_token);
+  asset_path_ = std::move(asset_path);
+  cache_folder_ = std::move(cache_folder);
+  misc_folder_ = std::move(misc_folder);
+  pending_width_ = static_cast<int32_t>(width);
+  pending_height_ = static_cast<int32_t>(height);
 
-  egl_display_ = eglGetDisplay(display_);
-  assert(egl_display_);
-  egl_window_ = wl_egl_window_create(surface_, width_, height_);
-  assert(egl_window_);
-
-  native_window_ = {
-      .wl_display = display_,
-      .wl_surface = surface_,
-      .egl_display = egl_display_,
-      .egl_window = egl_window_,
-      .width = static_cast<uint32_t>(width_),
-      .height = static_cast<uint32_t>(height_),
-  };
-
-  context_ = LibNavRender->SurfaceInitialize(
-      access_token.c_str(), static_cast<int>(width), static_cast<int>(height),
-      &native_window_, asset_path.c_str(), cache_folder.c_str(),
-      misc_folder.c_str());
-  assert(context_);
-  SPDLOG_DEBUG("Context: {}", fmt::ptr(context_));
-
-  // Sub Surface
-  auto sub_compositor = view_->GetDisplay()->GetSubCompositor();
-  parent_surface_ = view_->GetWindow()->GetBaseSurface();
-  subsurface_ = wl_subcompositor_get_subsurface(sub_compositor, surface_,
-                                                parent_surface_);
-
-  wl_subsurface_set_desync(subsurface_);
+  if (state && state->view_controller && state->view_controller->view) {
+    state->view_controller->view->RegisterCompositorSurface(
+        id_,
+        std::shared_ptr<ICompositorSurface>(this, [](ICompositorSurface*) {
+          // Aliasing deleter — PluginRegistrar owns the plugin.
+        }));
+  }
+#else
+  (void)state;
+  (void)access_token;
+  (void)asset_path;
+  (void)cache_folder;
+  (void)misc_folder;
+  spdlog::warn(
+      "[NavRenderViewPlugin] BUILD_COMPOSITOR is off; plugin will not "
+      "render. Rebuild with -DBUILD_COMPOSITOR=ON.");
+#endif
 
   addListener(platformViewsContext_, id, &platform_view_listener_, this);
   SPDLOG_TRACE("--NavRenderSurface::NavRenderSurface");
 }
 
 NavRenderSurface::~NavRenderSurface() {
-  SPDLOG_TRACE("++NavRenderSurface::~NavRenderSurface");
-  SPDLOG_TRACE("--NavRenderSurface::~NavRenderSurface");
-}
-
-void NavRenderSurface::on_frame(void* data,
-                                wl_callback* callback,
-                                const uint32_t /* time */) {
-  const auto obj = static_cast<NavRenderSurface*>(data);
-
-  obj->callback_ = nullptr;
-
-  if (callback) {
-    wl_callback_destroy(callback);
-  }
-
-  obj->DrawFrame();
-
-  if (obj->subsurface_ == nullptr)
-    return;
-
-  // Z-Order
-  /// Place below or we miss mouse/touch
-  wl_subsurface_place_below(obj->subsurface_, obj->parent_surface_);
-
-  obj->callback_ = wl_surface_frame(obj->surface_);
-  wl_callback_add_listener(obj->callback_, &NavRenderSurface::frame_listener,
-                           data);
-
-  wl_subsurface_set_position(obj->subsurface_, obj->left_, obj->top_);
-
-  wl_surface_commit(obj->surface_);
-}
-
-const wl_callback_listener NavRenderSurface::frame_listener = {.done =
-                                                                   on_frame};
-
-void NavRenderSurface::Resize(int32_t width, int32_t height) {
-  SPDLOG_TRACE("[NavRenderView] Resize: {} {}", width, height);
-  width_ = width;
-  height_ = height;
-}
-
-void NavRenderSurface::Dispose() {
-  LibNavRender->SurfaceDeInitialize(context_);
-  context_ = nullptr;
-
-  if (callback_) {
-    wl_callback_destroy(callback_);
-    callback_ = nullptr;
-  }
-
-  if (subsurface_) {
-    wl_subsurface_destroy(subsurface_);
-    subsurface_ = nullptr;
-  }
-
-  if (egl_window_) {
-    wl_egl_window_destroy(egl_window_);
-    egl_window_ = nullptr;
-  }
-
-  if (surface_) {
-    wl_surface_destroy(surface_);
-    surface_ = nullptr;
-  }
   removeListener_(platformViewsContext_, id_);
 }
 
-void NavRenderSurface::DrawFrame() {
-  if (!context_)
-    return;
-
-  if (dispose_pending_) {
-    dispose_pending_ = false;
-    Dispose();
-    return;
-  }
-
-  LibNavRender->SurfaceDrawFrame(context_);
-}
-
-void NavRenderSurface::SetOffset(int32_t left, int32_t top) {
-  SPDLOG_DEBUG("[NavRenderSurface] SetOffset: left: {}, top: {}", left, top);
-  wl_subsurface_set_position(subsurface_, left, top);
-  if (!callback_) {
-    on_frame(this, callback_, 0);
-  }
-}
-
 void NavRenderSurface::on_resize(double width, double height, void* data) {
-  SPDLOG_TRACE("[NavRenderSurface] on_resize: {} {}", width, height);
-  const auto plugin = static_cast<NavRenderSurface*>(data);
-  plugin->Resize(static_cast<int32_t>(width), static_cast<int32_t>(height));
+  if (auto* p = static_cast<NavRenderSurface*>(data)) {
+    p->width_ = static_cast<int32_t>(width);
+    p->height_ = static_cast<int32_t>(height);
+#if BUILD_COMPOSITOR
+    p->pending_width_ = static_cast<int32_t>(width);
+    p->pending_height_ = static_cast<int32_t>(height);
+#endif
+    SPDLOG_TRACE("[NavRenderSurface] on_resize: {} {}", width, height);
+  }
 }
 
 void NavRenderSurface::on_set_direction(int32_t direction, void* data) {
-  SPDLOG_TRACE("[NavRenderSurface] on_set_direction: {}", direction);
-  if (!data) {
-    return;
+  if (auto* p = static_cast<NavRenderSurface*>(data)) {
+    p->direction_ = direction;
+    SPDLOG_TRACE("[NavRenderSurface] on_set_direction: {}", direction);
   }
-  static_cast<NavRenderSurface*>(data)->direction_ = direction;
 }
 
-void NavRenderSurface::on_set_offset(const double left,
-                                     const double top,
-                                     void* data) {
-  (void)left;
-  (void)top;
-  SPDLOG_TRACE("[NavRenderSurface] on_set_offset: left: {}, top: {}", left,
-               top);
-  if (!data) {
-    return;
+void NavRenderSurface::on_set_offset(double left, double top, void* data) {
+  if (auto* p = static_cast<NavRenderSurface*>(data)) {
+    p->left_ = static_cast<int32_t>(left);
+    p->top_ = static_cast<int32_t>(top);
+    SPDLOG_TRACE("[NavRenderSurface] on_set_offset: {} {}", left, top);
   }
-  static_cast<NavRenderSurface*>(data)->SetOffset(static_cast<int32_t>(left),
-                                                  static_cast<int32_t>(top));
 }
 
-void NavRenderSurface::on_touch(const int32_t action,
-                                const int32_t point_count,
-                                const size_t point_data_size,
-                                const double* /* point_data */,
-                                void* /* data */) {
-  (void)action;
-  (void)point_count;
-  (void)point_data_size;
-  SPDLOG_TRACE(
-      "[NavRenderSurface] on_touch: action: {}, point_count: {}, "
-      "point_data_size: {}",
-      action, point_count, point_data_size);
-}
+void NavRenderSurface::on_touch(int32_t /*action*/,
+                                int32_t /*point_count*/,
+                                size_t /*point_data_size*/,
+                                const double* /*point_data*/,
+                                void* /*data*/) {}
 
-void NavRenderSurface::on_dispose(bool /* hybrid */, void* data) {
-  const auto obj = static_cast<NavRenderSurface*>(data);
-
-  /// Dispose on the next frame callback
-  obj->dispose_pending_ = true;
+void NavRenderSurface::on_dispose(bool /*hybrid*/, void* /*data*/) {
+  // GL state and the libnav_render context are intentionally leaked —
+  // tearing them down requires the engine's GL context current on the
+  // rasterizer thread, and there's no clean way to marshal that from
+  // the platform-thread dispose call. The engine context outlives the
+  // plugin and reclaims the resources at shutdown.
+  // PlatformViewsHandler invokes UnregisterCompositorSurface for us.
 }
 
 const platform_view_listener NavRenderSurface::platform_view_listener_ = {
@@ -299,5 +210,98 @@ const platform_view_listener NavRenderSurface::platform_view_listener_ = {
     .accept_gesture = nullptr,
     .reject_gesture = nullptr,
 };
+
+#if BUILD_COMPOSITOR
+
+void NavRenderSurface::EnsureGlState(int32_t w, int32_t h) {
+  if (init_failed_) {
+    return;
+  }
+  if (gl_initialized_ && w == tex_width_ && h == tex_height_) {
+    return;
+  }
+
+  // Recreate the FBO + texture on size change. The libnav_render context
+  // is told to resize so it re-allocates internal G-buffers.
+  if (color_texture_) {
+    glDeleteTextures(1, &color_texture_);
+    color_texture_ = 0;
+  }
+  if (framebuffer_) {
+    glDeleteFramebuffers(1, &framebuffer_);
+    framebuffer_ = 0;
+  }
+
+  tex_width_ = w;
+  tex_height_ = h;
+
+  glGenTextures(1, &color_texture_);
+  glBindTexture(GL_TEXTURE_2D, color_texture_);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, tex_width_, tex_height_, 0, GL_RGBA,
+               GL_UNSIGNED_BYTE, nullptr);
+
+  glGenFramebuffers(1, &framebuffer_);
+  glBindFramebuffer(GL_FRAMEBUFFER, framebuffer_);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                         color_texture_, 0);
+  if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+    spdlog::error("[NavRenderSurface] FBO incomplete at {}x{}", w, h);
+    init_failed_ = true;
+    return;
+  }
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+  glBindTexture(GL_TEXTURE_2D, 0);
+
+  if (!context_) {
+    context_ = LibNavRender->TextureInitialize(
+        access_token_.c_str(), tex_width_, tex_height_, asset_path_.c_str(),
+        cache_folder_.c_str(), misc_folder_.c_str());
+    if (!context_) {
+      spdlog::error("[NavRenderSurface] TextureInitialize failed");
+      init_failed_ = true;
+      return;
+    }
+  } else if (LibNavRender->TextureResize) {
+    LibNavRender->TextureResize(context_, tex_width_, tex_height_);
+  }
+
+  gl_initialized_ = true;
+}
+
+bool NavRenderSurface::OnPresent(const FlutterLayer* /*layer*/) {
+  if (init_failed_) {
+    return false;
+  }
+  const int32_t w = pending_width_.load();
+  const int32_t h = pending_height_.load();
+  if (w <= 0 || h <= 0) {
+    return true;
+  }
+
+  EnsureGlState(w, h);
+  if (!gl_initialized_ || !context_) {
+    return false;
+  }
+
+  if (LibNavRender->TextureRunTask) {
+    LibNavRender->TextureRunTask(context_);
+  }
+  // libnav_render renders into the framebuffer we provide. After this
+  // call returns, color_texture_ contains the latest map frame; the
+  // compositor will composite it into the scene.
+  LibNavRender->TextureRender(context_, framebuffer_);
+  return true;
+}
+
+void NavRenderSurface::OnResize(int32_t w, int32_t h) {
+  pending_width_ = w;
+  pending_height_ = h;
+}
+
+#endif  // BUILD_COMPOSITOR
 
 }  // namespace nav_render_view_plugin

--- a/plugins/nav_render_view/nav_render_surface.cc
+++ b/plugins/nav_render_view/nav_render_surface.cc
@@ -135,10 +135,16 @@ NavRenderSurface::NavRenderSurface(int32_t id,
 
   if (state && state->view_controller && state->view_controller->view) {
     state->view_controller->view->RegisterCompositorSurface(
-        id_,
-        std::shared_ptr<ICompositorSurface>(this, [](ICompositorSurface*) {
+        id_, std::shared_ptr<ICompositorSurface>(this, [](ICompositorSurface*) {
           // Aliasing deleter — PluginRegistrar owns the plugin.
         }));
+    SPDLOG_TRACE("[pv-trace] NavRenderSurface registered: id={} size={}x{}",
+                 id_, pending_width_.load(), pending_height_.load());
+  } else {
+    SPDLOG_TRACE(
+        "[pv-trace] NavRenderSurface could NOT register (state/view null): "
+        "id={}",
+        id_);
   }
 #else
   (void)state;
@@ -272,18 +278,44 @@ void NavRenderSurface::EnsureGlState(int32_t w, int32_t h) {
   gl_initialized_ = true;
 }
 
-bool NavRenderSurface::OnPresent(const FlutterLayer* /*layer*/) {
+bool NavRenderSurface::OnPresent(const FlutterLayer* layer) {
   if (init_failed_) {
     return false;
   }
-  const int32_t w = pending_width_.load();
-  const int32_t h = pending_height_.load();
-  if (w <= 0 || h <= 0) {
+  // The engine supplies the composed layer size every frame in layer->size;
+  // trust that over on_resize, which the embedder may never deliver while the
+  // widget is laid out (the platform-views `create` message carries 1x1
+  // placeholders). Fall back to pending_*/ atomic if the layer is absent.
+  int32_t target_w = pending_width_.load();
+  int32_t target_h = pending_height_.load();
+  if (layer && layer->size.width > 0 && layer->size.height > 0) {
+    target_w = static_cast<int32_t>(layer->size.width);
+    target_h = static_cast<int32_t>(layer->size.height);
+  }
+  static thread_local int32_t last_w = 0;
+  static thread_local int32_t last_h = 0;
+  static thread_local bool first_fire = true;
+  const bool size_changed = (target_w != last_w) || (target_h != last_h);
+  if (first_fire || size_changed) {
+    SPDLOG_TRACE(
+        "[pv-trace] NavRenderSurface::OnPresent id={} target={}x{} "
+        "tex={}x{} gl_init={} (first={}, size_changed={})",
+        id_, target_w, target_h, tex_width_, tex_height_, gl_initialized_,
+        first_fire, size_changed);
+    first_fire = false;
+    last_w = target_w;
+    last_h = target_h;
+  }
+  if (target_w <= 0 || target_h <= 0) {
     return true;
   }
 
-  EnsureGlState(w, h);
+  EnsureGlState(target_w, target_h);
   if (!gl_initialized_ || !context_) {
+    SPDLOG_TRACE(
+        "[pv-trace] NavRenderSurface::OnPresent id={} gl NOT initialised "
+        "(context/FBO init failed?); returning false",
+        id_);
     return false;
   }
 

--- a/plugins/nav_render_view/nav_render_surface.h
+++ b/plugins/nav_render_view/nav_render_surface.h
@@ -1,20 +1,57 @@
+/*
+ * Copyright 2021-2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 
-#include <wayland-client.h>
-#include <wayland-egl.h>
+#include <atomic>
+#include <memory>
+#include <string>
+#include <vector>
 
+#include <GLES2/gl2.h>
+#include <flutter/plugin_registrar.h>
+
+#include "config/common.h"
 #include "flutter_desktop_engine_state.h"
 #include "flutter_homescreen.h"
 #include "libnav_render.h"
 #include "platform_views/platform_view.h"
-#include "wayland/display.h"
 
-class Display;
-
-class FlutterView;
+#if BUILD_COMPOSITOR
+#include "view/compositor_surface_interface.h"
+#endif
 
 namespace nav_render_view_plugin {
-class NavRenderSurface final : public PlatformView, public flutter::Plugin {
+
+/**
+ * Nav-render platform view backed by libnav_render's TextureRender API.
+ *
+ * Renders into an FBO using the engine's GL context (no per-plugin EGL
+ * context, no Wayland subsurface). The compositor composites the
+ * resulting GL_TEXTURE_2D into the scene at the layer's offset/size each
+ * frame. When BUILD_COMPOSITOR is off the plugin still constructs but
+ * does no rendering — compositor mode is a hard prerequisite for the
+ * texture-mode path.
+ */
+class NavRenderSurface final : public flutter::Plugin,
+                               public PlatformView
+#if BUILD_COMPOSITOR
+    , public ICompositorSurface
+#endif
+{
  public:
   static void RegisterWithRegistrar(flutter::PluginRegistrar* registrar,
                                     int32_t id,
@@ -47,69 +84,73 @@ class NavRenderSurface final : public PlatformView, public flutter::Plugin {
 
   ~NavRenderSurface() override;
 
-  // Disallow copy and assign.
   NavRenderSurface(const NavRenderSurface&) = delete;
   NavRenderSurface& operator=(const NavRenderSurface&) = delete;
 
+#if BUILD_COMPOSITOR
+  // ICompositorSurface
+  bool OnCreateBackingStore(const FlutterBackingStoreConfig*,
+                            FlutterBackingStore*) override {
+    return false;
+  }
+  bool OnCollectBackingStore(const FlutterBackingStore*) override {
+    return true;
+  }
+  bool OnPresent(const FlutterLayer* layer) override;
+  [[nodiscard]] FlutterPlatformViewIdentifier GetIdentifier() const override {
+    return id_;
+  }
+  void OnResize(int32_t w, int32_t h) override;
+
+  [[nodiscard]] uint32_t GetGlTextureName() const override {
+    return color_texture_;
+  }
+  [[nodiscard]] int32_t GetGlTextureWidth() const override {
+    return tex_width_;
+  }
+  [[nodiscard]] int32_t GetGlTextureHeight() const override {
+    return tex_height_;
+  }
+#endif
+
  private:
-  struct NATIVE_WINDOW {
-    struct wl_display* wl_display;
-    struct wl_surface* wl_surface;
-    EGLDisplay egl_display;
-    wl_egl_window* egl_window;
-    uint32_t width;
-    uint32_t height;
-  };
-
   int32_t id_;
-  FlutterView* view_;
-  int32_t left_{};
-  int32_t top_{};
-  int32_t width_{};
-  int32_t height_{};
-
-  nav_render_Context* context_{};
-  volatile bool dispose_pending_{};
-
-  NATIVE_WINDOW native_window_{};
-  wl_display* display_;
-  wl_surface* surface_;
-  EGLDisplay egl_display_;
-  wl_egl_window* egl_window_;
-
-  wl_surface* parent_surface_;
-  wl_callback* callback_;
-  wl_subsurface* subsurface_;
-
   void* platformViewsContext_;
   PlatformViewRemoveListener removeListener_;
-  const std::string flutterAssetsPath_;
+  std::string flutterAssetsPath_;
 
-  void DrawFrame();
+#if BUILD_COMPOSITOR
+  // libnav_render configuration captured in the constructor; consumed
+  // when GL state is initialized lazily on the rasterizer thread.
+  std::string access_token_;
+  std::string asset_path_;
+  std::string cache_folder_;
+  std::string misc_folder_;
 
-  void Dispose();
+  nav_render_Context* context_{nullptr};
+  bool gl_initialized_{false};
+  bool init_failed_{false};
+  GLuint framebuffer_{0};
+  GLuint color_texture_{0};
+  int32_t tex_width_{0};
+  int32_t tex_height_{0};
+  std::atomic<int32_t> pending_width_{0};
+  std::atomic<int32_t> pending_height_{0};
 
-  void Resize(int32_t width, int32_t height);
-
-  void SetOffset(int32_t left, int32_t top);
+  void EnsureGlState(int32_t w, int32_t h);
+#endif
 
   static void on_resize(double width, double height, void* data);
-
   static void on_set_direction(int32_t direction, void* data);
-
   static void on_set_offset(double left, double top, void* data);
-
   static void on_touch(int32_t action,
                        int32_t point_count,
                        size_t point_data_size,
                        const double* point_data,
                        void* data);
-
   static void on_dispose(bool hybrid, void* data);
 
-  static void on_frame(void* data, wl_callback* callback, uint32_t time);
-
-  static const wl_callback_listener frame_listener;
   static const struct platform_view_listener platform_view_listener_;
 };
+
 }  // namespace nav_render_view_plugin

--- a/plugins/nav_render_view/nav_render_surface.h
+++ b/plugins/nav_render_view/nav_render_surface.h
@@ -49,7 +49,8 @@ namespace nav_render_view_plugin {
 class NavRenderSurface final : public flutter::Plugin,
                                public PlatformView
 #if BUILD_COMPOSITOR
-    , public ICompositorSurface
+    ,
+                               public ICompositorSurface
 #endif
 {
  public:


### PR DESCRIPTION
1. 1fc3aed1 [layer_playground_view] migrate to ICompositorSurface — Demo plugin (single colored triangle). Removes Wayland/EGL state, the wl_callback self-driven frame loop, and InitializeEGL / GetConfig ceremony. Adds an FBO + RGBA color texture + shader program lazy-initialized in OnPresent on the rasterizer thread. CMake drops WAYLAND_EGL and EGL deps.
2. 9330b07c [nav_render_view] migrate to ICompositorSurface — Production plugin. Switches from LibNavRender->Surface* (renders into a wl_egl_window) to LibNavRender->Texture* (renders into a caller-provided FBO). New kExpectedTextureApiVersion check. OnPresent calls TextureRunTask + TextureRender(ctx, framebuffer) with the lazy-allocated FBO; TextureResize fires on size
change. Same CMake cleanup.

Both share the same lifetime pattern: shared_ptr<ICompositorSurface> with an aliasing deleter (PluginRegistrar still owns lifetime), GL handles intentionally leaked at dispose since destroying them needs the engine's context current on the rasterizer thread. When BUILD_COMPOSITOR=OFF, both compile but log a warning and don't render — compositor mode is the only supported path under the new model.