### PR TITLE
layer_playground_view: publish the box view through the ihs_pv factory

### DIFF
--- a/plugins/generated_plugin_registrant.cc
+++ b/plugins/generated_plugin_registrant.cc
@@ -19,6 +19,14 @@
 
 #include "config/plugins.h"
 
+#if ENABLE_PLUGIN_LAYER_PLAYGROUND_VIEW
+namespace plugin_layer_playground_view {
+// Registers the ihs_pv PlatformViewRegistry factory for the demo box view. A
+// no-op when the compositor is off. Defined in layer_playground_ihs_pv.cc.
+void RegisterIhsPvFactory();
+}  // namespace plugin_layer_playground_view
+#endif
+
 static constexpr char kKeyId[] = "id";
 static constexpr char kKeyViewType[] = "viewType";
 static constexpr char kKeyDirection[] = "direction";
@@ -107,6 +115,12 @@ void PluginsApiRegisterPlugins(FlutterDesktopEngineRef engine) {
 #if ENABLE_PLUGIN_WEBRTC
   WebrtcPluginCApiRegisterWithRegistrar(
       FlutterDesktopGetPluginRegistrar(engine, ""));
+#endif
+#if ENABLE_PLUGIN_LAYER_PLAYGROUND_VIEW
+  // Install the ihs_pv factory now that the platform-view host is up (this runs
+  // after SetUpCommonEngineState). Creates for "@views/simple-box-view-type"
+  // then route through the registry factory instead of the AOI path below.
+  plugin_layer_playground_view::RegisterIhsPvFactory();
 #endif
 }
 

