### PR TITLE
[common/glib] fix MainLoop teardown hang (atexit join never returns)

### DIFF
--- a/plugins/common/glib/main_loop.cc
+++ b/plugins/common/glib/main_loop.cc
@@ -23,6 +23,15 @@ MainLoop::MainLoop()
 
 MainLoop::~MainLoop() {
   if (gthread_ && gthread_->joinable()) {
+    // The loop polls g_main_context_iteration(context_, TRUE) which may
+    // block forever inside ppoll waiting for a glib event. Without the
+    // exit_loop_ flip + a wakeup, ~MainLoop's join() hangs at atexit
+    // (the singleton instance is destructed by the C++ runtime after
+    // main() returns).
+    exit_loop_ = true;
+    if (context_ != nullptr) {
+      g_main_context_wakeup(context_);
+    }
     gthread_->join();
   }
 }
@@ -37,11 +46,17 @@ void MainLoop::main_loop(MainLoop* data) {
 
   data->is_running_ = true;
   while (data->is_running_) {
+    // Block until a glib event or ~MainLoop's g_main_context_wakeup(). Check
+    // the exit flag AFTER the iteration, not before: ~MainLoop sets exit_loop_
+    // and issues a single wakeup that unblocks exactly one iteration. Checking
+    // before would set is_running_ = false and then fall into another blocking
+    // g_main_context_iteration(TRUE) that never returns (the wakeup is already
+    // consumed), parking the thread forever and hanging ~MainLoop's join() at
+    // atexit. Checking after lets the wakeup-returning iteration exit the loop.
+    g_main_context_iteration(data->context_, TRUE);
     if (data->exit_loop_) {
       data->is_running_ = false;
     }
-
-    g_main_context_iteration(data->context_, TRUE);
   }
 
   g_main_loop_quit(data->main_loop_);


### PR DESCRIPTION
## Problem

ivi-homescreen intermittently fails to exit on `SIGTERM` and gets `SIGKILL`ed (rc137) — observed on amdgpu. gdb on the hung process: the **main thread** is blocked at `exit()`:
```
exit() -> __run_exit_handlers -> plugin_common_glib::MainLoop::~MainLoop
       -> std::thread::join -> __pthread_clockjoin_ex   (blocked forever)
```
while the glib thread sits in `g_main_context_iteration` / `ppoll`.

## Root cause

`MainLoop`'s glib thread loops on a **blocking** `g_main_context_iteration(context, TRUE)`. `~MainLoop` (an `atexit` singleton destructor) sets `exit_loop_`, issues a single `g_main_context_wakeup()`, then `join()`s the thread. But the loop checked the exit flag at the **top**, before the iteration:

```cpp
while (is_running_) {
  if (exit_loop_) is_running_ = false;   // checked first
  g_main_context_iteration(context_, TRUE);   // ...then blocks
}
```

The wakeup unblocks the *current* iteration; the loop returns to the top, sets `is_running_ = false`, then falls into **another** `g_main_context_iteration(TRUE)` that never returns (the single wakeup was already consumed). The thread parks there forever → `join()` hangs → `exit()` never completes → SIGKILL. Intermittent because it depends on the loop being mid-`ppoll` when the dtor fires.

## Fix

Check the exit flag **after** the iteration so the wakeup-returning iteration leaves the loop instead of entering a second blocking one (and add the dtor's `exit_loop_` + `g_main_context_wakeup()`):

```cpp
while (is_running_) {
  g_main_context_iteration(context_, TRUE);
  if (exit_loop_) is_running_ = false;
}
```

## Testing

Reproduced on amdgpu (ivi-homescreen, `dart_defines` bundle) — process hung past the SIGKILL grace, gdb backtrace as above. After the fix: **teardown exits cleanly 4/4 (~1s)**.

This is distinct from the ivi-homescreen `drm_kms_egl` teardown leak (toyota-connected/ivi-homescreen#234) — that was a GBM buffer starvation on the GL path; this is the glib plugin's atexit join, which bites any build that spins up the glib `MainLoop` (gstreamer/video_player).