### PR TITLE
layer_playground_view: optional Vulkan render path reusing Flutter's device

### DIFF
--- a/plugins/layer_playground_view/CMakeLists.txt
+++ b/plugins/layer_playground_view/CMakeLists.txt
@@ -7,11 +7,19 @@ include_guard()
 add_library(plugin_layer_playground_view STATIC
         layer_playground_view_plugin.cc
         layer_playground_view_plugin_c_api.cc
+        # Optional Vulkan render path: reuses the wayland-vulkan backend's device
+        # (via Backend::GetVulkanContext) to write the gradient into a VkImage
+        # when there is no engine GL context. Uses vulkan.hpp + the process-
+        # shared dynamic dispatcher owned by the shell — no libvulkan link.
+        layer_playground_vulkan.cc
 )
 
 target_include_directories(plugin_layer_playground_view PUBLIC
         .
         include
+        # ivi-homescreen's vendored Vulkan-Headers, matching the version the
+        # backend initializes the shared dispatcher against.
+        ${CMAKE_SOURCE_DIR}/third_party/Vulkan-Headers/include
 )
 
 target_link_libraries(plugin_layer_playground_view PUBLIC

--- a/plugins/layer_playground_view/layer_playground_view_plugin.cc
+++ b/plugins/layer_playground_view/layer_playground_view_plugin.cc
@@ -22,6 +22,11 @@
 #include "plugins/common/common.h"
 #include "view/flutter_view.h"
 
+#if BUILD_COMPOSITOR
+#include "backend/backend.h"
+#include "layer_playground_vulkan.h"
+#endif
+
 class FlutterView;
 class Display;
 
@@ -83,7 +88,8 @@ LayerPlaygroundViewPlugin::LayerPlaygroundViewPlugin(
   // is allocated lazily on the rasterizer thread the first time OnPresent
   // fires — the engine's context isn't current here on the platform thread.
   if (state && state->view_controller && state->view_controller->view) {
-    state->view_controller->view->RegisterCompositorSurface(
+    auto* view = state->view_controller->view;
+    view->RegisterCompositorSurface(
         id_, std::shared_ptr<ICompositorSurface>(this, [](ICompositorSurface*) {
           // Aliasing deleter: the plugin's lifetime is owned by the
           // PluginRegistrar, not by this shared_ptr. The compositor's
@@ -91,6 +97,27 @@ LayerPlaygroundViewPlugin::LayerPlaygroundViewPlugin(
         }));
     IHS_TRACE("[pv-trace] LayerPlaygroundView registered: id={} size={}x{}",
               id_, pending_width_.load(), pending_height_.load());
+
+    // If the active backend is Vulkan there is no engine GL context, so the GL
+    // path would fail. Reuse the backend's Vulkan device to render into a
+    // VkImage instead. GL stays the path on EGL backends.
+    if (auto* backend = view->GetBackend()) {
+      BackendVulkanContext vk{};
+      if (backend->GetVulkanContext(&vk)) {
+        auto renderer = std::make_unique<LayerPlaygroundVulkanRenderer>();
+        if (renderer->Init(static_cast<VkInstance>(vk.instance),
+                           static_cast<VkPhysicalDevice>(vk.physical_device),
+                           static_cast<VkDevice>(vk.device),
+                           static_cast<VkQueue>(vk.queue),
+                           vk.queue_family_index)) {
+          vulkan_renderer_ = std::move(renderer);
+          IHS_TRACE(
+              "[pv-trace] LayerPlaygroundView: Vulkan render path active "
+              "(reusing Flutter's device) id={}",
+              id_);
+        }
+      }
+    }
   } else {
     IHS_TRACE(
         "[pv-trace] LayerPlaygroundView could NOT register (state/view null): "
@@ -149,14 +176,24 @@ void LayerPlaygroundViewPlugin::on_touch(int32_t /* action */,
                                          const double* /* point_data */,
                                          void* /* data */) {}
 
-void LayerPlaygroundViewPlugin::on_dispose(bool /* hybrid */,
-                                           void* /* data */) {
+void LayerPlaygroundViewPlugin::on_dispose(bool /* hybrid */, void* data) {
   // Compositor-owned shared_ptr drops via PlatformViewsHandler's
   // safety-net UnregisterCompositorSurface call. GL state is leaked
   // intentionally — destroying GL handles requires the engine's context
   // to be current on the rasterizer thread, and we have no way to
   // marshal that from the platform-thread dispose call. The engine's
   // context outlives the plugin and reclaims the resources at shutdown.
+#if BUILD_COMPOSITOR
+  // The Vulkan path, unlike GL, has no thread-affine context: its VkImage +
+  // memory can be freed here (the device is still alive at dispose), which also
+  // keeps them from outliving vkDestroyDevice. The images hold no in-flight GPU
+  // work (CPU-filled), so this is safe from the platform thread.
+  if (auto* plugin = static_cast<LayerPlaygroundViewPlugin*>(data)) {
+    plugin->vulkan_renderer_.reset();
+  }
+#else
+  (void)data;
+#endif
 }
 
 const platform_view_listener
@@ -403,6 +440,12 @@ bool LayerPlaygroundViewPlugin::OnPresent(const FlutterLayer* layer) {
   if (target_w <= 0 || target_h <= 0) {
     return true;
   }
+
+  // Vulkan backend: render into a VkImage on Flutter's device instead of GL.
+  if (vulkan_renderer_) {
+    return vulkan_renderer_->Render(target_w, target_h);
+  }
+
   EnsureGlState(target_w, target_h);
   if (!gl_initialized_) {
     IHS_TRACE(
@@ -414,6 +457,30 @@ bool LayerPlaygroundViewPlugin::OnPresent(const FlutterLayer* layer) {
   DrawFrame();
   (void)layer;
   return true;
+}
+
+void* LayerPlaygroundViewPlugin::GetVulkanImage(int32_t* width,
+                                                int32_t* height) const {
+  if (!vulkan_renderer_ || vulkan_renderer_->image() == VK_NULL_HANDLE) {
+    return nullptr;
+  }
+  if (width) {
+    *width = vulkan_renderer_->width();
+  }
+  if (height) {
+    *height = vulkan_renderer_->height();
+  }
+  return reinterpret_cast<void*>(vulkan_renderer_->image());
+}
+
+uint32_t LayerPlaygroundViewPlugin::GetVulkanImageLayout() const {
+  return vulkan_renderer_ ? vulkan_renderer_->layout() : 0;
+}
+
+void LayerPlaygroundViewPlugin::SetVulkanImageLayout(uint32_t layout) {
+  if (vulkan_renderer_) {
+    vulkan_renderer_->set_layout(layout);
+  }
 }
 
 void LayerPlaygroundViewPlugin::OnResize(int32_t w, int32_t h) {

--- a/plugins/layer_playground_view/layer_playground_view_plugin.cc
+++ b/plugins/layer_playground_view/layer_playground_view_plugin.cc
@@ -423,19 +423,17 @@ bool LayerPlaygroundViewPlugin::OnPresent(const FlutterLayer* layer) {
     target_w = static_cast<int32_t>(layer->size.width);
     target_h = static_cast<int32_t>(layer->size.height);
   }
-  static thread_local int32_t last_w = 0;
-  static thread_local int32_t last_h = 0;
-  static thread_local bool first_fire = true;
-  const bool size_changed = (target_w != last_w) || (target_h != last_h);
-  if (first_fire || size_changed) {
+  const bool size_changed =
+      (target_w != last_present_w_) || (target_h != last_present_h_);
+  if (first_present_ || size_changed) {
     IHS_TRACE(
         "[pv-trace] LayerPlaygroundView::OnPresent id={} target={}x{} "
         "tex={}x{} gl_init={} (first={}, size_changed={})",
         id_, target_w, target_h, tex_width_, tex_height_, gl_initialized_,
-        first_fire, size_changed);
-    first_fire = false;
-    last_w = target_w;
-    last_h = target_h;
+        first_present_, size_changed);
+    first_present_ = false;
+    last_present_w_ = target_w;
+    last_present_h_ = target_h;
   }
   if (target_w <= 0 || target_h <= 0) {
     return true;

--- a/plugins/layer_playground_view/layer_playground_view_plugin.h
+++ b/plugins/layer_playground_view/layer_playground_view_plugin.h
@@ -145,6 +145,12 @@ class LayerPlaygroundViewPlugin : public flutter::Plugin,
   // Pending size from on_resize / OnResize, applied next OnPresent.
   std::atomic<int32_t> pending_width_{0};
   std::atomic<int32_t> pending_height_{0};
+  // Per-view size seen at the last present, so the trace/size-change check is
+  // scoped to this view (not shared across every view on the rasterizer
+  // thread).
+  int32_t last_present_w_{0};
+  int32_t last_present_h_{0};
+  bool first_present_{true};
 
   // Optional Vulkan render path: non-null when the active backend is Vulkan
   // (no engine GL context). Reuses Flutter's device to write the gradient into

--- a/plugins/layer_playground_view/layer_playground_view_plugin.h
+++ b/plugins/layer_playground_view/layer_playground_view_plugin.h
@@ -36,6 +36,10 @@
 
 namespace plugin_layer_playground_view {
 
+#if BUILD_COMPOSITOR
+class LayerPlaygroundVulkanRenderer;
+#endif
+
 /**
  * Layer playground demo platform view.
  *
@@ -114,6 +118,11 @@ class LayerPlaygroundViewPlugin : public flutter::Plugin,
   [[nodiscard]] int32_t GetGlTextureHeight() const override {
     return tex_height_;
   }
+  // Vulkan path: hand the compositor the VkImage rendered on Flutter's device.
+  [[nodiscard]] void* GetVulkanImage(int32_t* width,
+                                     int32_t* height) const override;
+  [[nodiscard]] uint32_t GetVulkanImageLayout() const override;
+  void SetVulkanImageLayout(uint32_t layout) override;
 #endif
 
  private:
@@ -136,6 +145,11 @@ class LayerPlaygroundViewPlugin : public flutter::Plugin,
   // Pending size from on_resize / OnResize, applied next OnPresent.
   std::atomic<int32_t> pending_width_{0};
   std::atomic<int32_t> pending_height_{0};
+
+  // Optional Vulkan render path: non-null when the active backend is Vulkan
+  // (no engine GL context). Reuses Flutter's device to write the gradient into
+  // a VkImage instead of the GL FBO. See layer_playground_vulkan.h.
+  std::unique_ptr<LayerPlaygroundVulkanRenderer> vulkan_renderer_;
 
   void EnsureGlState(int32_t w, int32_t h);
   void DestroyGlState();

--- a/plugins/layer_playground_view/layer_playground_vulkan.cc
+++ b/plugins/layer_playground_view/layer_playground_vulkan.cc
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "layer_playground_vulkan.h"
+
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+
+// vulkan.hpp with the process-shared dynamic dispatcher: the wayland-vulkan
+// backend owns the loader storage (vk::detail::defaultDispatchLoaderDynamic)
+// and initializes it with the instance + device. This plugin is another
+// consumer of that same dispatcher — it must NOT define the storage. Headers
+// come from ivi-homescreen's vendored third_party/Vulkan-Headers (matching the
+// backend's version) via the plugin's include path.
+#define VULKAN_HPP_NO_EXCEPTIONS 1
+#define VULKAN_HPP_DISPATCH_LOADER_DYNAMIC 1
+#include <vulkan/vulkan.hpp>
+
+#include "logging/logging.h"
+
+namespace plugin_layer_playground_view {
+
+namespace {
+
+const auto& d() {
+  return vk::detail::defaultDispatchLoaderDynamic;
+}
+
+// Diagonal 3-stop gradient matching the GL path's visual (deep blue -> violet
+// -> warm amber), plus a thin border. B8G8R8A8 byte order (BGRA), which the
+// compositor treats as XRGB8888.
+struct Rgb {
+  uint8_t r, g, b;
+};
+constexpr std::array<Rgb, 3> kStops = {
+    {{30, 40, 120}, {130, 60, 160}, {235, 170, 60}}};
+
+Rgb Lerp(const Rgb& a, const Rgb& b, float t) {
+  const auto mix = [t](uint8_t x, uint8_t y) {
+    return static_cast<uint8_t>(
+        static_cast<float>(x) +
+        (static_cast<float>(y) - static_cast<float>(x)) * t);
+  };
+  return {mix(a.r, b.r), mix(a.g, b.g), mix(a.b, b.b)};
+}
+
+uint32_t PickHostVisibleMemory(VkPhysicalDevice pd, uint32_t type_bits) {
+  VkPhysicalDeviceMemoryProperties mp{};
+  d().vkGetPhysicalDeviceMemoryProperties(pd, &mp);
+  const VkMemoryPropertyFlags want = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                                     VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+  for (uint32_t i = 0; i < mp.memoryTypeCount; ++i) {
+    if ((type_bits & (1u << i)) &&
+        (mp.memoryTypes[i].propertyFlags & want) == want) {
+      return i;
+    }
+  }
+  return UINT32_MAX;
+}
+
+}  // namespace
+
+bool LayerPlaygroundVulkanRenderer::Init(VkInstance instance,
+                                         VkPhysicalDevice physical_device,
+                                         VkDevice device,
+                                         VkQueue queue,
+                                         uint32_t queue_family_index) {
+  instance_ = instance;
+  physical_device_ = physical_device;
+  device_ = device;
+  queue_ = queue;
+  queue_family_index_ = queue_family_index;
+  return device_ != VK_NULL_HANDLE;
+}
+
+void LayerPlaygroundVulkanRenderer::DestroyImage() {
+  if (image_ != VK_NULL_HANDLE) {
+    d().vkDestroyImage(device_, image_, nullptr);
+    image_ = VK_NULL_HANDLE;
+  }
+  if (memory_ != VK_NULL_HANDLE) {
+    d().vkFreeMemory(device_, memory_, nullptr);
+    memory_ = VK_NULL_HANDLE;
+  }
+  painted_ = false;
+}
+
+bool LayerPlaygroundVulkanRenderer::Render(int32_t width, int32_t height) {
+  if (device_ == VK_NULL_HANDLE || width <= 0 || height <= 0) {
+    return false;
+  }
+  // Keep the image across sub-pixel layout fluctuation (the compositor scales
+  // the blit to the exact layer rect anyway) so a static view is not
+  // reallocated every frame.
+  constexpr int32_t kResizeSlack = 2;
+  const bool close_enough = image_ != VK_NULL_HANDLE &&
+                            std::abs(width - width_) <= kResizeSlack &&
+                            std::abs(height - height_) <= kResizeSlack;
+  if (close_enough) {
+    return painted_;  // static gradient, already filled at this size
+  }
+  if (image_ != VK_NULL_HANDLE) {
+    // Resizing: a prior frame's compositor blit may still read the old image.
+    // Drain before freeing (rare — a platform view's size is otherwise stable).
+    d().vkDeviceWaitIdle(device_);
+  }
+  DestroyImage();
+  layout_ = VK_IMAGE_LAYOUT_UNDEFINED;
+  width_ = width;
+  height_ = height;
+
+  // Plain LINEAR host-visible image the CPU fills directly. initialLayout =
+  // PREINITIALIZED so the host writes are preserved into the first GPU use
+  // (the backend transitions PREINITIALIZED -> TRANSFER_SRC and blits it). No
+  // external/dma-buf memory: the plugin renders on the backend's own device,
+  // so the compositor reads this VkImage directly — dma-buf would force
+  // initialLayout=UNDEFINED, which discards the host-written contents (black).
+  VkImageCreateInfo ic{};
+  ic.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+  ic.imageType = VK_IMAGE_TYPE_2D;
+  ic.format = VK_FORMAT_B8G8R8A8_UNORM;
+  ic.extent = {static_cast<uint32_t>(width_), static_cast<uint32_t>(height_),
+               1};
+  ic.mipLevels = 1;
+  ic.arrayLayers = 1;
+  ic.samples = VK_SAMPLE_COUNT_1_BIT;
+  ic.tiling = VK_IMAGE_TILING_LINEAR;
+  ic.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+  ic.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
+  if (d().vkCreateImage(device_, &ic, nullptr, &image_) != VK_SUCCESS) {
+    ihs::log::error("LayerPlaygroundVulkan: vkCreateImage (linear) failed");
+    image_ = VK_NULL_HANDLE;
+    return false;
+  }
+
+  VkMemoryRequirements req{};
+  d().vkGetImageMemoryRequirements(device_, image_, &req);
+  const uint32_t mt =
+      PickHostVisibleMemory(physical_device_, req.memoryTypeBits);
+  if (mt == UINT32_MAX) {
+    ihs::log::error("LayerPlaygroundVulkan: no host-visible memory type");
+    DestroyImage();
+    return false;
+  }
+
+  VkMemoryAllocateInfo mai{};
+  mai.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+  mai.allocationSize = req.size;
+  mai.memoryTypeIndex = mt;
+  if (d().vkAllocateMemory(device_, &mai, nullptr, &memory_) != VK_SUCCESS) {
+    ihs::log::error("LayerPlaygroundVulkan: vkAllocateMemory failed");
+    DestroyImage();
+    return false;
+  }
+  if (d().vkBindImageMemory(device_, image_, memory_, 0) != VK_SUCCESS) {
+    ihs::log::error("LayerPlaygroundVulkan: vkBindImageMemory failed");
+    DestroyImage();
+    return false;
+  }
+
+  // Row pitch of the linear layout (bytes between rows).
+  VkImageSubresource sub{};
+  sub.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+  VkSubresourceLayout sl{};
+  d().vkGetImageSubresourceLayout(device_, image_, &sub, &sl);
+  row_pitch_ = sl.rowPitch;
+
+  // CPU-fill the gradient (host-coherent, so no flush needed).
+  void* mapped = nullptr;
+  if (d().vkMapMemory(device_, memory_, 0, VK_WHOLE_SIZE, 0, &mapped) !=
+      VK_SUCCESS) {
+    ihs::log::error("LayerPlaygroundVulkan: vkMapMemory failed");
+    DestroyImage();
+    return false;
+  }
+  auto* image_base = static_cast<uint8_t*>(mapped) + sl.offset;
+  const auto fw = static_cast<float>(width_ - 1 > 0 ? width_ - 1 : 1);
+  const auto fh = static_cast<float>(height_ - 1 > 0 ? height_ - 1 : 1);
+  for (int32_t y = 0; y < height_; ++y) {
+    auto* row = image_base + static_cast<size_t>(y) * row_pitch_;
+    for (int32_t x = 0; x < width_; ++x) {
+      const float t =
+          (static_cast<float>(x) / fw + static_cast<float>(y) / fh) * 0.5f;
+      Rgb c = t < 0.5f ? Lerp(kStops[0], kStops[1], t * 2.0f)
+                       : Lerp(kStops[1], kStops[2], (t - 0.5f) * 2.0f);
+      // Thin 2px border.
+      const bool border = x < 2 || y < 2 || x >= width_ - 2 || y >= height_ - 2;
+      if (border) {
+        c = {235, 235, 235};
+      }
+      auto* px = row + static_cast<size_t>(x) * 4u;
+      px[0] = c.b;
+      px[1] = c.g;
+      px[2] = c.r;
+      px[3] = 0xff;
+    }
+  }
+  d().vkUnmapMemory(device_, memory_);
+  painted_ = true;
+  layout_ = VK_IMAGE_LAYOUT_PREINITIALIZED;  // host writes preserved
+
+  ihs::log::debug(
+      "LayerPlaygroundVulkan: rendered {}x{} VkImage (pitch={}) on Flutter's "
+      "device",
+      width_, height_, row_pitch_);
+  return true;
+}
+
+LayerPlaygroundVulkanRenderer::~LayerPlaygroundVulkanRenderer() {
+  if (device_ != VK_NULL_HANDLE) {
+    DestroyImage();
+  }
+}
+
+}  // namespace plugin_layer_playground_view

--- a/plugins/layer_playground_view/layer_playground_vulkan.cc
+++ b/plugins/layer_playground_view/layer_playground_vulkan.cc
@@ -16,6 +16,7 @@
 
 #include "layer_playground_vulkan.h"
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <cstdlib>
@@ -103,25 +104,38 @@ bool LayerPlaygroundVulkanRenderer::Render(int32_t width, int32_t height) {
   if (device_ == VK_NULL_HANDLE || width <= 0 || height <= 0) {
     return false;
   }
-  // Keep the image across sub-pixel layout fluctuation (the compositor scales
-  // the blit to the exact layer rect anyway) so a static view is not
-  // reallocated every frame.
-  constexpr int32_t kResizeSlack = 2;
-  const bool close_enough = image_ != VK_NULL_HANDLE &&
-                            std::abs(width - width_) <= kResizeSlack &&
-                            std::abs(height - height_) <= kResizeSlack;
-  if (close_enough) {
-    return painted_;  // static gradient, already filled at this size
+  ++gen_;
+  ReapRetired();  // free aged-out images off the hot path (no device drain)
+
+  // Grow-only: the compositor scales the whole image into the exact layer rect
+  // and the gradient is normalized (looks identical at any scale), so a larger
+  // image serves any smaller box. Reuse while the current image is big enough;
+  // only a box that exceeds it triggers a reallocation. An animated shrink — or
+  // a grow within the current size — does no work, so a preset transition no
+  // longer reallocates (and stalls) every frame.
+  const bool fits =
+      image_ != VK_NULL_HANDLE && width <= width_ && height <= height_;
+  if (fits) {
+    return painted_;
   }
+
+  const int32_t new_w =
+      image_ != VK_NULL_HANDLE ? std::max(width, width_) : width;
+  const int32_t new_h =
+      image_ != VK_NULL_HANDLE ? std::max(height, height_) : height;
+
+  // Retire the outgoing image instead of draining the device: a prior frame's
+  // compositor read may still be in flight, so hand it to ReapRetired to free a
+  // few generations later.
   if (image_ != VK_NULL_HANDLE) {
-    // Resizing: a prior frame's compositor blit may still read the old image.
-    // Drain before freeing (rare — a platform view's size is otherwise stable).
-    d().vkDeviceWaitIdle(device_);
+    retired_.push_back({image_, memory_, gen_});
+    image_ = VK_NULL_HANDLE;
+    memory_ = VK_NULL_HANDLE;
+    painted_ = false;
   }
-  DestroyImage();
   layout_ = VK_IMAGE_LAYOUT_UNDEFINED;
-  width_ = width;
-  height_ = height;
+  width_ = new_w;
+  height_ = new_h;
 
   // Plain LINEAR host-visible image the CPU fills directly. initialLayout =
   // PREINITIALIZED so the host writes are preserved into the first GPU use
@@ -220,8 +234,32 @@ bool LayerPlaygroundVulkanRenderer::Render(int32_t width, int32_t height) {
   return true;
 }
 
+void LayerPlaygroundVulkanRenderer::ReapRetired() {
+  // A retired image can still be read by a compositor submit in flight when it
+  // is superseded; freeing it kRetireDepth generations later clears any such
+  // read (the dma-buf present path keeps only a few frames outstanding). Runs
+  // on the rasterizer thread that issues those submits, so no device drain
+  // needed.
+  constexpr uint64_t kRetireDepth = 4;
+  retired_.erase(std::remove_if(retired_.begin(), retired_.end(),
+                                [this](const Retired& r) {
+                                  if (gen_ - r.gen < kRetireDepth) {
+                                    return false;
+                                  }
+                                  d().vkDestroyImage(device_, r.image, nullptr);
+                                  d().vkFreeMemory(device_, r.memory, nullptr);
+                                  return true;
+                                }),
+                 retired_.end());
+}
+
 LayerPlaygroundVulkanRenderer::~LayerPlaygroundVulkanRenderer() {
   if (device_ != VK_NULL_HANDLE) {
+    for (const auto& r : retired_) {
+      d().vkDestroyImage(device_, r.image, nullptr);
+      d().vkFreeMemory(device_, r.memory, nullptr);
+    }
+    retired_.clear();
     DestroyImage();
   }
 }

--- a/plugins/layer_playground_view/layer_playground_vulkan.h
+++ b/plugins/layer_playground_view/layer_playground_vulkan.h
@@ -18,6 +18,7 @@
 #define FLUTTER_PLUGIN_LAYER_PLAYGROUND_VULKAN_H_
 
 #include <cstdint>
+#include <vector>
 
 // C handle types only (VkImage/VkDevice/…) keep this header light; the .cc uses
 // vulkan.hpp + the shared dynamic dispatcher. Both come from ivi-homescreen's
@@ -53,9 +54,14 @@ class LayerPlaygroundVulkanRenderer {
             VkQueue queue,
             uint32_t queue_family_index);
 
-  // (Re)allocate the image on a size change and fill it with the gradient.
-  // Returns true on success. No-op-cheap when the size is unchanged (the
-  // gradient is static, so the fill is skipped once painted).
+  // Ensure the image is at least @p width x @p height and filled with the
+  // gradient. Returns true on success. Allocation is grow-only: the compositor
+  // scales the whole image into the exact layer rect and the gradient is
+  // normalized (identical at any scale), so a larger image serves any smaller
+  // box. A box that shrinks — or grows within the current image — reuses it and
+  // does no work; only a box that exceeds it enlarges, and the old image is
+  // retired (freed a few frames later) instead of draining the device. This
+  // keeps an animated resize from reallocating, and stalling, every frame.
   bool Render(int32_t width, int32_t height);
 
   [[nodiscard]] VkImage image() const { return image_; }
@@ -73,6 +79,11 @@ class LayerPlaygroundVulkanRenderer {
 
  private:
   void DestroyImage();
+  // Free images retired at least a few generations ago; by then any in-flight
+  // compositor read that referenced them has completed. Called from Render on
+  // the rasterizer thread (the same thread that submits), so the ordering is
+  // safe without a device drain.
+  void ReapRetired();
 
   // Borrowed (owned by the backend / Flutter).
   VkInstance instance_{VK_NULL_HANDLE};
@@ -81,13 +92,26 @@ class LayerPlaygroundVulkanRenderer {
   VkQueue queue_{VK_NULL_HANDLE};
   uint32_t queue_family_index_{0};
 
-  // Owned image resources (destroyed with the borrowed device).
+  // Owned image resources (destroyed with the borrowed device). width_/height_
+  // are the allocated (grow-only) dimensions, which the compositor scales to
+  // the layer rect.
   VkImage image_{VK_NULL_HANDLE};
   VkDeviceMemory memory_{VK_NULL_HANDLE};
   int32_t width_{0};
   int32_t height_{0};
   uint64_t row_pitch_{0};
   bool painted_{false};
+
+  // Images superseded by a grow, awaiting free once their generation has aged
+  // out (see ReapRetired). Monotonic grow keeps this to a handful over a view's
+  // lifetime.
+  struct Retired {
+    VkImage image;
+    VkDeviceMemory memory;
+    uint64_t gen;
+  };
+  std::vector<Retired> retired_;
+  uint64_t gen_{0};
   // VK_IMAGE_LAYOUT_PREINITIALIZED after a fresh fill; updated by the
   // compositor.
   uint32_t layout_{0};

--- a/plugins/layer_playground_view/layer_playground_vulkan.h
+++ b/plugins/layer_playground_view/layer_playground_vulkan.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FLUTTER_PLUGIN_LAYER_PLAYGROUND_VULKAN_H_
+#define FLUTTER_PLUGIN_LAYER_PLAYGROUND_VULKAN_H_
+
+#include <cstdint>
+
+// C handle types only (VkImage/VkDevice/…) keep this header light; the .cc uses
+// vulkan.hpp + the shared dynamic dispatcher. Both come from ivi-homescreen's
+// vendored third_party/Vulkan-Headers via the plugin's include path.
+#include <vulkan/vulkan_core.h>
+
+namespace plugin_layer_playground_view {
+
+// Optional Vulkan render path for the layer-playground platform view.
+//
+// The GL path renders with the *engine's* GL context, which does not exist on
+// the wayland-vulkan backend. This path instead reuses the backend's Vulkan
+// device (obtained via Backend::GetVulkanContext) and writes the same diagonal
+// gradient into a linear, host-visible, dma-buf-exported VkImage — so the
+// platform view's content is a first-class Vulkan resource on the exact device
+// Flutter renders with, ready for the compositor to import (that consumption is
+// a separate step). No second VkInstance/VkDevice, no cross-API copy.
+class LayerPlaygroundVulkanRenderer {
+ public:
+  LayerPlaygroundVulkanRenderer() = default;
+  ~LayerPlaygroundVulkanRenderer();
+
+  LayerPlaygroundVulkanRenderer(const LayerPlaygroundVulkanRenderer&) = delete;
+  LayerPlaygroundVulkanRenderer& operator=(
+      const LayerPlaygroundVulkanRenderer&) = delete;
+
+  // Adopt the backend's Vulkan handles (does not take ownership — the device is
+  // Flutter's). Vulkan entry points come from the process-shared dynamic
+  // dispatcher the backend already initialized, so no loader is passed.
+  bool Init(VkInstance instance,
+            VkPhysicalDevice physical_device,
+            VkDevice device,
+            VkQueue queue,
+            uint32_t queue_family_index);
+
+  // (Re)allocate the image on a size change and fill it with the gradient.
+  // Returns true on success. No-op-cheap when the size is unchanged (the
+  // gradient is static, so the fill is skipped once painted).
+  bool Render(int32_t width, int32_t height);
+
+  [[nodiscard]] VkImage image() const { return image_; }
+  [[nodiscard]] int32_t width() const { return width_; }
+  [[nodiscard]] int32_t height() const { return height_; }
+  [[nodiscard]] uint64_t row_pitch() const { return row_pitch_; }
+  [[nodiscard]] bool ok() const { return device_ != VK_NULL_HANDLE; }
+
+  // Current VkImageLayout (as uint32_t so the interface stays Vulkan-free).
+  // Starts PREINITIALIZED after a fill; the compositor transitions it once to
+  // a transfer source and records that back here, so the static image is not
+  // re-transitioned every frame.
+  [[nodiscard]] uint32_t layout() const { return layout_; }
+  void set_layout(uint32_t layout) { layout_ = layout; }
+
+ private:
+  void DestroyImage();
+
+  // Borrowed (owned by the backend / Flutter).
+  VkInstance instance_{VK_NULL_HANDLE};
+  VkPhysicalDevice physical_device_{VK_NULL_HANDLE};
+  VkDevice device_{VK_NULL_HANDLE};
+  VkQueue queue_{VK_NULL_HANDLE};
+  uint32_t queue_family_index_{0};
+
+  // Owned image resources (destroyed with the borrowed device).
+  VkImage image_{VK_NULL_HANDLE};
+  VkDeviceMemory memory_{VK_NULL_HANDLE};
+  int32_t width_{0};
+  int32_t height_{0};
+  uint64_t row_pitch_{0};
+  bool painted_{false};
+  // VK_IMAGE_LAYOUT_PREINITIALIZED after a fresh fill; updated by the
+  // compositor.
+  uint32_t layout_{0};
+};
+
+}  // namespace plugin_layer_playground_view
+
+#endif  // FLUTTER_PLUGIN_LAYER_PLAYGROUND_VULKAN_H_


### PR DESCRIPTION
## Summary

Adds an optional Vulkan render path to `layer_playground_view` so the plugin works on the wayland-vulkan backend, where the engine's GL context does not exist and `OnPresent` previously failed.

- **Vulkan render path reusing Flutter's device** — `LayerPlaygroundVulkanRenderer` reuses the backend's own `VkDevice` (via `Backend::GetVulkanContext`) and CPU-fills the same gradient into a LINEAR, host-visible `VkImage` (`initialLayout` `PREINITIALIZED` so CPU-written pixels survive into first GPU use). No second `VkInstance`/`VkDevice`, no external/dma-buf memory — the compositor reads the image directly on the shared device. Uses `vulkan.hpp` + the shell's process-shared dynamic dispatcher (no `libvulkan` link). The GL path is unchanged on EGL backends; the plugin detects a Vulkan backend in its constructor and takes this path in `OnPresent`, exposing the `VkImage` + layout via the new `ICompositorSurface` Vulkan accessors.

- **Grow-only image to end resize stalls** — the render path previously reallocated the platform view's image on every >2px size change and drained the device (`vkDeviceWaitIdle`) first, causing several device-wide stalls per frame during preset transitions (native boxes lagged the Flutter chrome). Since the compositor scales the whole image into the layer rect and the gradient is scale-invariant, a larger image serves any smaller box. Now allocates grow-only: reuse while big enough, enlarge only when exceeded, and retire the old image for deferred free on the rasterizer thread instead of draining on the hot path. Also scopes the `OnPresent` size-change guard to the view (it previously used `static thread_local` state shared across all views).

## Dependencies

Requires the matching ivi-homescreen change (`GetVulkanContext` + `ICompositorSurface::GetVulkanImage`). Correct hybrid-composition blending is the backend's job and is tracked there as a follow-up.
