### PR TITLE
[nav_render_view] add missing <spdlog/spdlog.h> include

### DIFF
--- a/plugins/nav_render_view/nav_render_texture.cc
+++ b/plugins/nav_render_view/nav_render_texture.cc
@@ -1,6 +1,8 @@
 
 #include "nav_render_texture.h"
 
+#include <spdlog/spdlog.h>
+
 #include "libnav_render.h"
 
 namespace nav_render_view_plugin {


### PR DESCRIPTION
## Problem

The `nav_render_view` CI jobs (`build`, `tidy`, `codeql`) fail on `v2.0`:
```
plugins/nav_render_view/nav_render_texture.cc:13: error: use of undeclared identifier 'spdlog'
```
`nav_render_texture.cc` calls `spdlog::error()` (lines 13, 17) but includes only `nav_render_texture.h` and `libnav_render.h`, neither of which transitively pulls in spdlog.

## Fix

Add `#include <spdlog/spdlog.h>` (the same include the other plugins use). One line.

This is a pre-existing base-branch breakage, independent of any feature work — surfaced while reviewing CI on an unrelated PR. Fixes the `nav_render_view` build/tidy/codeql jobs for all PRs.