### PR TITLE
plugins: include <memory> where std::make_unique / unique_ptr is used

### DIFF
--- a/plugins/audioplayers_linux/audio_player.cc
+++ b/plugins/audioplayers_linux/audio_player.cc
@@ -3,6 +3,7 @@
 
 #include <flutter/event_stream_handler_functions.h>
 #include <flutter/standard_method_codec.h>
+#include <memory>
 #include "logging/logging.h"
 
 extern "C" {

--- a/plugins/camera/camera_context.cc
+++ b/plugins/camera/camera_context.cc
@@ -16,6 +16,7 @@
 
 #include "camera_context.h"
 
+#include <memory>
 #include <sstream>
 
 #include <flutter/event_channel.h>

--- a/plugins/camera_pipewire/camera_stream.cc
+++ b/plugins/camera_pipewire/camera_stream.cc
@@ -19,6 +19,7 @@
 #include <cstdio>
 #include <filesystem>
 #include <future>
+#include <memory>
 #include <sstream>
 #include <utility>
 

--- a/plugins/common/json/json_utils.cc
+++ b/plugins/common/json/json_utils.cc
@@ -18,6 +18,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <memory>
 
 #include "rapidjson/filewritestream.h"
 #include "rapidjson/istreamwrapper.h"

--- a/plugins/common/tools/command.cc
+++ b/plugins/common/tools/command.cc
@@ -15,6 +15,7 @@
  */
 
 #include "command.h"
+#include <memory>
 
 #include "../logging.h"
 

--- a/plugins/desktop_window_linux/desktop_window_plugin.cc
+++ b/plugins/desktop_window_linux/desktop_window_plugin.cc
@@ -15,6 +15,7 @@
  */
 
 #include "desktop_window_plugin.h"
+#include <memory>
 
 #include "messages.h"
 

--- a/plugins/flatpak/cache/operations/flatpak_application_cache_operation.h
+++ b/plugins/flatpak/cache/operations/flatpak_application_cache_operation.h
@@ -19,6 +19,7 @@
 #define PLUGINS_FLATPAK_CACHE_APPLICATION_CACHE_OPERATION_H
 
 #include <chrono>
+#include <memory>
 
 #include "cache_operation_template.h"
 #include "encodablelist_cache_operation.h"

--- a/plugins/flatpak/cache/operations/flatpak_installation_cache_operation.h
+++ b/plugins/flatpak/cache/operations/flatpak_installation_cache_operation.h
@@ -19,6 +19,7 @@
 #define PLUGINS_FLATPAK_CACHE_INSTALLATION_CACHE_OPERATION_H
 
 #include <chrono>
+#include <memory>
 
 #include "cache_operation_template.h"
 #include "encodablelist_cache_operation.h"

--- a/plugins/flatpak/flatpak_plugin.cc
+++ b/plugins/flatpak/flatpak_plugin.cc
@@ -17,6 +17,7 @@
 #include "flatpak_plugin.h"
 
 #include <filesystem>
+#include <memory>
 #include <sstream>
 #include <system_error>
 #include <vector>

--- a/plugins/flatpak/flatpak_shim.cc
+++ b/plugins/flatpak/flatpak_shim.cc
@@ -17,6 +17,7 @@
 #include "flatpak_shim.h"
 
 #include <filesystem>
+#include <memory>
 
 #include <cstdlib>
 

--- a/plugins/flatpak/portals/permissions_portal/permissions_portal.cc
+++ b/plugins/flatpak/portals/permissions_portal/permissions_portal.cc
@@ -18,6 +18,7 @@
 #include "permissions_portal.h"
 
 #include <iomanip>
+#include <memory>
 #include "asio/post.hpp"
 #include "flatpak/flatpak_shim.h"
 #include "logging/logging.h"

--- a/plugins/flatpak/portals/portal_manager.cc
+++ b/plugins/flatpak/portals/portal_manager.cc
@@ -16,6 +16,7 @@
  */
 
 #include "portal_manager.h"
+#include <memory>
 
 #include "asio/post.hpp"
 #include "logging/logging.h"

--- a/plugins/flatpak/portals/portal_proxy.cc
+++ b/plugins/flatpak/portals/portal_proxy.cc
@@ -16,6 +16,7 @@
  */
 
 #include "portal_proxy.h"
+#include <memory>
 
 #include "logging/logging.h"
 

--- a/plugins/flatpak/test/test_flatpak.cc
+++ b/plugins/flatpak/test/test_flatpak.cc
@@ -1,6 +1,7 @@
 #include <asio/steady_timer.hpp>
 #include <fstream>
 #include <future>
+#include <memory>
 #include <thread>
 #include <utility>
 

--- a/plugins/generated_plugin_registrant.cc
+++ b/plugins/generated_plugin_registrant.cc
@@ -15,6 +15,7 @@
  */
 
 #include "generated_plugin_registrant.h"
+#include <memory>
 
 #include "config/plugins.h"
 

--- a/plugins/go_router/messages.cc
+++ b/plugins/go_router/messages.cc
@@ -23,6 +23,7 @@
 #include <flutter/encodable_value.h>
 #include <flutter/method_call.h>
 #include <flutter/method_channel.h>
+#include <memory>
 
 #include <string>
 

--- a/plugins/google_sign_in/google_sign_in.cc
+++ b/plugins/google_sign_in/google_sign_in.cc
@@ -15,6 +15,7 @@
  */
 
 #include "google_sign_in.h"
+#include <memory>
 
 #include "engine.h"
 #include "plugins/common/common.h"

--- a/plugins/google_sign_in/google_sign_in_plugin.cc
+++ b/plugins/google_sign_in/google_sign_in_plugin.cc
@@ -17,6 +17,7 @@
 #include "google_sign_in_plugin.h"
 
 #include <filesystem>
+#include <memory>
 
 #include "messages.g.h"
 

--- a/plugins/integration_test/messages.cc
+++ b/plugins/integration_test/messages.cc
@@ -23,6 +23,7 @@
 #include <flutter/encodable_value.h>
 #include <flutter/method_call.h>
 #include <flutter/method_channel.h>
+#include <memory>
 
 #include <string>
 

--- a/plugins/layer_playground_view/layer_playground_view_plugin.cc
+++ b/plugins/layer_playground_view/layer_playground_view_plugin.cc
@@ -17,6 +17,7 @@
 #include "layer_playground_view_plugin.h"
 
 #include <flutter/standard_message_codec.h>
+#include <memory>
 
 #include "plugins/common/common.h"
 #include "view/flutter_view.h"

--- a/plugins/nav_render_view/nav_render_surface.cc
+++ b/plugins/nav_render_view/nav_render_surface.cc
@@ -18,6 +18,7 @@
 
 #include <flutter/standard_message_codec.h>
 #include <plugins/common/common.h>
+#include <memory>
 
 #include <utility>
 

--- a/plugins/nav_render_view/nav_render_texture.cc
+++ b/plugins/nav_render_view/nav_render_texture.cc
@@ -1,5 +1,6 @@
 
 #include "nav_render_texture.h"
+#include <memory>
 
 #include "logging/logging.h"
 

--- a/plugins/pdf/messages.cc
+++ b/plugins/pdf/messages.cc
@@ -14,6 +14,7 @@
 #include <flutter/method_call.h>
 #include <flutter/method_channel.h>
 #include <flutter/standard_method_codec.h>
+#include <memory>
 
 #include <optional>
 #include <string>

--- a/plugins/secure_storage/messages.cc
+++ b/plugins/secure_storage/messages.cc
@@ -14,6 +14,7 @@
 #include <flutter/method_call.h>
 #include <flutter/method_channel.h>
 #include <flutter/standard_method_codec.h>
+#include <memory>
 
 #include <string>
 

--- a/plugins/video_player_linux/video_player.cc
+++ b/plugins/video_player_linux/video_player.cc
@@ -21,6 +21,7 @@
 #include <flutter/event_stream_handler_functions.h>
 #include <flutter/plugin_registrar_homescreen.h>
 #include <flutter/standard_method_codec.h>
+#include <memory>
 
 #include <atomic>
 #include <climits>

--- a/plugins/webrtc/third_party/flutter-webrtc/common/cpp/src/flutter_peerconnection.cc
+++ b/plugins/webrtc/third_party/flutter-webrtc/common/cpp/src/flutter_peerconnection.cc
@@ -1,5 +1,6 @@
 #include "flutter_peerconnection.h"
 
+#include <memory>
 #include <utility>
 
 #include "base/scoped_ref_ptr.h"

--- a/plugins/webrtc/third_party/flutter-webrtc/common/cpp/src/flutter_screen_capture.cc
+++ b/plugins/webrtc/third_party/flutter-webrtc/common/cpp/src/flutter_screen_capture.cc
@@ -1,4 +1,5 @@
 #include "flutter_screen_capture.h"
+#include <memory>
 
 namespace flutter_webrtc_plugin {
 


### PR DESCRIPTION
## Summary

Follow-up to the spdlog retirement (#257). Retiring spdlog dropped its **transitive `<memory>`** include. 27 TUs use `std::make_unique` / `unique_ptr` / `shared_ptr` but never included `<memory>` directly — libstdc++ on the plugins CI host provided it transitively, so they built there, but the **aarch64 GCC cross-build** (ivi-homescreen's PiOS matrix) does not:

```
plugins/common/tools/command.cc:34: error: 'make_unique' is not a member of 'std'
note: 'std::make_unique' is defined in header '<memory>'; add '#include <memory>'
```

Add the explicit `#include <memory>` (IWYU) — same class of fix the shell needed when it retired spdlog.

## Testing

Reproduced the failure with `emb cross . --target rpi4-trixie --backend software --build` against the ivi-homescreen spdlog-drop branch; with this fix the cross-build compiles the plugins cleanly (`software: built`). clang-format-18 clean on all 27 files.

Unblocks the ivi-homescreen PiOS builds on the standalone-fmt PR.