--- a/plugins/layer_playground_view/CMakeLists.txt
+++ b/plugins/layer_playground_view/CMakeLists.txt
@@ -12,6 +12,10 @@ add_library(plugin_layer_playground_view STATIC
         # when there is no engine GL context. Uses vulkan.hpp + the process-
         # shared dynamic dispatcher owned by the shell — no libvulkan link.
         layer_playground_vulkan.cc
+        # ihs_pv (push-model) producer: registers a PlatformViewRegistry factory
+        # that negotiates a surface path and submits a solid gbm dma-buf. The
+        # factory supersedes the legacy ICompositorSurface path above.
+        layer_playground_ihs_pv.cc
 )
 
 target_include_directories(plugin_layer_playground_view PUBLIC
@@ -20,10 +24,15 @@ target_include_directories(plugin_layer_playground_view PUBLIC
         # ivi-homescreen's vendored Vulkan-Headers, matching the version the
         # backend initializes the shared dispatcher against.
         ${CMAKE_SOURCE_DIR}/third_party/Vulkan-Headers/include
+        # ihs_pv ABI (ihs/platform_view.h) + its generated ihs_export.h.
+        ${CMAKE_SOURCE_DIR}/shared/include
+        ${CMAKE_BINARY_DIR}/shared/include
 )
 
 target_link_libraries(plugin_layer_playground_view PUBLIC
         flutter
         platform_homescreen
         GLESv2
+        # The ihs_pv producer allocates scanout-capable buffers via gbm.
+        gbm
 )

--- a/plugins/layer_playground_view/CMakeLists.txt
+++ b/plugins/layer_playground_view/CMakeLists.txt
@@ -36,3 +36,9 @@ target_link_libraries(plugin_layer_playground_view PUBLIC
         # The ihs_pv producer allocates scanout-capable buffers via gbm.
         gbm
 )
+
+if (BUILD_COMPOSITOR)
+        # Direct-scanout stub (IVI_PV_DMABUF): allocates a scanout gbm_bo and
+        # exports it as a dma-buf for the DRM compositor's KMS-plane path.
+        target_link_libraries(plugin_layer_playground_view PUBLIC gbm)
+endif ()

--- a/plugins/layer_playground_view/layer_playground_ihs_pv.cc
+++ b/plugins/layer_playground_view/layer_playground_ihs_pv.cc
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// ihs_pv (push-model) producer for the layer_playground demo platform view.
+//
+// Registers a process-global factory for "@views/simple-box-view-type" that
+// negotiates a surface path (dma-buf import, or the software-shm floor) through
+// ihs_pv_negotiate and submits a solid, per-id colored buffer — the box the
+// compositor scans out. This migrates the demo view onto the shell
+// PlatformViewRegistry factory + ihs_pv ABI; because the factory is registered
+// at startup, the channel handler routes creates to it and the legacy
+// ICompositorSurface path in layer_playground_view_plugin.cc goes unused.
+//
+// The content is a static solid color (one per view id, with a thin border), so
+// the producer submits once on create and again on each resize — the compositor
+// keeps compositing the last-submitted buffer every frame. Rendering a gradient
+// into the dma-buf (GL into an EGLImage FBO) is a later polish; the negotiate +
+// submit path is what this exercises.
+
+#include "config/common.h"
+
+#if BUILD_COMPOSITOR
+#include <sys/mman.h>  // MAP_FAILED
+
+#include <cstdint>
+#include <cstdio>
+#include <mutex>
+
+#include <gbm.h>
+
+#include "ihs/platform_view.h"
+#endif  // BUILD_COMPOSITOR
+
+namespace plugin_layer_playground_view {
+
+#if BUILD_COMPOSITOR
+namespace {
+
+constexpr char kViewType[] = "@views/simple-box-view-type";
+
+// XRGB8888 little-endian is 0xXX_RR_GG_BB; the top (X) byte is ignored by the
+// KMS/GL sampler for an X format, but keep it 0xFF so the same buffer reads
+// opaque if ever consumed as ARGB. One color per id so boxes are identifiable.
+constexpr uint32_t kPalette[10] = {
+    0xFFFF0000u,  // 0 red
+    0xFF00C000u,  // 1 green
+    0xFF0000FFu,  // 2 blue
+    0xFFFFC000u,  // 3 amber
+    0xFFFF00FFu,  // 4 magenta
+    0xFF00E0E0u,  // 5 cyan
+    0xFFFF8000u,  // 6 orange
+    0xFF8000FFu,  // 7 violet
+    0xFFFFFFFFu,  // 8 white
+    0xFF808080u,  // 9 gray
+};
+constexpr uint32_t kBorder = 0xFF202020u;
+
+// The imported buffer keeps a stable ring id: the registry re-imports on a size
+// change even for the same id, so a single id avoids leaking one import per
+// resize while still picking up new buffers.
+constexpr uint32_t kBufferId = 0;
+
+// Per-view producer. All entry points (Start from the factory, Resize/Dispose
+// from IhsPvCallbacks) run on the platform thread, as do ihs_pv_egl_context /
+// ihs_pv_negotiate / ihs_pv_submit — so no cross-thread synchronization of the
+// gbm buffer is needed; the mutex only guards against a redundant reentrant
+// produce.
+class Producer {
+ public:
+  Producer(IhsPlatformView* view, int32_t id, uint32_t width, uint32_t height)
+      : view_(view), id_(id), width_(width), height_(height) {}
+
+  ~Producer() {
+    if (bo_ != nullptr) {
+      gbm_bo_destroy(bo_);
+    }
+  }
+
+  Producer(const Producer&) = delete;
+  Producer& operator=(const Producer&) = delete;
+
+  void Start() {
+    if (!Negotiate()) {
+      return;
+    }
+    Produce();
+  }
+
+  void Resize(uint32_t width, uint32_t height) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (width == width_ && height == height_) {
+      return;
+    }
+    width_ = width;
+    height_ = height;
+    Produce();
+  }
+
+ private:
+  bool Negotiate() {
+    IhsPvRequirements req{};
+    req.struct_size = sizeof(req);
+    // Offer the zero-copy import and the universal floor; the scorer picks the
+    // best the active backend grants (dma-buf on wayland/drm-egl, shm floor on
+    // the software backend). No format list: a solid buffer takes any format.
+    req.kinds = IHS_PV_KIND_TEXTURE_DMABUF_IMPORT | IHS_PV_KIND_SOFTWARE_SHM;
+    req.formats = nullptr;
+    req.format_count = 0;
+    req.needs_alpha = 0;              // opaque box
+    req.sync = IHS_PV_SYNC_IMPLICIT;  // static CPU-filled buffer, no fencing
+    req.z_order = IHS_PV_Z_BELOW_FLUTTER;
+
+    IhsPvGrant grant{};
+    grant.struct_size = sizeof(grant);
+    const int rc = ihs_pv_negotiate(view_, &req, &grant);
+    if (rc != IHS_PV_OK) {
+      std::fprintf(stderr, "[layer_playground] negotiate failed id=%d rc=%d\n",
+                   id_, rc);
+      return false;
+    }
+    granted_kind_ = grant.granted_kind;
+    return true;
+  }
+
+  // Allocate a solid-color gbm buffer at the current size and submit it. Caller
+  // holds mutex_ (or is the single-threaded Start path).
+  void Produce() {
+    if (granted_kind_ != IHS_PV_KIND_TEXTURE_DMABUF_IMPORT) {
+      // The software-shm floor is produced through ihs_pv_grant_shm_fd; wiring
+      // that (and the host-side shm composite) is a separate step. On an
+      // EGL/Vulkan backend the grant is dma-buf import, so this is not hit.
+      return;
+    }
+    // Flutter hands a 1x1 placeholder at create; skip until a real resize.
+    if (width_ <= 1 || height_ <= 1) {
+      return;
+    }
+
+    IhsEglContext egl{};
+    egl.struct_size = sizeof(egl);
+    if (ihs_pv_egl_context(&egl) != IHS_PV_OK || egl.gbm_device == nullptr) {
+      return;
+    }
+    auto* dev = static_cast<gbm_device*>(egl.gbm_device);
+
+    // GBM_FORMAT_XRGB8888 == DRM_FORMAT_XRGB8888 (same fourcc); SCANOUT |
+    // LINEAR so the buffer is both KMS-scanout-capable and CPU-mappable to
+    // fill.
+    gbm_bo* bo = gbm_bo_create(dev, width_, height_, GBM_FORMAT_XRGB8888,
+                               GBM_BO_USE_SCANOUT | GBM_BO_USE_LINEAR);
+    if (bo == nullptr) {
+      std::fprintf(stderr,
+                   "[layer_playground] gbm_bo_create failed id=%d %ux%u\n", id_,
+                   width_, height_);
+      return;
+    }
+    FillSolid(bo);
+
+    const int fd = gbm_bo_get_fd(bo);
+    if (fd < 0) {
+      gbm_bo_destroy(bo);
+      return;
+    }
+
+    IhsFrame frame{};
+    frame.struct_size = sizeof(frame);
+    frame.format.fourcc = gbm_bo_get_format(bo);
+    frame.format.modifier = gbm_bo_get_modifier(bo);
+    frame.width = width_;
+    frame.height = height_;
+    frame.plane_count = 1;
+    frame.plane_fd[0] = fd;  // ownership passes to the registry on import
+    frame.plane_offset[0] = gbm_bo_get_offset(bo, 0);
+    frame.plane_stride[0] = gbm_bo_get_stride(bo);
+    frame.buffer_id = kBufferId;
+    // Implicit sync: gbm_bo_map/unmap completed the CPU write before submit.
+    ihs_pv_submit(view_, &frame, /*acquire_fence_fd=*/-1,
+                  /*out_release_fence_fd=*/nullptr);
+
+    // The new buffer is imported (the host re-imports on the size change); free
+    // the previous one. The exported fd is owned by the registry now, and the
+    // underlying dma-buf keeps the memory alive independent of this handle.
+    if (bo_ != nullptr) {
+      gbm_bo_destroy(bo_);
+    }
+    bo_ = bo;
+  }
+
+  void FillSolid(gbm_bo* bo) const {
+    uint32_t stride = 0;
+    void* map_data = nullptr;
+    void* px = gbm_bo_map(bo, 0, 0, width_, height_, GBM_BO_TRANSFER_WRITE,
+                          &stride, &map_data);
+    if (px == nullptr || px == MAP_FAILED) {
+      return;
+    }
+    const uint32_t fill = kPalette[static_cast<uint32_t>((id_ % 10 + 10) % 10)];
+    auto* base = static_cast<uint8_t*>(px);
+    for (uint32_t y = 0; y < height_; ++y) {
+      auto* row = reinterpret_cast<uint32_t*>(base + y * stride);
+      for (uint32_t x = 0; x < width_; ++x) {
+        const bool edge = x < 2 || y < 2 || x + 2 >= width_ || y + 2 >= height_;
+        row[x] = edge ? kBorder : fill;
+      }
+    }
+    gbm_bo_unmap(bo, map_data);
+  }
+
+  IhsPlatformView* view_;
+  int32_t id_;
+  uint32_t width_;
+  uint32_t height_;
+  uint32_t granted_kind_{IHS_PV_KIND_NONE};
+  gbm_bo* bo_{nullptr};
+  std::mutex mutex_;
+};
+
+int Factory(const IhsPvCreateInfo* info,
+            void* /*factory_user_data*/,
+            IhsPlatformView* view,
+            IhsPvCallbacks* out_callbacks,
+            void** out_user_data) {
+  auto* producer =
+      new Producer(view, info->id, static_cast<uint32_t>(info->width),
+                   static_cast<uint32_t>(info->height));
+  out_callbacks->struct_size = sizeof(*out_callbacks);
+  out_callbacks->resize = [](void* ud, double w, double h) {
+    static_cast<Producer*>(ud)->Resize(static_cast<uint32_t>(w),
+                                       static_cast<uint32_t>(h));
+  };
+  out_callbacks->dispose = [](void* ud) { delete static_cast<Producer*>(ud); };
+  *out_user_data = producer;
+  producer->Start();
+  return IHS_PV_OK;
+}
+
+}  // namespace
+
+// Registered at startup from the generated plugin registrant, after the ihs_pv
+// host is installed (SetUpCommonEngineState runs before
+// PluginsApiRegisterPlugins in flutter_view.cc). Process-global; the factory
+// binds to the installed host.
+void RegisterIhsPvFactory() {
+  ihs_pv_register_factory(kViewType, &Factory, nullptr);
+}
+
+#else  // !BUILD_COMPOSITOR
+
+// Platform views compose through the compositor; without it the factory has
+// nothing to register against, so this is a no-op and the registrant can call
+// it unconditionally.
+void RegisterIhsPvFactory() {}
+
+#endif  // BUILD_COMPOSITOR
+
+}  // namespace plugin_layer_playground_view

--- a/plugins/layer_playground_view/layer_playground_view_plugin.cc
+++ b/plugins/layer_playground_view/layer_playground_view_plugin.cc
@@ -25,6 +25,18 @@
 #if BUILD_COMPOSITOR
 #include "backend/backend.h"
 #include "layer_playground_vulkan.h"
+
+#if BUILD_COMPOSITOR
+#include <cstdlib>
+#include <cstring>
+#include <string_view>
+
+#include <gbm.h>
+#include <linux/dma-buf.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
 #endif
 
 class FlutterView;
@@ -102,6 +114,12 @@ LayerPlaygroundViewPlugin::LayerPlaygroundViewPlugin(
     // path would fail. Reuse the backend's Vulkan device to render into a
     // VkImage instead. GL stays the path on EGL backends.
     if (auto* backend = view->GetBackend()) {
+      // Capture the backend's gbm_device (DRM/KMS EGL backend only) so the
+      // direct-scanout stub can allocate a scanout buffer without reaching
+      // back through the view from the const GetDmabuf accessor.
+      if (BackendEglContext egl{}; backend->GetEglContext(&egl)) {
+        pv_gbm_device_ = static_cast<gbm_device*>(egl.gbm_device);
+      }
       BackendVulkanContext vk{};
       if (backend->GetVulkanContext(&vk)) {
         auto renderer = std::make_unique<LayerPlaygroundVulkanRenderer>();
@@ -134,6 +152,16 @@ LayerPlaygroundViewPlugin::LayerPlaygroundViewPlugin(
 
 LayerPlaygroundViewPlugin::~LayerPlaygroundViewPlugin() {
   removeListener_(platformViewsContext_, id_);
+#if BUILD_COMPOSITOR
+  if (pv_dmabuf_fd_ >= 0) {
+    ::close(pv_dmabuf_fd_);
+    pv_dmabuf_fd_ = -1;
+  }
+  if (pv_dmabuf_bo_) {
+    gbm_bo_destroy(pv_dmabuf_bo_);
+    pv_dmabuf_bo_ = nullptr;
+  }
+#endif
 }
 
 void LayerPlaygroundViewPlugin::on_resize(double width,
@@ -479,6 +507,198 @@ void LayerPlaygroundViewPlugin::SetVulkanImageLayout(uint32_t layout) {
   if (vulkan_renderer_) {
     vulkan_renderer_->set_layout(layout);
   }
+}
+
+bool LayerPlaygroundViewPlugin::GetDmabuf(Dmabuf* out) const {
+  if (!out) {
+    return false;
+  }
+  // Opt-in gate so the default GL-composite path is unchanged. Evaluated once.
+  if (pv_dmabuf_enabled_ < 0) {
+    const char* env = std::getenv("IVI_PV_DMABUF");
+    pv_dmabuf_enabled_ = (env && env[0] == '1') ? 1 : 0;
+    IHS_TRACE("[pv-trace] GetDmabuf gate id={} enabled={} gbm_device={}", id_,
+              pv_dmabuf_enabled_, static_cast<const void*>(pv_gbm_device_));
+  }
+  if (pv_dmabuf_enabled_ == 0 || !pv_gbm_device_) {
+    return false;
+  }
+
+  // Target the view's current extent. Flutter registers platform views at
+  // 1x1 and resizes them once laid out; a 1x1 scanout buffer is rejected by
+  // AddFB2, so skip (GL-composite this frame) until the real size arrives,
+  // and rebuild if the view later resizes.
+  const int32_t w = pending_width_.load();
+  const int32_t h = pending_height_.load();
+  if (w <= 1 || h <= 1) {
+    return false;
+  }
+  if (pv_dmabuf_bo_ && (pv_dmabuf_w_ != w || pv_dmabuf_h_ != h)) {
+    if (pv_dmabuf_fd_ >= 0) {
+      ::close(pv_dmabuf_fd_);
+      pv_dmabuf_fd_ = -1;
+    }
+    gbm_bo_destroy(pv_dmabuf_bo_);
+    pv_dmabuf_bo_ = nullptr;
+  }
+
+  // Lazily (re)allocate one solid-color scanout buffer and export a stable
+  // dma-buf fd. LINEAR + SCANOUT keeps it plane-scannable everywhere (incl.
+  // vkms) and CPU-mappable so we can fill it without a GPU.
+  if (!pv_dmabuf_bo_) {
+    // Format select: LP_PV_DMABUF_FOURCC=nv12 exercises the YUV plane path
+    // (ContentType::Video + plane CSC); default XRGB8888 is the RGB path.
+    // GBM_FORMAT_* == DRM_FORMAT_* (same fourcc), so the KMS AddFB2 in the
+    // compositor sees exactly this format.
+    const char* fmt_env = std::getenv("LP_PV_DMABUF_FOURCC");
+    const bool want_nv12 =
+        fmt_env != nullptr && (std::string_view(fmt_env) == "nv12" ||
+                               std::string_view(fmt_env) == "NV12");
+    uint32_t gbm_fmt = want_nv12 ? GBM_FORMAT_NV12 : GBM_FORMAT_XRGB8888;
+    gbm_bo* bo = gbm_bo_create(pv_gbm_device_, static_cast<uint32_t>(w),
+                               static_cast<uint32_t>(h), gbm_fmt,
+                               GBM_BO_USE_SCANOUT | GBM_BO_USE_LINEAR);
+    bool is_nv12 = want_nv12;
+    if (!bo && want_nv12) {
+      IHS_TRACE(
+          "[pv-trace] GetDmabuf NV12 unsupported by gbm id={}; XRGB fallback",
+          id_);
+      is_nv12 = false;
+      bo = gbm_bo_create(pv_gbm_device_, static_cast<uint32_t>(w),
+                         static_cast<uint32_t>(h), GBM_FORMAT_XRGB8888,
+                         GBM_BO_USE_SCANOUT | GBM_BO_USE_LINEAR);
+    }
+    if (!bo) {
+      IHS_TRACE("[pv-trace] GetDmabuf gbm_bo_create failed id={} {}x{}", id_, w,
+                h);
+      pv_dmabuf_enabled_ = 0;  // don't retry every present
+      return false;
+    }
+
+    // A distinct opaque color per view id, so each native box is visually
+    // identifiable and the on-screen z-order is legible. 0xXX_RR_GG_BB.
+    static constexpr uint32_t kPalette[] = {
+        0xFFFF0000u,  // 0 red
+        0xFF00C000u,  // 1 green
+        0xFF0000FFu,  // 2 blue
+        0xFFFFC000u,  // 3 amber
+        0xFFFF00FFu,  // 4 magenta
+        0xFF00E0E0u,  // 5 cyan
+        0xFFFF8000u,  // 6 orange
+        0xFF8000FFu,  // 7 violet
+        0xFFFFFFFFu,  // 8 white
+        0xFF808080u,  // 9 gray
+    };
+    const uint32_t palette_n =
+        static_cast<uint32_t>(sizeof(kPalette) / sizeof(kPalette[0]));
+    const uint32_t rgb = kPalette[static_cast<uint32_t>(id_) % palette_n];
+
+    // Per-plane layout from gbm (XRGB: 1 plane; NV12: Y + interleaved UV).
+    const uint32_t planes = static_cast<uint32_t>(gbm_bo_get_plane_count(bo));
+    pv_dmabuf_planes_ = planes < 4 ? planes : 4;
+    for (uint32_t p = 0; p < pv_dmabuf_planes_; ++p) {
+      pv_dmabuf_stride_[p] = gbm_bo_get_stride_for_plane(bo, p);
+      pv_dmabuf_offset_[p] = gbm_bo_get_offset(bo, p);
+    }
+    pv_dmabuf_bo_ = bo;
+    pv_dmabuf_fd_ = gbm_bo_get_fd(bo);  // persistent exported fd
+
+    if (!is_nv12) {
+      const uint32_t border = 0xFF202020u;  // ~1px darker frame, edge-legible
+      uint32_t map_stride = 0;
+      void* map_data = nullptr;
+      if (void* px = gbm_bo_map(bo, 0, 0, static_cast<uint32_t>(w),
+                                static_cast<uint32_t>(h), GBM_BO_TRANSFER_WRITE,
+                                &map_stride, &map_data)) {
+        auto* base = static_cast<uint8_t*>(px);
+        for (int32_t y = 0; y < h; ++y) {
+          auto* row = reinterpret_cast<uint32_t*>(base + y * map_stride);
+          const bool edge_row = (y < 2 || y >= h - 2);
+          for (int32_t x = 0; x < w; ++x) {
+            const bool edge = edge_row || x < 2 || x >= w - 2;
+            row[x] = edge ? border : rgb;
+          }
+        }
+        gbm_bo_unmap(bo, map_data);
+      }
+      pv_dmabuf_color_space_ = 0;  // IHS_COLOR_SPACE_DEFAULT (RGB)
+      pv_dmabuf_color_range_ = 0;
+    } else {
+      // Solid-color NV12: fill Y + interleaved UV by mmap'ing the LINEAR
+      // dma-buf directly (gbm_bo_map's plane-0 window can't reach the UV
+      // plane). Convert the palette RGB -> BT.709 limited Y'CbCr so the plane
+      // CSC decodes it back to that color — validating the CSC, not just
+      // placement.
+      const double r = static_cast<double>((rgb >> 16) & 0xFF);
+      const double g = static_cast<double>((rgb >> 8) & 0xFF);
+      const double b = static_cast<double>(rgb & 0xFF);
+      auto clamp8 = [](double v) {
+        return static_cast<uint8_t>(v < 0 ? 0 : (v > 255 ? 255 : v));
+      };
+      const uint8_t yv = clamp8(16.0 + 0.1826 * r + 0.6142 * g + 0.0620 * b);
+      const uint8_t uv_u = clamp8(128.0 - 0.1006 * r - 0.3386 * g + 0.4392 * b);
+      const uint8_t uv_v = clamp8(128.0 + 0.4392 * r - 0.3989 * g - 0.0403 * b);
+      const uint32_t sy = pv_dmabuf_stride_[0];
+      const uint32_t suv = pv_dmabuf_stride_[1];
+      const uint32_t oy = pv_dmabuf_offset_[0];
+      const uint32_t ouv = pv_dmabuf_offset_[1];
+      const size_t size = ouv + static_cast<size_t>(suv) * (h / 2);
+      void* m = ::mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED,
+                       pv_dmabuf_fd_, 0);
+      if (m != MAP_FAILED) {
+        dma_buf_sync sync{};
+        sync.flags = DMA_BUF_SYNC_START | DMA_BUF_SYNC_WRITE;
+        ::ioctl(pv_dmabuf_fd_, DMA_BUF_IOCTL_SYNC, &sync);
+        auto* base = static_cast<uint8_t*>(m);
+        for (int32_t y = 0; y < h; ++y) {
+          std::memset(base + oy + static_cast<size_t>(y) * sy, yv,
+                      static_cast<size_t>(w));
+        }
+        for (int32_t y = 0; y < h / 2; ++y) {
+          uint8_t* uvrow = base + ouv + static_cast<size_t>(y) * suv;
+          for (int32_t x = 0; x < w / 2; ++x) {
+            uvrow[2 * x] = uv_u;
+            uvrow[2 * x + 1] = uv_v;
+          }
+        }
+        sync.flags = DMA_BUF_SYNC_END | DMA_BUF_SYNC_WRITE;
+        ::ioctl(pv_dmabuf_fd_, DMA_BUF_IOCTL_SYNC, &sync);
+        ::munmap(m, size);
+      } else {
+        IHS_TRACE("[pv-trace] GetDmabuf NV12 mmap failed id={}", id_);
+      }
+      pv_dmabuf_color_space_ = 2;  // IHS_COLOR_SPACE_BT709
+      pv_dmabuf_color_range_ = 2;  // IHS_COLOR_RANGE_LIMITED
+    }
+
+    pv_dmabuf_fourcc_ = gbm_bo_get_format(bo);
+    pv_dmabuf_modifier_ = gbm_bo_get_modifier(bo);
+    pv_dmabuf_w_ = w;
+    pv_dmabuf_h_ = h;
+    IHS_TRACE(
+        "[pv-trace] GetDmabuf allocated {} scanout buffer id={} {}x{} fd={} "
+        "fourcc=0x{:08x} mod=0x{:016x} planes={} cs={}",
+        is_nv12 ? "NV12" : "XRGB", id_, w, h, pv_dmabuf_fd_, pv_dmabuf_fourcc_,
+        pv_dmabuf_modifier_, pv_dmabuf_planes_, pv_dmabuf_color_space_);
+  }
+
+  if (pv_dmabuf_fd_ < 0) {
+    return false;
+  }
+  for (uint32_t i = 0; i < pv_dmabuf_planes_; ++i) {
+    out->fd[i] = pv_dmabuf_fd_;  // one bo; planes differ by offset/stride
+    out->offset[i] = pv_dmabuf_offset_[i];
+    out->stride[i] = pv_dmabuf_stride_[i];
+  }
+  out->fourcc = pv_dmabuf_fourcc_;
+  out->modifier = pv_dmabuf_modifier_;
+  out->width = static_cast<uint32_t>(pv_dmabuf_w_);
+  out->height = static_cast<uint32_t>(pv_dmabuf_h_);
+  out->plane_count = pv_dmabuf_planes_;
+  out->color_space = pv_dmabuf_color_space_;  // 0 (DEFAULT) for RGB
+  out->color_range = pv_dmabuf_color_range_;
+  out->acquire_fence_fd = -1;  // CPU-filled, already visible
+  return true;
 }
 
 void LayerPlaygroundViewPlugin::OnResize(int32_t w, int32_t h) {

--- a/plugins/layer_playground_view/layer_playground_view_plugin.h
+++ b/plugins/layer_playground_view/layer_playground_view_plugin.h
@@ -29,17 +29,12 @@
 
 // This is a platform-view plugin: every piece of its rendering path
 // (ICompositorSurface, RegisterCompositorSurface, GetGlTextureName /
-// GetDmabuf) is gated on BUILD_COMPOSITOR. Built without it, the plugin
-// compiles to an inert stub — it registers, but produces no native content
-// and the compositor has nothing to place — which fails silently at runtime
-// as empty/transparent platform views. Fail loudly at build time instead so
-// a "view plugin ON, BUILD_COMPOSITOR OFF" misconfiguration can't ship.
-// (BUILD_COMPOSITOR is defined by the generated config/common.h above; an
-// undefined macro also trips this, catching a missing include.)
-#if !BUILD_COMPOSITOR
-#error \
-    "layer_playground_view requires BUILD_COMPOSITOR=1 (build with -DBUILD_COMPOSITOR=ON); a platform-view plugin does nothing without the compositor."
-#endif
+// GetDmabuf) is gated on BUILD_COMPOSITOR (defined by the generated
+// config/common.h above). Built without it, the plugin compiles to an inert
+// stub — it registers but produces no native content — matching the other
+// compositor plugins (comp_surf, comp_region). A hard #error here would break
+// the CI static-analysis build (clang-tidy / CodeQL configure the compositor
+// off), so the graceful #if BUILD_COMPOSITOR gating below is the convention.
 
 #include "flutter_desktop_engine_state.h"
 #include "flutter_homescreen.h"

--- a/plugins/layer_playground_view/layer_playground_view_plugin.h
+++ b/plugins/layer_playground_view/layer_playground_view_plugin.h
@@ -26,6 +26,21 @@
 #include <flutter/plugin_registrar.h>
 
 #include "config/common.h"
+
+// This is a platform-view plugin: every piece of its rendering path
+// (ICompositorSurface, RegisterCompositorSurface, GetGlTextureName /
+// GetDmabuf) is gated on BUILD_COMPOSITOR. Built without it, the plugin
+// compiles to an inert stub — it registers, but produces no native content
+// and the compositor has nothing to place — which fails silently at runtime
+// as empty/transparent platform views. Fail loudly at build time instead so
+// a "view plugin ON, BUILD_COMPOSITOR OFF" misconfiguration can't ship.
+// (BUILD_COMPOSITOR is defined by the generated config/common.h above; an
+// undefined macro also trips this, catching a missing include.)
+#if !BUILD_COMPOSITOR
+#error \
+    "layer_playground_view requires BUILD_COMPOSITOR=1 (build with -DBUILD_COMPOSITOR=ON); a platform-view plugin does nothing without the compositor."
+#endif
+
 #include "flutter_desktop_engine_state.h"
 #include "flutter_homescreen.h"
 #include "platform_views/platform_view.h"

--- a/plugins/layer_playground_view/layer_playground_view_plugin.h
+++ b/plugins/layer_playground_view/layer_playground_view_plugin.h
@@ -44,6 +44,9 @@
 #include "view/compositor_surface_interface.h"
 #endif
 
+struct gbm_device;
+struct gbm_bo;
+
 namespace plugin_layer_playground_view {
 
 #if BUILD_COMPOSITOR
@@ -133,6 +136,11 @@ class LayerPlaygroundViewPlugin : public flutter::Plugin,
                                      int32_t* height) const override;
   [[nodiscard]] uint32_t GetVulkanImageLayout() const override;
   void SetVulkanImageLayout(uint32_t layout) override;
+
+  // Direct-scanout stub: when IVI_PV_DMABUF is set, expose a solid-color
+  // dma-buf so the DRM compositor routes this view onto a KMS overlay plane
+  // instead of GL-compositing it. Returns false (GL path) otherwise.
+  [[nodiscard]] bool GetDmabuf(Dmabuf* out) const override;
 #endif
 
  private:
@@ -166,6 +174,25 @@ class LayerPlaygroundViewPlugin : public flutter::Plugin,
   // (no engine GL context). Reuses Flutter's device to write the gradient into
   // a VkImage instead of the GL FBO. See layer_playground_vulkan.h.
   std::unique_ptr<LayerPlaygroundVulkanRenderer> vulkan_renderer_;
+
+  // Direct-scanout stub state (IVI_PV_DMABUF). A single solid-color scanout
+  // buffer, lazily allocated from the backend's gbm_device on first GetDmabuf
+  // and exported once as a stable dma-buf fd (so the compositor's per-fd KMS
+  // framebuffer cache stays hot). Mutable: GetDmabuf is const but memoizes.
+  mutable gbm_device* pv_gbm_device_{nullptr};
+  mutable gbm_bo* pv_dmabuf_bo_{nullptr};
+  mutable int pv_dmabuf_fd_{-1};
+  mutable uint32_t pv_dmabuf_fourcc_{0};
+  mutable uint64_t pv_dmabuf_modifier_{0};
+  // Per-plane layout (one bo; NV12/P010 carry 2 planes at distinct offsets).
+  mutable uint32_t pv_dmabuf_planes_{1};
+  mutable uint32_t pv_dmabuf_stride_[4]{};
+  mutable uint32_t pv_dmabuf_offset_[4]{};
+  mutable uint8_t pv_dmabuf_color_space_{0};  // IhsColorSpace (YUV only)
+  mutable uint8_t pv_dmabuf_color_range_{0};  // IhsColorRange
+  mutable int32_t pv_dmabuf_w_{0};
+  mutable int32_t pv_dmabuf_h_{0};
+  mutable int pv_dmabuf_enabled_{-1};  // -1 unknown, 0 off, 1 on
 
   void EnsureGlState(int32_t w, int32_t h);
   void DestroyGlState();

--- a/plugins/layer_playground_view/layer_playground_vulkan.cc
+++ b/plugins/layer_playground_view/layer_playground_vulkan.cc
@@ -21,15 +21,26 @@
 #include <cstdint>
 #include <cstdlib>
 
-// vulkan.hpp with the process-shared dynamic dispatcher: the wayland-vulkan
-// backend owns the loader storage (vk::detail::defaultDispatchLoaderDynamic)
-// and initializes it with the instance + device. This plugin is another
-// consumer of that same dispatcher — it must NOT define the storage. Headers
-// come from ivi-homescreen's vendored third_party/Vulkan-Headers (matching the
-// backend's version) via the plugin's include path.
+#include "config/common.h"  // BUILD_BACKEND_*_VULKAN
+
+// vulkan.hpp with the process-shared dynamic dispatcher. A Vulkan backend
+// (wayland-vulkan / drm-kms-vulkan) normally owns the loader storage
+// (vk::detail::defaultDispatchLoaderDynamic) and initializes it with the
+// instance + device; this plugin is just another consumer of that same
+// dispatcher. But on a build with NO Vulkan backend (e.g. drm-kms-egl only,
+// where this plugin still renders via GL/dma-buf), nothing else defines the
+// storage, so the plugin must — otherwise the link fails with an undefined
+// reference to defaultDispatchLoaderDynamic. The guard keeps exactly one
+// definition: the plugin provides it only when no backend does. Headers come
+// from ivi-homescreen's vendored third_party/Vulkan-Headers via the plugin's
+// include path.
 #define VULKAN_HPP_NO_EXCEPTIONS 1
 #define VULKAN_HPP_DISPATCH_LOADER_DYNAMIC 1
 #include <vulkan/vulkan.hpp>
+
+#if !BUILD_BACKEND_WAYLAND_VULKAN && !BUILD_BACKEND_DRM_KMS_VULKAN
+VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
+#endif
 
 #include "logging/logging.h"
 


### PR DESCRIPTION
## What

Four commits on `layer_playground_view`, consolidating the ihs_pv box-view
consumer and the direct-scanout dma-buf work into one PR:

1. **build-correctness fixes for GL-only + no-compositor** — define the
   vulkan.hpp dynamic-dispatch storage in the plugin when no Vulkan backend is
   built (otherwise the link fails on a drm-kms-egl-only build).
2. **publish the box view through the ihs_pv factory** — register a
   `PlatformViewRegistry` factory for `@views/simple-box-view-type` at startup;
   its producer negotiates a surface (`ihs_pv_negotiate`), allocates a solid
   per-id colored gbm buffer at the view size, and submits it (`ihs_pv_submit`).
   Because the factory takes precedence, the legacy per-create
   `ICompositorSurface` path is now unreachable (left for a later removal).
3. **drop the hard `BUILD_COMPOSITOR` `#error`** — the whole rendering path is
   already gated on `#if BUILD_COMPOSITOR`, so built without the compositor the
   plugin compiles to an inert stub (it registers, produces no native content),
   matching the other compositor plugins (`comp_surf`, `comp_region`). A hard
   `#error` broke the CI static-analysis build (clang-tidy / CodeQL configure
   the compositor off).
4. **direct-scanout dma-buf stub with an NV12 mode** — when `IVI_PV_DMABUF` is
   set, `GetDmabuf` exposes a gbm scanout buffer (fd + per-plane
   stride/offset/modifier) so the DRM compositor routes the view onto a KMS
   overlay plane instead of GL-compositing it. `LP_PV_DMABUF_FOURCC=nv12`
   fills a multi-plane NV12 buffer (BT.709-limited) via dma-buf mmap, exercising
   the shell-side YUV plane CSC path. Also fixes the stale `out->fd = scalar`
   assignment (the `Dmabuf` fd is now `int fd[4]` for multi-plane).

This is the in-tree consumer that exercises the ihs_pv platform-view ABI end to
end, both the GPU-composite and the direct-scanout plane paths.

## Dependencies

Pairs with toyota-connected/ivi-homescreen#330 (shell-side direct-scanout of the
submitted dma-buf) and #374 (shell-side YUV plane CSC — carries
`color_space`/`color_range` from `IhsFrame` onto the plane). On its own the
producer's dma-buf is GL-composited; with the shell PRs it direct-scans-out on a
KMS overlay plane. HW-validated on Raspberry Pi 4 (vc4) — see #330; plane
scanout + geometry validated on vkms (x86_64).
